### PR TITLE
Will it be better if the default async options set is auto-loaded with the default value?

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -471,7 +471,7 @@ var Select = React.createClass({
 
 	autoloadAsyncOptions: function() {
 		var self = this;
-		this.loadAsyncOptions('', {}, function () {
+		this.loadAsyncOptions((this.props.value || ''), {}, function () {
 			// update with fetched but don't focus
 			self.setValue(self.props.value, false);
 		});


### PR DESCRIPTION
Just like where this PR has changed. I think it's useful to autoload the correct options set base on the initial value (if it exists).