### PR TITLE
Prevent add  the last focused value when the drop down menu is closed.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -373,7 +373,9 @@ var Select = React.createClass({
 			break;
 
 			case 13: // enter
-				this.selectFocusedOption();
+				if (this.state.isOpen) {
+					this.selectFocusedOption();
+				}	
 			break;
 
 			case 27: // escape


### PR DESCRIPTION
Hi, 

Thank you very much for developing this nice module. I found a small bug when a user presses `ENTER` and the drop-down is closed. Basically, the module remembers the last selected value, and when a user presses `ENTER` this value is added. I think, this is incorrect behaviour as a user might accidentally add a value to the list of select values. 

This is the behaviour I am fixing ( I ma just pressing enter ) :
![spxyk2ojvl](https://cloud.githubusercontent.com/assets/1751200/7767594/bf2f1aae-006b-11e5-8f43-4149d210da1c.gif)

