### PR TITLE
Callback context is undefined. 

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -470,7 +470,7 @@ var Select = React.createClass({
 					}
 				}
 				this.setState(newState);
-				if(callback) callback({});
+				if(callback) callback.call(this, {});
 				return;
 			}
 		}
@@ -499,7 +499,7 @@ var Select = React.createClass({
 			}
 			self.setState(newState);
 
-			if(callback) callback({});
+			if(callback) callback.call(self, {});
 
 		});
 	},


### PR DESCRIPTION
Hi, 

Diving into your code, I found another small bug. When options are loaded asynchronously, the context of the callback is not correctly set. Therefore, when `this._closeMenuIfClickedOutside` is called within a callback function ( for example, when a user types something) a javascript error is thrown. 
