### PR TITLE
Stopped eslint from linting bower_components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ lib/*
 dist/*
 examples/dist/*
 node_modules/*
+bower_components/*


### PR DESCRIPTION
Hey, I know there isn't an issue for this but `npm run lint` reports a ton of errors from bower_components. 

It still reports problems but it's only 3 from [wallaby.js](https://github.com/JedWatson/react-select/blob/master/wallaby.js)