### PR TITLE
allow the translation of the 'Add label ?' line on multi-value input

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -31,6 +31,7 @@ var Select = React.createClass({
 		matchProp: React.PropTypes.string,         // (any|label|value) which option property to filter on
 		multi: React.PropTypes.bool,               // multi-value input
 		name: React.PropTypes.string,              // field name, for hidden <input /> tag
+		addLabelText: React.PropTypes.string,      // placeholder displayed when you want to add a label on a multi-value input
 		noResultsText: React.PropTypes.string,     // placeholder displayed when there are no matching search results
 		onBlur: React.PropTypes.func,              // onBlur handler: function(event) {}
 		onChange: React.PropTypes.func,            // onChange handler: function(newValue) {}
@@ -61,6 +62,7 @@ var Select = React.createClass({
 			matchPos: 'any',
 			matchProp: 'any',
 			name: undefined,
+			addLabelText: 'Add {label} ?',
 			noResultsText: 'No results found',
 			onChange: undefined,
 			onOptionLabelClick: undefined,
@@ -678,7 +680,7 @@ var Select = React.createClass({
 			return op.disabled ? (
 				<div ref={ref} key={'option-' + op.value} className={optionClass}>{renderedLabel}</div>
 			) : (
-				<div ref={ref} key={'option-' + op.value} className={optionClass} onMouseEnter={mouseEnter} onMouseLeave={mouseLeave} onMouseDown={mouseDown} onClick={mouseDown}>{ op.create ? 'Add ' + op.label + ' ?' : renderedLabel}</div>
+				<div ref={ref} key={'option-' + op.value} className={optionClass} onMouseEnter={mouseEnter} onMouseLeave={mouseLeave} onMouseDown={mouseDown} onClick={mouseDown}>{ op.create ? this.props.addLabelText.replace('{label}', op.label) : renderedLabel}</div>
 			);
 		}, this);
 


### PR DESCRIPTION
This 'Add label ?' line was the only one that I found that was hardcoded and was then preventing a translation on react-select. 

I choose this simple system of replacing {label} to accomodate different languages that might need to replace the entire sentence and not just the "Add" part (the verb could be at the end, punctuation could differ...). 

I only touched to the src folder. Please let me know if I need to change other places to make it work :)