### PR TITLE
Unbreak react-select for case-sensitive file systems.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -2,7 +2,7 @@ var _ = require('underscore'),
 	React = require('react'),
 	Input = require('react-input-autosize'),
 	classes = require('classnames'),
-	Value = require('./value');
+	Value = require('./Value');
 
 var requestId = 0;
 


### PR DESCRIPTION
`require()` statements are case-sensitive on Linux. They are also
case-sensitive on Mac OS X, if HFS is configured to be case-sensitive.
