### PR TITLE
Corrected typo in text-overflow:ellipsis

### DIFF
--- a/less/select-control.less
+++ b/less/select-control.less
@@ -66,7 +66,7 @@
 	// crop text
 	max-width: 100%;
 	overflow: hidden;
-	text-overflow: ellipses;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
Just fixing a tiny typo in the `text-overflow` of `.Select-placeholder`