### PR TITLE
Fix an issue where options are not filtered at all

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -133,14 +133,14 @@ var Select = React.createClass({
 	},
 
 	componentWillReceiveProps: function(newProps) {
-		if (newProps.value !== this.state.value) {
-			this.setState(this.getStateFromValue(newProps.value, newProps.options));
-		}
 		if (JSON.stringify(newProps.options) !== JSON.stringify(this.props.options)) {
 			this.setState({
 				options: newProps.options,
 				filteredOptions: this.filterOptions(newProps.options)
 			});
+		}
+		if (newProps.value !== this.state.value) {
+			this.setState(this.getStateFromValue(newProps.value, newProps.options));
 		}
 	},
 


### PR DESCRIPTION
Prior to this fix, if both `props.value` and `props.options` are being altered at the same time, two consecutive `setState` calls will be fired with the latter one's `filteredOptions` not taking into account the newly set `props.value` at all. This PR fixes the issue by reversing the order of the `setState` calls so the correct `filteredOptions`, generated by `this.getStateFromValue`, can overwrite the wrong one.