### PR TITLE
Updating clear buttons to use the string code rather than raw html

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -609,7 +609,7 @@ var Select = React.createClass({
 		}
 
 		var loading = this.state.isLoading ? <span className="Select-loading" aria-hidden="true" /> : null;
-		var clear = this.props.clearable && this.state.value && !this.props.disabled ? <span className="Select-clear" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} onMouseDown={this.clearValue} onClick={this.clearValue} dangerouslySetInnerHTML={{ __html: '&times;' }} /> : null;
+		var clear = this.props.clearable && this.state.value && !this.props.disabled ? <span className="Select-clear" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} onMouseDown={this.clearValue} onClick={this.clearValue}>{String.fromCharCode(215)}</span> : null;
 
 		var menu;
 		var menuProps;

--- a/src/Value.js
+++ b/src/Value.js
@@ -31,7 +31,7 @@ var Option = React.createClass({
 				<span className="Select-item-icon"
 					onMouseDown={this.blockEvent}
 					onClick={this.props.onRemove}
-					onTouchEnd={this.props.onRemove}>&times;</span>
+					onTouchEnd={this.props.onRemove}>{String.fromCharCode(215)}</span>
 				<span className="Select-item-label">{label}</span>
 			</div>
 		);


### PR DESCRIPTION
When including this library in my project (react w/ webpack), the clear buttons displayed 'ã—' instead of 'x' (&times). I looked into it and found that the code was using raw HTML and the dangerouslySetInnerHTML option when it didn't need to. 

This pull changes the code to comply with the react site: https://facebook.github.io/react/docs/jsx-gotchas.html#html-entities 

Tested using the gulp scripts on Linux and Windows with Chrome and Firefox. Thanks for the great library!
