### PR TITLE
Add a property called backspaceRemoves

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	matchProp 			|	string		|	 (any, label, value) which option property to filter on
 	ignoreCase 			|	bool		|	 whether to perform case-insensitive filtering
 	inputProps 			|	object		|	 custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
+	backspaceRemoves 		|	bool		|	 whether pressing backspace removes the last item when there is no input value
 
 
 # Contributing

--- a/src/Select.js
+++ b/src/Select.js
@@ -17,6 +17,7 @@ var Select = React.createClass({
 		allowCreate: React.PropTypes.bool,         // wether to allow creation of new entries
 		asyncOptions: React.PropTypes.func,        // function to call to get options
 		autoload: React.PropTypes.bool,            // whether to auto-load the default async options set
+		backspaceRemoves: React.PropTypes.bool,    // whether backspace removes an item if there is no text input
 		className: React.PropTypes.string,         // className for the outer element
 		clearable: React.PropTypes.bool,           // should it be possible to reset value
 		clearAllText: React.PropTypes.string,      // title for the "clear" control when multi: true
@@ -50,6 +51,7 @@ var Select = React.createClass({
 			allowCreate: false,
 			asyncOptions: undefined,
 			autoload: true,
+			backspaceRemoves: true,
 			className: undefined,
 			clearable: true,
 			clearAllText: 'Clear all',
@@ -383,7 +385,7 @@ var Select = React.createClass({
 		switch (event.keyCode) {
 
 			case 8: // backspace
-				if (!this.state.inputValue) {
+				if (!this.state.inputValue && this.props.backspaceRemoves) {
 					this.popValue();
 				}
 			return;


### PR DESCRIPTION
The standard behavior has been that pressing backspace removes the last item if
there is no input value present. This property allows the user to disable this
behavior by setting backspaceRemoves to false. Default behavior remains the
same, i.e. backspace removes an item.