### PR TITLE
Enable add custom value when allowCreate is true

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -613,13 +613,13 @@ var Select = React.createClass({
 			focusedValue = focusedValue == null ? this.state.filteredOptions[0] : focusedValue;
 		}
 		// Add the current value to the filtered options in last resort
-		if (this.props.allowCreate && !this.state.filteredOptions.length) {
+		if (this.props.allowCreate && this.state.inputValue.trim()) {
 			var inputValue = this.state.inputValue;
-			this.state.filteredOptions.push({
+			this.state.filteredOptions.unshift({
 				value: inputValue,
 				label: inputValue,
 				create: true
-			})
+			});
 		};
 
 		var ops = Object.keys(this.state.filteredOptions).map(function(key) {


### PR DESCRIPTION
Hi, 

This PR enables the add custom field feature despite the number of the filter options. In addition, it moves the `Add new value?` as first option in case the list of possible options is big. It mimics the behaviour of selectize.js. 

This GIF shows the new behaviour:
![znlsaffc6v](https://cloud.githubusercontent.com/assets/1751200/7768744/13f23256-0076-11e5-81c9-11873bbba33f.gif)

