### PR TITLE
Added some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "collectCoverage": true,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react"
     ],

--- a/src/Value.js
+++ b/src/Value.js
@@ -6,9 +6,9 @@ var Option = React.createClass({
 
 	propTypes: {
 		label: React.PropTypes.string.isRequired,
-		onRemove : React.PropTypes.func,
-		optionLabelClick : React.PropTypes.bool,
-		onOptionLabelClick : React.PropTypes.func
+		onRemove: React.PropTypes.func,
+		optionLabelClick: React.PropTypes.bool,
+		onOptionLabelClick: React.PropTypes.func
 	},
 
 	blockEvent: function(event) {

--- a/src/Value.js
+++ b/src/Value.js
@@ -5,7 +5,10 @@ var Option = React.createClass({
 	displayName: 'Value',
 
 	propTypes: {
-		label: React.PropTypes.string.isRequired
+		label: React.PropTypes.string.isRequired,
+		onRemove : React.PropTypes.func,
+		optionLabelClick : React.PropTypes.bool,
+		onOptionLabelClick : React.PropTypes.func
 	},
 
 	blockEvent: function(event) {

--- a/src/__tests__/Value-test.js
+++ b/src/__tests__/Value-test.js
@@ -1,0 +1,88 @@
+'use strict';
+/*global describe, it, jest, expect*/
+
+jest.dontMock('../Value');
+
+var React = require('react/addons');
+var Value = require('../Value');
+var TestUtils = React.addons.TestUtils;
+
+describe('Value component', function() {
+
+	var props;
+	var value;
+
+	beforeEach(function() {
+		props = {
+			label : 'TEST-LABEL',
+			onRemove : jest.genMockFn()
+		};
+		value = TestUtils.renderIntoDocument(<Value {...props}/>);
+	});
+
+	it('requests its own removal when the remove icon is clicked', function() {
+		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
+		TestUtils.Simulate.click(selectItemIcon.getDOMNode());
+		expect(props.onRemove).toBeCalled();
+	});
+
+	it('requests its own removal when the remove icon is touched', function() {
+		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
+		TestUtils.Simulate.touchEnd(selectItemIcon.getDOMNode());
+		expect(props.onRemove).toBeCalled();
+	});
+
+	it('prevents event propagation', function() {
+		var mockEvent = { stopPropagation : jest.genMockFn() };
+		value.blockEvent(mockEvent);
+		expect(mockEvent.stopPropagation).toBeCalled();
+
+		// Note: we presently cannot mock the blockEvent method and trigger the mock
+		// with mouseDown - relevant discussion here -
+		// https://github.com/facebook/jest/issues/207
+
+	});
+
+	describe('without a custom click handler', function() {
+
+		it('presents the given label', function() {
+			var selectItemLabel = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-label');
+			expect(selectItemLabel.getDOMNode().textContent).toBe(props.label);
+		});
+
+	});
+
+	describe('with a custom click handler', function() {
+		var selectItemLabelA;
+
+		beforeEach(function() {
+			props = {
+				label : 'TEST-LABEL',
+				onRemove : jest.genMockFn(),
+				optionLabelClick : true,
+				onOptionLabelClick : jest.genMockFn()
+			};
+			value = TestUtils.renderIntoDocument(<Value {...props}/>);
+			selectItemLabelA = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-label__a');
+		});
+
+		it('presents the given label', function() {
+			expect(selectItemLabelA.getDOMNode().textContent).toBe(props.label);
+		});
+
+		it('calls a custom callback when the anchor is clicked', function() {
+			TestUtils.Simulate.click(selectItemLabelA.getDOMNode());
+			expect(props.onOptionLabelClick).toBeCalled();
+		});
+
+		it('calls a custom callback when the anchor is touched', function() {
+			TestUtils.Simulate.touchEnd(selectItemLabelA.getDOMNode());
+			expect(props.onOptionLabelClick).toBeCalled();
+		});
+
+	
+	
+	});
+
+});
+

--- a/src/__tests__/Value-test.js
+++ b/src/__tests__/Value-test.js
@@ -1,5 +1,5 @@
 'use strict';
-/*global describe, it, jest, expect*/
+/*global describe, it, jest, expect, beforeEach*/
 
 jest.dontMock('../Value');
 
@@ -14,8 +14,8 @@ describe('Value component', function() {
 
 	beforeEach(function() {
 		props = {
-			label : 'TEST-LABEL',
-			onRemove : jest.genMockFn()
+			label: 'TEST-LABEL',
+			onRemove: jest.genMockFn()
 		};
 		value = TestUtils.renderIntoDocument(<Value {...props}/>);
 	});
@@ -33,7 +33,7 @@ describe('Value component', function() {
 	});
 
 	it('prevents event propagation', function() {
-		var mockEvent = { stopPropagation : jest.genMockFn() };
+		var mockEvent = { stopPropagation: jest.genMockFn() };
 		value.blockEvent(mockEvent);
 		expect(mockEvent.stopPropagation).toBeCalled();
 
@@ -57,10 +57,10 @@ describe('Value component', function() {
 
 		beforeEach(function() {
 			props = {
-				label : 'TEST-LABEL',
-				onRemove : jest.genMockFn(),
-				optionLabelClick : true,
-				onOptionLabelClick : jest.genMockFn()
+				label: 'TEST-LABEL',
+				onRemove: jest.genMockFn(),
+				optionLabelClick: true,
+				onOptionLabelClick: jest.genMockFn()
 			};
 			value = TestUtils.renderIntoDocument(<Value {...props}/>);
 			selectItemLabelA = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-label__a');
@@ -80,8 +80,6 @@ describe('Value component', function() {
 			expect(props.onOptionLabelClick).toBeCalled();
 		});
 
-	
-	
 	});
 
 });


### PR DESCRIPTION
Hello!

I see that there is some room to increase the test coverage (particularly on such a customisable component) so I thought I'd get started on the low-hanging `<Value/>` component, and get some feedback before moving onto the more intricate  `<Select/>` component.

I've taken the liberty of setting the `collectCoverage: true` in `package.json` - very happy to switch it back if you consider it to be too noisy in the test output:

```
Using Jest CLI v0.4.10
 PASS  src/__tests__/Value-test.js (0.933s)
 PASS  src/__tests__/Select-test.js (1.252s)
2 tests passed (2 total)
Run time: 1.859s
----------------|-----------|-----------|-----------|-----------|
File            |   % Stmts |% Branches |   % Funcs |   % Lines |
----------------|-----------|-----------|-----------|-----------|
   src/         |      23.9 |     18.01 |     24.56 |     22.85 |
      Select.js |     21.94 |     17.41 |     21.82 |     20.75 |
      Value.js  |       100 |       100 |       100 |       100 |
----------------|-----------|-----------|-----------|-----------|
All files       |      23.9 |     18.01 |     24.56 |     22.85 |
----------------|-----------|-----------|-----------|-----------|

All reports generated
```

Please let me know your thoughts and if anything needs changing.