### PR TITLE
Fix issue w/ remote callbacks overriding cached options

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -348,6 +348,8 @@ var Select = React.createClass({
 
 	loadAsyncOptions: function(input, state) {
 
+		var thisRequestId = this._currentRequestId = requestId++;
+
 		for (var i = 0; i <= input.length; i++) {
 			var cacheKey = input.slice(0, i);
 			if (this._optionsCache[cacheKey] && (input === cacheKey || this._optionsCache[cacheKey].complete)) {
@@ -359,8 +361,6 @@ var Select = React.createClass({
 				return;
 			}
 		}
-
-		var thisRequestId = this._currentRequestId = requestId++;
 
 		this.props.asyncOptions(input, function(err, data) {
 


### PR DESCRIPTION
Fixes an issue with the async callback overriding options populated from the cache.

Steps to reproduce:

1. User types `abcde`, callback issued for `?query=abcde`. Results displayed as expected.
2. User backspaces to `abc`
3. User *again* types `abcde`, slowly this time.
4. Options are correctly displayed from the cache (`cacheKey=abcde`), but an async request is raised for `abcd`
5. When the remote request is completed, the callback is initiated. Because `requestId` was not incremented for the last input change (as options were populated from the cache), the async results are pushed into the `options`.
6. User sees options for `abcd` even though they have typed `abcde`.