### PR TITLE
Add option disabled attribute

### DIFF
--- a/examples/src/data/states.js
+++ b/examples/src/data/states.js
@@ -10,7 +10,7 @@ exports.AU = [
 ];
 
 exports.US = [
-    { value: 'AL', label: 'Alabama' },
+    { value: 'AL', label: 'Alabama', disabled: true },
     { value: 'AK', label: 'Alaska' },
     { value: 'AS', label: 'American Samoa' },
     { value: 'AZ', label: 'Arizona' },

--- a/less/menu.less
+++ b/less/menu.less
@@ -53,6 +53,11 @@
 		color: @select-option-focused-color;
 	}
 
+	&.is-disabled {
+		color: @select-option-disabled-color;
+		cursor: not-allowed;
+	}
+
 }
 
 

--- a/less/select.less
+++ b/less/select.less
@@ -27,6 +27,7 @@
 @select-option-color:              lighten(@select-text-color, 20%);
 @select-option-focused-color:      @select-text-color;
 @select-option-focused-bg:         #f2f9fc; // pale blue
+@select-option-disabled-color:     lighten(@select-text-color, 60%);
 
 @select-noresults-color:           lighten(@select-text-color, 40%);
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -585,7 +585,8 @@ var Select = React.createClass({
 
 			var optionClass = classes({
 				'Select-option': true,
-				'is-focused': isFocused
+				'is-focused': isFocused,
+				'is-disabled': op.disabled
 			});
 
 			var ref = isFocused ? 'focused' : null;
@@ -594,8 +595,11 @@ var Select = React.createClass({
 				mouseLeave = this.unfocusOption.bind(this, op),
 				mouseDown = this.selectValue.bind(this, op);
 
-			return <div ref={ref} key={'option-' + op.value} className={optionClass} onMouseEnter={mouseEnter} onMouseLeave={mouseLeave} onMouseDown={mouseDown} onClick={mouseDown}>{op.label}</div>;
-
+			if(op.disabled) {
+				return <div ref={ref} key={'option-' + op.value} className={optionClass}>{op.label}</div>;
+			} else {
+				return <div ref={ref} key={'option-' + op.value} className={optionClass} onMouseEnter={mouseEnter} onMouseLeave={mouseLeave} onMouseDown={mouseDown} onClick={mouseDown}>{op.label}</div>;
+			}
 		}, this);
 
 		return ops.length ? ops : (


### PR DESCRIPTION
Issue #147 

Allows adding a disabled attribute to an option.

```javascript
 exports.US = [
   { value: 'AL', label: 'Alabama' },
   { value: 'AL', label: 'Alabama', disabled: true },
   ....
```
![disabled-option](https://cloud.githubusercontent.com/assets/1840830/7356818/45c25b7e-ecf0-11e4-817f-8457eba6c108.png)