### PR TITLE
Reset height and box-shadow

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -86,6 +86,7 @@
 	> input {
 		cursor: default;
 		background: none transparent;
+		height: auto;
 		border: 0 none;
 		padding: 0;
 		font-family: inherit;

--- a/less/control.less
+++ b/less/control.less
@@ -86,6 +86,7 @@
 	> input {
 		cursor: default;
 		background: none transparent;
+		box-shadow: none;
 		height: auto;
 		border: 0 none;
 		font-family: inherit;

--- a/less/control.less
+++ b/less/control.less
@@ -88,7 +88,6 @@
 		background: none transparent;
 		height: auto;
 		border: 0 none;
-		padding: 0;
 		font-family: inherit;
 		font-size: inherit;
 		margin: 0;


### PR DESCRIPTION
While using react-select in a website that uses Foundation, I ran into a problem where the hidden input would be absurdly tall:

<img width="249" alt="screen shot 2015-07-05 at 12 05 51 pm" src="https://cloud.githubusercontent.com/assets/507047/8513011/2cec488e-2310-11e5-9b2c-991660e60834.png">

This is because Foundation modifies the height of all `input` elements. I simply ensured that react-select had its own height set, and the situation is now resolved:

<img width="246" alt="screen shot 2015-07-05 at 12 06 08 pm" src="https://cloud.githubusercontent.com/assets/507047/8513017/4fb28630-2310-11e5-8d5d-e2813d1219d5.png">

**Addendum**: I also removed and extra padding declaration and added a reset for box-shadow.