### PR TITLE
allow it to be browserified from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "test": "echo \"no tests yet\" && exit 0"
   },
-  "tags": [
+  "keywords": [
     "react",
     "react-component",
     "combobox",


### PR DESCRIPTION
The transform field is read when the parent project runs browserify.  Someone else can probably help set up webpack if it needs a config file for this.

CSS is an unsolved issue, but you could provide the compiled CSS and tell people to just copy it out of node_modules in their build tasks, or `@import` it in their LESS.
