### PR TITLE
Update `this.setState` call

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -408,11 +408,11 @@ var Select = React.createClass({
 				var options = this._optionsCache[cacheKey].options;
 				var filteredOptions = this.filterOptions(options);
 
-				this.setState(_.extend({
+				this.setState({
 					options: options,
 					filteredOptions: filteredOptions,
 					focusedOption: _.contains(filteredOptions, this.state.focusedOption) ? this.state.focusedOption : filteredOptions[0]
-				}, state));
+				});
 				if(callback) callback({});
 				return;
 			}


### PR DESCRIPTION
This is going to be a very naive statement here on my part:

I could be mistaken (it's happened before), but I believe that calling `_.extend({...}, state);` is unnecessary, because this call:
```javascript
this.setState({
  options: options,
  filteredOptions: filteredOptions,
  focusedOption: _.contains(filteredOptions, this.state.focusedOption) ? this.state.focusedOption : filteredOptions[0]
});
```
SHOULD only modify the `options`, `filteredOptions`, and `focusedOption` values of state successfully without modifying other properties of `this.state`.

That being said, there is potential that the 2nd parameter of `loadAsyncOptions` is an object that is being passed around so that you only have to call `this.setState` once, which is incredibly intelligent if that is the case, and my "fix" is invalid :)