### PR TITLE
Added ability to disable the searching input

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -18,11 +18,18 @@ var CountrySelect = React.createClass({
 });
  
 var StatesField = React.createClass({
+	getDefaultProps: function () {
+		return {
+			searchable: true,
+			label: 'States:',
+		};
+	},
+
 	getInitialState: function() {
 		return {
 			country: 'AU',
 			selectValue: 'new-south-wales'
-		}
+		};
 	},
 	switchCountry: function(newCountry) {
 		console.log('Country changed to ' + newCountry);
@@ -41,8 +48,8 @@ var StatesField = React.createClass({
 		var ops = STATES[this.state.country];
 		return (
 			<div>
-				<label>States:</label>
-				<Select options={ops} value={this.state.selectValue} onChange={this.updateValue} />
+				<label>{this.props.label}</label>
+				<Select options={ops} value={this.state.selectValue} onChange={this.updateValue} searchable={this.props.searchable} />
 				<div className="switcher">
 					Country:
 					<CountrySelect value="AU" selected={this.state.country} onSelect={this.switchCountry}>Australia</CountrySelect>
@@ -126,6 +133,7 @@ var MultiSelectField = React.createClass({
 React.render(
 	<div>
 		<StatesField />
+		<StatesField label="States (non-searchable):" searchable={false} />
 		<MultiSelectField label="Multiselect:"/>
 		<RemoteSelectField label="Remote Options:"/>
 	</div>,

--- a/less/select-control.less
+++ b/less/select-control.less
@@ -25,11 +25,16 @@
 	}
 }
 
+.is-searchable {
+	&.is-open > .Select-control {
+		cursor: text;
+	}
+}
+
 .is-open > .Select-control {
 	.border-bottom-radius( 0 );
 	background: white;
 	border-color: darken(@select-input-border-color, 10%) @select-input-border-color lighten(@select-input-border-color, 5%);
-	cursor: text;
 
 	// flip the arrow so its pointing up when the menu is open
 	> .Select-arrow {
@@ -38,10 +43,15 @@
 	}
 }
 
+.is-searchable {
+	&.is-focused:not(.is-open) > .Select-control {
+		cursor: text;
+	}
+}
+
 .is-focused:not(.is-open) > .Select-control {
 	border-color: @select-input-border-focus lighten(@select-input-border-focus, 5%) lighten(@select-input-border-focus, 5%);
 	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1), 0 0 5px -1px fade(@select-input-border-focus,50%);
-	cursor: text;
 }
 
 // placeholder
@@ -87,6 +97,11 @@
 		}
 	}
 
+}
+
+// fake input
+.Select-control:not(.is-searchable) > .Select-input {
+	outline: none;
 }
 
 


### PR DESCRIPTION
This PR adds a new prop, `searchable` (defaults to `true`), which will enable/disable the searching input functionality of a react-select element.

I haven't considered hiding the `input` element at all as suggested on #55, mostly because I quickly worked on this during xmas, therefore it was too early to read any suggestions made yesterday :sunglasses:
Instead, the `input` isn't rendered at all if `searchable` evaluates to false.

Fixes #55.