### PR TITLE
Adding Jest unit test framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "eslint": "^0.17.1",
     "eslint-plugin-react": "^1.5.0",
     "gulp": "^3.8.11",
-    "react-component-gulp-tasks": "^0.4.2"
+    "jest-cli": "^0.4.0",
+    "react-component-gulp-tasks": "^0.4.2",
+    "react-tools": "^0.12.1"
   },
   "browserify-shim": {
     "classnames": "global:classNames",
@@ -29,8 +31,20 @@
     "lodash": "global:_"
   },
   "scripts": {
-    "test": "echo \"no tests yet\" && exit 0",
+    "test": "jest",
     "lint": "eslint ./; true"
+  },
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/preprocessor.js",
+    "unmockedModulePathPatterns": [
+      "<rootDir>/node_modules/react"
+    ],
+    "testFileExtensions": [
+      "js"
+    ],
+    "testPathDirs": [
+      "<rootDir>/src"
+    ]
   },
   "keywords": [
     "react",

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var ReactTools = require('react-tools');
+
+module.exports = {
+  process: function(src) {
+	return ReactTools.transform(src);
+  }
+};

--- a/src/__tests__/Select-test.js
+++ b/src/__tests__/Select-test.js
@@ -1,0 +1,35 @@
+/** @jsx React.DOM */
+'use strict';
+jest.dontMock('../Select');
+jest.dontMock('../Value');
+
+var React = require('react/addons');
+var Select = require('../Select');
+var TestUtils = React.addons.TestUtils;
+
+describe('Select test', function() {
+
+    var options = [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' }
+    ];
+
+    function logChange(val) {
+        console.log('Selected: ' + val);
+    }
+
+    // Render an instance of the component
+    var instance = TestUtils.renderIntoDocument(
+        <Select
+            name="form-field-name"
+            value="one"
+            options={options}
+            onChange={logChange}/>
+    );
+
+	var selectInputElement = TestUtils.findRenderedDOMComponentWithTag(instance, 'input');
+
+	it('should assign the given name', function() {
+		expect(selectInputElement.getDOMNode().name).toEqual('form-field-name');
+	});
+});


### PR DESCRIPTION
Adding Jest unit test framework and one simple unit test to get started.

Run npm install and then npm test to run the test.

The unit test throws a ‘Maximum call stack size exceeded’ error, which seems to be caused by the Input component on line 631 of Select.js (change it to a div and you'll see). Input is a module of react-input-autosize, which is one of your other repositories so maybe you know more about why this happens?