### PR TITLE
adds a callback option after creating a new value

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,34 +140,35 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 ### Further options
 
 
-	Property			|	Type		|	Description
+	Property         | Type   | Description
 :-----------------------|:--------------|:--------------------------------
-	value 				|	any			|	 initial field value
-	multi 				|	bool		|	 multi-value input
-	disabled 			|	bool		|	 whether the Select is disabled or not
-	options 			|	array		|	 array of options
-	delimiter 			|	string		|	 delimiter to use to join multiple values
-	asyncOptions 		|	func		|	 function to call to get options
-	autoload 			|	bool		|	 whether to auto-load the default async options set
-	placeholder 		|	string		|	 field placeholder, displayed when there's no value
-	noResultsText 		|	string		|	 placeholder displayed when there are no matching search results
-	clearable 			|	bool		|	 should it be possible to reset value
-	clearValueText 		|	string		|	 title for the "clear" control
-	clearAllText 		|	string		|	 title for the "clear" control when multi: true
-	searchable 			|	bool		|	 whether to enable searching feature or not
-	searchPromptText 	|	string		|	 label to prompt for search input
-	name 				|	string		|	 field name, for hidden <input /> tag
-	onChange 			|	func		|	 onChange handler: function(newValue) {}
-	onFocus 			|	func		|	 onFocus handler: function(event) {}
-	onBlur 				|	func		|	 onBlur handler: function(event) {}
-	className 			|	string		|	 className for the outer element
-	filterOption 		|	func		|	 method to filter a single option: function(option, filterString)
-	filterOptions 		|	func		|	 method to filter the options array: function([options], filterString, [values])
-	matchPos 			|	string		|	 (any, start) match the start or entire string when filtering
-	matchProp 			|	string		|	 (any, label, value) which option property to filter on
-	ignoreCase 			|	bool		|	 whether to perform case-insensitive filtering
-	inputProps 			|	object		|	 custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
-
+	value            | any    | initial field value
+	multi            | bool   | multi-value input
+	disabled         | bool   | whether the Select is disabled or not
+	options          | array  | array of options
+	delimiter        | string | delimiter to use to join multiple values
+	asyncOptions     | func   | function to call to get options
+	autoload         | bool   | whether to auto-load the default async options set
+	placeholder      | string | field placeholder, displayed when there's no value
+	noResultsText    | string | placeholder displayed when there are no matching search results
+	clearable        | bool   | should it be possible to reset value
+	clearValueText   | string | title for the "clear" control
+	clearAllText     | string | title for the "clear" control when multi: true
+	searchable       | bool   | whether to enable searching feature or not
+	searchPromptText | string | label to prompt for search input
+	name             | string | field name, for hidden <input /> tag
+	onChange         | func   | onChange handler: function(newValue) {}
+	onFocus          | func   | onFocus handler: function(event) {}
+	onBlur           | func   | onBlur handler: function(event) {}
+	className        | string | className for the outer element
+	filterOption     | func   | method to filter a single option: function(option, filterString)
+	filterOptions    | func   | method to filter the options array: function([options], filterString, [values])
+	matchPos         | string | (any, start) match the start or entire string when filtering
+	matchProp        | string | (any, label, value) which option property to filter on
+	ignoreCase       | bool   | whether to perform case-insensitive filtering
+	inputProps       | object | custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
+	allowCreate      | bool   | allow creation of new values
+	onAddValue       | func   | callback to be called when user adds a non-existing value
 
 # Contributing
 

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -193,6 +193,9 @@ var SelectedValuesFieldCreate = React.createClass({
 	onLabelClick: function (data, event) {
 		console.log(data, event);
 	},
+	onCreateValue: function(newValue){
+		console.log("Congratulations, You've just created: " + newValue);
+	},
 	render: function() {
 		var ops = [
 			{ label: 'First Option', value: 'first' },
@@ -209,6 +212,7 @@ var SelectedValuesFieldCreate = React.createClass({
 					allowCreate={true}
 					placeholder="Select your favourite(s)"
 					options={ops}
+					onCreateValue={this.onCreateValue}
 					onChange={logChange} />
 			</div>
 		);

--- a/src/Select.js
+++ b/src/Select.js
@@ -36,6 +36,7 @@ var Select = React.createClass({
 		onChange: React.PropTypes.func,            // onChange handler: function(newValue) {}
 		onFocus: React.PropTypes.func,             // onFocus handler: function(event) {}
 		onOptionLabelClick: React.PropTypes.func,  // onCLick handler for value labels: function (value, event) {}
+		onCreateValue: React.PropTypes.func,         // onCreateValue handler: function(newOption) {}
 		optionRenderer: React.PropTypes.func,      // optionRenderer: function(option) {}
 		options: React.PropTypes.array,            // array of options
 		placeholder: React.PropTypes.string,       // field placeholder, displayed when there's no value
@@ -63,6 +64,7 @@ var Select = React.createClass({
 			name: undefined,
 			noResultsText: 'No results found',
 			onChange: undefined,
+			onCreateValue: undefined, 
 			onOptionLabelClick: undefined,
 			options: undefined,
 			placeholder: 'Select...',
@@ -256,7 +258,7 @@ var Select = React.createClass({
 	},
 
 	selectValue: function(value) {
-		if (!this.props.multi) {
+		if (!this.props.multi && !this.props.allowCreate) {
 			this.setValue(value);
 		} else if (value) {
 			this.addValue(value);
@@ -266,6 +268,9 @@ var Select = React.createClass({
 
 	addValue: function(value) {
 		this.setValue(this.state.values.concat(value));
+		if(this.props.onCreateValue) {
+			this.props.onCreateValue(value.value);
+		}
 	},
 
 	popValue: function() {


### PR DESCRIPTION
Have read the contributing guidelines only after making the (tiny) change, apols for this.

Adds a callback option after creating a new value. 
My usecase is the following. Students belong to a Studio, and you can assign the studio in a table. If the studio doesn't exist, adding it in the field should make a POST request to create one on the server.

`npm run test` failed on the previous commit already, I haven't tried to fix it.