### PR TITLE
Remove dependency on Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "classnames": "^1.2.0",
-    "lodash": "^3.7.0",
     "react-input-autosize": "^0.4.3"
   },
   "devDependencies": {
@@ -30,8 +29,7 @@
   "browserify-shim": {
     "classnames": "global:classNames",
     "react": "global:React",
-    "react-input-autosize": "global:AutosizeInput",
-    "lodash": "global:_"
+    "react-input-autosize": "global:AutosizeInput"
   },
   "scripts": {
     "test": "jest; true",


### PR DESCRIPTION
Most of the stuff in here can just be done with vanilla JavaScript. After this change, the minified file only ends up ~450 bytes larger than the original version, and the total size is greatly reduced due to the removal of lodash.

If you really dislike for-in loops, they can be replaced with a [small Object.assign implementation](https://www.npmjs.com/package/object-assign)

Fixes #129