### PR TITLE
Specify a min-height for .Select-control

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -22,6 +22,7 @@
 	// right padding allows for arrow, clear button and loading indicator
 	padding: @select-padding-vertical 52px @select-padding-vertical @select-padding-horizontal;
 	transition: all 200ms ease;
+	min-height: 40px;
 
 	&:hover {
 		box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
The select box collapses (similar to what is seen [here](https://github.com/JedWatson/react-select/issues/262#issue-89765704)) when `searchable` is false and no values are selected.

Specifying a `min-height` fixes this.
