### PR TITLE
Fixed JS error caused by disabling as a response to selection

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -166,7 +166,7 @@ var Select = React.createClass({
 			clearTimeout(this._blurTimeout);
 
 			this._focusTimeout = setTimeout(function() {
-				self.getInputNode().focus();
+				self.focus();
 				self._focusAfterUpdate = false;
 			}, 50);
 		}
@@ -189,7 +189,9 @@ var Select = React.createClass({
 	},
 
 	focus: function() {
-		this.getInputNode().focus();
+		if(!this.props.disabled) {
+			this.getInputNode().focus();
+		}
 	},
 
 	clickedOutsideElement: function(element, event) {
@@ -319,7 +321,7 @@ var Select = React.createClass({
 			}, this._bindCloseMenuIfClickedOutside);
 		} else {
 			this._openAfterFocus = true;
-			this.getInputNode().focus();
+			this.focus();
 		}
 	},
 


### PR DESCRIPTION
If you select an item from the dropdown and then disable the component
as a reaction to the event, we would hit a JS error in getInputNode().

This makes it so we always use the existing focus() method when setting focus
and that we check for whether or not we're disabled before attempting
to set focus.