### PR TITLE
README: added missing bit to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ function logChange(val) {
 	name="form-field-name"
 	value="one"
 	options={options}
+	onChange={logChange}
 />
 ```
 


### PR DESCRIPTION
The function is defined in the example but then it's unused.