### PR TITLE
Get tests passing on node again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+    - "0.10"
+    - "0.11"
+    - "0.12"
+    - "iojs"
+before_script:
+    - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-    - "0.10"
-    - "0.11"
-    - "0.12"
-    - "iojs"
-before_script:
-    - npm install

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-react": "^2.5.2",
     "gulp": "^3.9.0",
     "istanbul": "^0.3.15",
-    "jsdom": "^5.4.3",
+    "jsdom": "^3.1.2",
     "lessify": "^1.0.1",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^0.4.0",


### PR DESCRIPTION
Hello!

This change will lower the JSDOM version so tests will run on node again.

It turns out [JSDOM from 4.x and above will not work on node.](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400)

If _node_ is not intended to be supported we should probably put a note in the contributions documentation. 