### PR TITLE
Hitting Esc creates empty label if there are no previous options selected

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -266,7 +266,7 @@ var Select = React.createClass({
 	},
 
 	resetValue: function() {
-		this.setValue(this.state.value);
+		this.setValue(this.state.value === '' ? null : this.state.value);
 	},
 
 	getInputNode: function () {


### PR DESCRIPTION
Fixes #161 