### PR TITLE
Fix bug where Select shows the value instead of the label

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -152,12 +152,13 @@ var Select = React.createClass({
 
 	componentWillReceiveProps: function componentWillReceiveProps(newProps) {
 		if (JSON.stringify(newProps.options) !== JSON.stringify(this.props.options)) {
+			var optionsChanged = true;
 			this.setState({
 				options: newProps.options,
 				filteredOptions: this.filterOptions(newProps.options)
 			});
 		}
-		if (newProps.value !== this.state.value) {
+		if (newProps.value !== this.state.value || optionsChanged) {
 			this.setState(this.getStateFromValue(newProps.value, newProps.options));
 		}
 	},


### PR DESCRIPTION
This happens if there is no matching option on initial render.  Future
updates to the options do not fix this condition.