### PR TITLE
Allow entering of commas when allowCreate is on but multi is off.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -418,7 +418,7 @@ var Select = React.createClass({
 			break;
 
 			case 188: // ,
-				if (this.props.allowCreate) {
+				if (this.props.allowCreate && this.props.multi) {
 					event.preventDefault();
 					event.stopPropagation();
 					this.selectFocusedOption();


### PR DESCRIPTION
The keydown handler for commas was introduced in #151, but it is preventing created values from having commas in them.

This allows commas to be included in created values as long as multi isn't enabled.