### PR TITLE
fixing placeholder text overlap from .Select-arrow and .Select-clear elements

### DIFF
--- a/less/select-control.less
+++ b/less/select-control.less
@@ -62,6 +62,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
+	right: -(@select-arrow-width + @select-padding-horizontal);
 
 	// crop text
 	max-width: 100%;


### PR DESCRIPTION
Fixing a text overlap issue where if the placeholder text is very long, the arrow and clear btns overlap the text.

__Before Fix:__
![image](https://cloud.githubusercontent.com/assets/437318/6872764/a0673a18-d481-11e4-8688-1be8b1eb3829.png)

__After Fix:__
![image](https://cloud.githubusercontent.com/assets/437318/6872749/81f0b1ea-d481-11e4-8105-95577169862b.png)

Thanks!