### PR TITLE
Add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "react": ">=0.13.3",
     "react-component-gulp-tasks": "^0.7.0",
     "sinon": "^1.15.4",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "unexpected": "^9.2.1",
+    "unexpected-dom": "^1.1.3",
+    "unexpected-sinon": "^6.4.1"
   },
   "peerDependencies": {
     "react": ">=0.13.3"
@@ -42,23 +45,23 @@
     "bump": "gulp bump",
     "bump:major": "gulp bump:major",
     "bump:minor": "gulp bump:minor",
-    "start": "gulp dev",
+    "cover": "istanbul cover node_modules/.bin/_mocha -- -u exports --compilers js:babel/register -R spec",
     "examples": "gulp dev:server",
     "lint": "eslint .",
     "publish:examples": "gulp publish:examples",
     "release": "gulp release",
+    "start": "gulp dev",
     "test": "mocha --compilers js:babel/register",
-    "cover": "istanbul cover node_modules/.bin/_mocha -- -u exports --compilers js:babel/register -R spec",
     "watch": "gulp watch:lib"
   },
   "keywords": [
+    "combobox",
+    "form",
+    "input",
+    "multiselect",
     "react",
     "react-component",
     "select",
-    "multiselect",
-    "combobox",
-    "input",
-    "form",
     "ui"
   ]
 }

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1,47 +1,53 @@
 'use strict';
 /* global describe, it, beforeEach */
 
-var jsdom = require('mocha-jsdom');
-var chai = require('chai');
-var expect = chai.expect;
+var helper = require('../testHelpers/jsdomHelper');
+helper();
 
-chai.should();
+var sinon = require('sinon');
+var unexpected = require('unexpected');
+var unexpectedDom = require('unexpected-dom');
+var unexpectedSinon = require('unexpected-sinon');
+var expect = unexpected
+	.clone()
+	.installPlugin(unexpectedDom)
+	.installPlugin(unexpectedSinon);
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
 
 var Select = require('../src/Select');
 
-describe('Select test', function() {
-	jsdom();
+describe('Select', function() {
 
-	var options, instance;
+	describe('with simple options', function () {
+		var options, instance, onChange;
 
-	function logChange(val) {
-		console.log('Selected: ' + val);
-	}
+		beforeEach(function () {
 
-	beforeEach(function() {
+			options = [
+				{value: 'one', label: 'One'},
+				{value: 'two', label: 'Two'}
+			];
+			
+			onChange = sinon.spy();
 
-		options = [
-			{ value: 'one', label: 'One' },
-			{ value: 'two', label: 'Two' }
-		];
+			// Render an instance of the component
+			instance = TestUtils.renderIntoDocument(
+				<Select
+					name="form-field-name"
+					value="one"
+					options={options}
+					onChange={onChange}
+					/>
+			);
 
-		// Render an instance of the component
-		instance = TestUtils.renderIntoDocument(
-			<Select
-				name="form-field-name"
-				value="one"
-				options={options}
-				onChange={logChange}/>
-		);
+		});
 
+		it('should assign the given name', function () {
+			var selectInputElement = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'input')[0];
+			expect(React.findDOMNode(selectInputElement).name, 'to equal', 'form-field-name');
+		});
+		
 	});
-
-	it('should assign the given name', function() {
-		var selectInputElement = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'input')[0];
-		expect(selectInputElement.getDOMNode().name).to.equal('form-field-name');
-	});
-
 });

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -28,9 +28,9 @@ describe('Select', function() {
 		beforeEach(function () {
 
 			options = [
-				{value: 'one', label: 'One'},
-				{value: 'two', label: 'Two'},
-				{value: 'three', label: 'Three'}
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' }
 			];
 			
 			onChange = sinon.spy();
@@ -61,6 +61,10 @@ describe('Select', function() {
 		
 		function typeSearchText(text) {
 			TestUtils.Simulate.change(searchInputNode, { target: { value: text } });
+		}
+		
+		function getSelectControl(instance) {
+			return React.findDOMNode(instance).querySelector('.Select-control');
 		}
 
 		it('should assign the given name', function () {
@@ -124,5 +128,130 @@ describe('Select', function() {
 			pressTabToAccept();
 			expect(onChange, 'was called with', 'three');
 		});
+		
+		it('should focus the first value on mouse click', function () {
+
+			TestUtils.Simulate.mouseDown(React.findDOMNode(instance).querySelector('.Select-control'));
+			expect(React.findDOMNode(instance), 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'One');
+		});
+		
+		it('should move the focused value to the second value when down pressed', function () {
+
+			var selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			expect(React.findDOMNode(instance), 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'Two');
+		});
+		
+		it('should move the focused value to the second value when down pressed', function () {
+
+			var selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			expect(React.findDOMNode(instance), 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'Three');
+		});
+		
+		it('should loop round to top item when down is pressed on the last item', function () {
+
+			var selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			expect(React.findDOMNode(instance), 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'One');
+		});
+		
+		
+		it('should loop round to bottom item when up is pressed on the first item', function () {
+
+			var selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 38, key: 'ArrowUp' });
+			expect(React.findDOMNode(instance), 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'Three');
+		});
+		
+		it('should clear the selection on escape', function () {
+			
+			var selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 27, key: 'Escape' });
+			expect(React.findDOMNode(instance).querySelectorAll('.Select-option'),
+				'to have length', 0);
+			
+		});
+		
+		it('should open the options on arrow down with the top option focused, when the options are closed', function () {
+
+			var selectControl = getSelectControl(instance);
+			var domNode = React.findDOMNode(instance);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 38, key: 'ArrowDown' });
+			expect(domNode, 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'One');
+		});
+		
+		it('should open the options on arrow up with the top option focused, when the options are closed', function () {
+
+			var selectControl = getSelectControl(instance);
+			var domNode = React.findDOMNode(instance);
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+			expect(domNode, 'queried for', '.Select-option.is-focused',
+				'to have items satisfying',
+				'to have text', 'One');
+		});
+		
+		
+		describe('after mouseEnter and leave of an option', function () {
+			
+			beforeEach(function () {
+
+				// Show the options
+				var selectControl = getSelectControl(instance);
+				TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+				
+				var optionTwo = React.findDOMNode(instance).querySelectorAll('.Select-option')[1];
+				TestUtils.SimulateNative.mouseOver(optionTwo);
+				TestUtils.SimulateNative.mouseOut(optionTwo);
+			});
+			
+			it('should have no focused options', function () {
+				
+				var domNode = React.findDOMNode(instance);
+				expect(domNode.querySelectorAll('.Select-option.is-focused'), 'to have length', 0);
+			});
+			
+			it('should focus top option after down arrow pressed', function () {
+
+				var selectControl = getSelectControl(instance);
+				TestUtils.Simulate.keyDown(selectControl, { keyCode: 40, key: 'ArrowDown' });
+				var domNode = React.findDOMNode(instance);
+				expect(domNode, 'queried for', '.Select-option.is-focused',
+					'to have items satisfying',
+					'to have text', 'One');
+				
+			});
+			
+			it('should focus last option after up arrow pressed', function () {
+
+				var selectControl = getSelectControl(instance);
+				TestUtils.Simulate.keyDown(selectControl, { keyCode: 38, key: 'ArrowUp' });
+				var domNode = React.findDOMNode(instance);
+				expect(domNode, 'queried for', '.Select-option.is-focused',
+					'to have items satisfying',
+					'to have text', 'Three');
+			});
+		});
+		
 	});
 });

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -18,16 +18,19 @@ var TestUtils = React.addons.TestUtils;
 
 var Select = require('../src/Select');
 
+
 describe('Select', function() {
 
 	describe('with simple options', function () {
 		var options, instance, onChange;
+		var searchInputNode;
 
 		beforeEach(function () {
 
 			options = [
 				{value: 'one', label: 'One'},
-				{value: 'two', label: 'Two'}
+				{value: 'two', label: 'Two'},
+				{value: 'three', label: 'Three'}
 			];
 			
 			onChange = sinon.spy();
@@ -39,15 +42,87 @@ describe('Select', function() {
 					value="one"
 					options={options}
 					onChange={onChange}
+					searchable={true}
 					/>
 			);
+			
+			// Focus on the input, such that mouse events are accepted
+			searchInputNode = instance.getInputNode().getDOMNode().querySelector('input');
+			TestUtils.Simulate.focus(searchInputNode);
 
 		});
+		
+		function pressEnterToAccept() {
+			TestUtils.Simulate.keyDown(searchInputNode, { keyCode: 13, key: 'Enter' });
+		}
+		function pressTabToAccept() {
+			TestUtils.Simulate.keyDown(searchInputNode, { keyCode: 9, key: 'Tab' });
+		}
+		
+		function typeSearchText(text) {
+			TestUtils.Simulate.change(searchInputNode, { target: { value: text } });
+		}
 
 		it('should assign the given name', function () {
 			var selectInputElement = TestUtils.scryRenderedDOMComponentsWithTag(instance, 'input')[0];
 			expect(React.findDOMNode(selectInputElement).name, 'to equal', 'form-field-name');
 		});
 		
+		it('should show the options on mouse click', function () {
+			TestUtils.Simulate.mouseDown(React.findDOMNode(instance).querySelector('.Select-control'));
+			var node = React.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option', 'to have length', 3);
+		});
+		
+		it('should display the labels on mouse click', function () {
+			TestUtils.Simulate.mouseDown(React.findDOMNode(instance).querySelector('.Select-control'));
+			var node = React.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option:nth-child(1)', 'to have items satisfying', 'to have text', 'One');
+			expect(node, 'queried for', '.Select-option:nth-child(2)', 'to have items satisfying', 'to have text', 'Two');
+			expect(node, 'queried for', '.Select-option:nth-child(3)', 'to have items satisfying', 'to have text', 'Three');
+		});
+		
+		it('should filter after entering some text', function () {
+			
+			typeSearchText('T');
+			var node = React.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option:nth-child(1)', 'to have items satisfying', 'to have text', 'Two');
+			expect(node, 'queried for', '.Select-option:nth-child(2)', 'to have items satisfying', 'to have text', 'Three');
+			expect(node, 'queried for', '.Select-option', 'to have length', 2);
+		});
+		
+		it('should filter case insensitively', function () {
+
+			typeSearchText('t');
+			var node = React.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option:nth-child(1)', 'to have items satisfying', 'to have text', 'Two');
+			expect(node, 'queried for', '.Select-option:nth-child(2)', 'to have items satisfying', 'to have text', 'Three');
+			expect(node, 'queried for', '.Select-option', 'to have length', 2);
+		});
+		
+		it('should filter using "contains"', function () {
+			
+			// Search 'h', should only show 'Three'
+			typeSearchText('h');
+			var node = React.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option:nth-child(1)', 'to have items satisfying', 'to have text', 'Three');
+			expect(node, 'queried for', '.Select-option', 'to have length', 1);
+		});
+		
+		it('should accept when enter is pressed', function () {
+
+			// Search 'h', should only show 'Three'
+			typeSearchText('h');
+			pressEnterToAccept();
+			expect(onChange, 'was called with', 'three');
+		});
+		
+		it('should accept when tab is pressed', function () {
+
+			// Search 'h', should only show 'Three'
+			typeSearchText('h');
+			pressTabToAccept();
+			expect(onChange, 'was called with', 'three');
+		});
 	});
 });

--- a/test/Value-test.js
+++ b/test/Value-test.js
@@ -1,14 +1,18 @@
 'use strict';
 /* global describe, it, beforeEach */
 
-var jsdom = require('mocha-jsdom');
-var chai = require('chai');
-var sinon = require('sinon');
-var sinonChai = require('sinon-chai');
-var expect = chai.expect;
+var helper = require('../testHelpers/jsdomHelper');
+helper();
 
-chai.should();
-chai.use(sinonChai);
+var unexpected = require('unexpected');
+var unexpectedDom = require('unexpected-dom');
+var unexpectedSinon = require('unexpected-sinon');
+var sinon = require('sinon');
+
+var expect = unexpected
+	.clone()
+	.installPlugin(unexpectedSinon)
+	.installPlugin(unexpectedDom);
 
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
@@ -18,7 +22,6 @@ var OPTION = { label: 'TEST-LABEL', value: 'TEST-VALUE' };
 var Value = require('../src/Value');
 
 describe('Value component', function() {
-	jsdom();
 
 	var props;
 	var value;
@@ -34,26 +37,26 @@ describe('Value component', function() {
 	it('requests its own removal when the remove icon is clicked', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
 		TestUtils.Simulate.click(selectItemIcon.getDOMNode());
-		expect(props.onRemove).to.have.been.called;
+		expect(props.onRemove, 'was called');
 	});
 
 	it('requests its own removal when the remove icon is touched', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
 		TestUtils.Simulate.touchEnd(selectItemIcon.getDOMNode());
-		expect(props.onRemove).to.have.been.called;
+		expect(props.onRemove, 'was called');
 	});
 
 	it('prevents event propagation, pt 1', function() {
 		var mockEvent = { stopPropagation: sinon.spy() };
 		value.blockEvent(mockEvent);
-		expect(mockEvent.stopPropagation).to.have.been.called;
+		expect(mockEvent.stopPropagation, 'was called');
 	});
 
 	describe('without a custom click handler', function() {
 
 		it('presents the given label', function() {
 			var selectItemLabel = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-label');
-			expect(selectItemLabel.getDOMNode().textContent).to.equal(OPTION.label);
+			expect(selectItemLabel.getDOMNode().textContent, 'to equal', OPTION.label);
 		});
 
 	});
@@ -73,17 +76,17 @@ describe('Value component', function() {
 		});
 
 		it('presents the given label', function() {
-			expect(selectItemLabelA.getDOMNode().textContent).to.equal(OPTION.label);
+			expect(selectItemLabelA.getDOMNode().textContent, 'to equal', OPTION.label);
 		});
 
 		it('calls a custom callback when the anchor is clicked', function() {
 			TestUtils.Simulate.click(selectItemLabelA.getDOMNode());
-			expect(props.onOptionLabelClick).to.have.been.called;
+			expect(props.onOptionLabelClick, 'was called');
 		});
 
 		it('calls a custom callback when the anchor is touched', function() {
 			TestUtils.Simulate.touchEnd(selectItemLabelA.getDOMNode());
-			expect(props.onOptionLabelClick).to.have.been.called;
+			expect(props.onOptionLabelClick, 'was called');
 		});
 
 	});

--- a/test/Value-test.js
+++ b/test/Value-test.js
@@ -36,13 +36,13 @@ describe('Value component', function() {
 
 	it('requests its own removal when the remove icon is clicked', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
-		TestUtils.Simulate.click(selectItemIcon.getDOMNode());
+		TestUtils.Simulate.click(selectItemIcon);
 		expect(props.onRemove, 'was called');
 	});
 
 	it('requests its own removal when the remove icon is touched', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-icon');
-		TestUtils.Simulate.touchEnd(selectItemIcon.getDOMNode());
+		TestUtils.Simulate.touchEnd(selectItemIcon);
 		expect(props.onRemove, 'was called');
 	});
 
@@ -56,7 +56,7 @@ describe('Value component', function() {
 
 		it('presents the given label', function() {
 			var selectItemLabel = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-item-label');
-			expect(selectItemLabel.getDOMNode().textContent, 'to equal', OPTION.label);
+			expect(React.findDOMNode(selectItemLabel), 'to have text', OPTION.label);
 		});
 
 	});
@@ -76,16 +76,16 @@ describe('Value component', function() {
 		});
 
 		it('presents the given label', function() {
-			expect(selectItemLabelA.getDOMNode().textContent, 'to equal', OPTION.label);
+			expect(React.findDOMNode(selectItemLabelA), 'to have text', OPTION.label);
 		});
 
 		it('calls a custom callback when the anchor is clicked', function() {
-			TestUtils.Simulate.click(selectItemLabelA.getDOMNode());
+			TestUtils.Simulate.click(selectItemLabelA);
 			expect(props.onOptionLabelClick, 'was called');
 		});
 
 		it('calls a custom callback when the anchor is touched', function() {
-			TestUtils.Simulate.touchEnd(selectItemLabelA.getDOMNode());
+			TestUtils.Simulate.touchEnd(selectItemLabelA);
 			expect(props.onOptionLabelClick, 'was called');
 		});
 

--- a/testHelpers/jsdomHelper.js
+++ b/testHelpers/jsdomHelper.js
@@ -1,0 +1,13 @@
+
+module.exports = function (html) {
+	if (typeof document !== 'undefined') {
+		return;
+	}
+
+	var jsdom = require('jsdom').jsdom;
+	global.document = jsdom(html || '');
+	global.window = global.document.parentWindow;
+	global.navigator = {
+		userAgent: 'JSDOM'
+	};
+};

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,19 @@
+var babel = require('babel');
+
+module.exports = function (wallaby) {
+	
+	return {
+
+		files: ['src/*.js', 'testHelpers/*.js'],
+
+		tests: ['test/*-test.js' ],
+
+		env: {
+			type: 'node'
+		},
+
+		preprocessors: {
+			'**/*.js': file => babel.transform(file.content, {sourceMap: true})
+		}
+	};
+};


### PR DESCRIPTION
I'm starting to add some tests to react-select, as we're beginning to rely on it as an excellent "native" implementation of select2. I'm submitting this PR to see how the land lies - we've had previous success using [unexpected](https://github.com/unexpectedjs/unexpected) and [unexpected-dom](https://github.com/Munter/unexpected-dom) testing react components.

I'm aiming towards writing tests for where I've seen a couple of issues, but are difficult to prove/check without tests. However, in order to get there, I thought I'd start with a few general tests to cover the basics.

Coverage has improved from about 24% to about 62% :)

I know changing assertion libraries is not necessarily seen as a positive thing, but as the previous tests weren't really being extended, I thought I'd give it a go.

Comments welcome, obviously!