### PR TITLE
valueRenderer now works when multi={false} #296

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	Property			|	Type		|	Description
 :-----------------------|:--------------|:--------------------------------
 	value 				|	any			|	 initial field value
+	valueRenderer		|	func		|	 function which returns a custom way to render the value selected
 	multi 				|	bool		|	 multi-value input
 	disabled 			|	bool		|	 whether the Select is disabled or not
 	options 			|	array		|	 array of options
+	optionRenderer		|	func		|	 function which returns a custom way to render the options in the menu
 	delimiter 			|	string		|	 delimiter to use to join multiple values
 	asyncOptions 		|	func		|	 function to call to get options
 	autoload 			|	bool		|	 whether to auto-load the default async options set

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -236,6 +236,38 @@ var CustomRenderField = React.createClass({
 			<div>
 				<label>{this.props.label}</label>
 				<Select
+					allowCreate={true}
+					placeholder="Select your favourite"
+					options={ops}
+					optionRenderer={this.renderOption}
+					valueRenderer={this.renderValue}
+					onChange={logChange} />
+			</div>
+		);
+	}
+});
+
+var CustomRenderMultiField = React.createClass({
+	onLabelClick: function (data, event) {
+		console.log(data, event);
+	},
+	renderOption: function(option) {
+		return <span style={{ color: option.hex }}>{option.label} ({option.hex})</span>;
+
+	},
+	renderValue: function(option) {
+		return <strong style={{ color: option.hex }}>{option.label}</strong>;
+	},
+	render: function() {
+		var ops = [
+			{ label: 'Red', value: 'red', hex: '#EC6230' },
+			{ label: 'Green', value: 'green', hex: '#4ED84E' },
+			{ label: 'Blue', value: 'blue', hex: '#6D97E2' }
+		];
+		return (
+			<div>
+				<label>{this.props.label}</label>
+				<Select
 					delimiter=","
 					multi={true}
 					allowCreate={true}
@@ -257,6 +289,7 @@ React.render(
 		<SelectedValuesField label="Clickable labels (labels as links):" />
 		<SelectedValuesFieldCreate label="Option Creation (tags mode):" />
 		<CustomRenderField label="Custom rendering for options and values:" />
+		<CustomRenderMultiField label="Custom rendering for multiple options and values:" />
 		<RemoteSelectField label="Remote Options:"/>
 	</div>,
 	document.getElementById('example')

--- a/less/control.less
+++ b/less/control.less
@@ -78,6 +78,27 @@
 	color: @select-text-color;
 }
 
+// value with custom renderer
+
+.Select-value {
+	color: @select-input-placeholder;
+	padding: @select-padding-vertical 52px @select-padding-vertical @select-padding-horizontal;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: -(@select-arrow-width + @select-padding-horizontal);
+
+	// crop text
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.has-value > .Select-control > .Select-value {
+	color: @select-text-color;
+}
+
 
 // the <input> element users type in
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -722,8 +722,19 @@ var Select = React.createClass({
 			}, this);
 		}
 
-		if (!this.state.inputValue && (!this.props.multi || !value.length)) {
-			value.push(<div className="Select-placeholder" key="placeholder">{this.state.placeholder}</div>);
+		if(!this.state.inputValue && (!this.props.multi || !value.length)) {
+			if(this.props.valueRenderer && !!this.state.values.length) {
+				var val = this.state.values[0] || null;
+				console.log('select-value', this.state.values);
+				value.push(<Value
+						key={0}
+						option={val}
+						renderer={this.props.valueRenderer}
+						disabled={this.props.disabled} />);
+			} else {
+				value.push(<div className="Select-placeholder" key="placeholder">{this.state.placeholder}</div>);
+			}
+			
 		}
 
 		var loading = this.state.isLoading ? <span className="Select-loading" aria-hidden="true" /> : null;

--- a/src/Value.js
+++ b/src/Value.js
@@ -29,6 +29,10 @@ var Value = React.createClass({
 			label = this.props.renderer(this.props.option);
 		}
 
+		if(!this.props.onRemove && !this.props.optionLabelClick) {
+			return <div className="Select-value">{label}</div>;
+		}
+
 		if (this.props.optionLabelClick) {
 			label = (
 				<a className="Select-item-label__a"


### PR DESCRIPTION
* Updated the README to mention the custom renders
* Updated examples with custom renderer that has multi disabled
* Added style for custom value rendering `Select-value` (basically `Select-placeholder`, but different so it can be selected)
* Using valueRenderer to render `label` to display as value which fixes #296
* Works with custom inputs as well.

Are there any tests to create or anything else I need to update?