### PR TITLE
fix: set default options to null for correct async options state

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -49,7 +49,7 @@ var Select = React.createClass({
 	getDefaultProps: function() {
 		return {
 			value: undefined,
-			options: [],
+			options: null,
 			disabled: false,
 			delimiter: ',',
 			asyncOptions: undefined,


### PR DESCRIPTION
getStateFromValue returns wrong result with default options empty array in line 151-153 Select.js