### PR TITLE
Add ability to use custom input options.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -302,8 +302,9 @@ var Select = React.createClass({
 	selectFocusedOption: function() {
 		if (this.props.customOptions && !this.state.focusedOption) {
 			return this.selectValue(this.state.inputValue);
+		} else if (this.state.focusedOption) {
+			return this.selectValue(this.state.focusedOption);
 		}
-		return this.selectValue(this.state.focusedOption);
 	},
 	
 	focusOption: function(op) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -13,6 +13,7 @@ var Select = React.createClass({
 	propTypes: {
 		value: React.PropTypes.any,             // initial field value
 		multi: React.PropTypes.bool,            // multi-value input
+		customOptions: React.PropTypes.bool,    // custom value input
 		options: React.PropTypes.array,         // array of options
 		delimiter: React.PropTypes.string,      // delimiter to use to join multiple values
 		asyncOptions: React.PropTypes.func,     // function to call to get options
@@ -299,6 +300,9 @@ var Select = React.createClass({
 	},
 	
 	selectFocusedOption: function() {
+		if (this.props.customOptions && !this.state.focusedOption) {
+			return this.selectValue(this.state.inputValue);
+		}
 		return this.selectValue(this.state.focusedOption);
 	},
 	


### PR DESCRIPTION
When customOptions={true}, the user will be able to input any arbitrary value as a selection value. This works in single and multi-selection modes. Because this input represents the value AND the label (or rather, we can't distinguish between the two), the inputted value will be used for both label and value in the onChange handler.

Example:

```
var opts = [
    { value: 'hobo', label: 'Hobo' },
    { value: 'home alone', label: 'Home Alone' },
    { value: 'horchata', label: 'Horchata' },
    { value: 'hohoho', label: 'Ho! Ho! Ho!' }
];
<Select multi={true} customOptions={true} options={opts} />
```
