### PR TITLE
Ignore click events when menu container is closed

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -100,6 +100,9 @@ var Select = React.createClass({
 		}
 
 		this._closeMenuIfClickedOutside = function(event) {
+			if (this.state.isOpen) {
+				return;
+			}
 			var menuElem = this.refs.selectMenuContainer.getDOMNode();
 			var controlElem = this.refs.control.getDOMNode();
 


### PR DESCRIPTION
For multiselect input it is possible to get into
race condition when user removes value while menu is visible.
Menu would be closed in Select.setValue() method, component
would be rerendered AND after this global click handler would fire.