### PR TITLE
Allow disabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can also use the standalone build by including `dist/select.js` and `dist/de
 
 React-Select generates a hidden text field containing the selected value, so you can submit it as part of a standard form. You can also listen for changes with the `onChange` event property.
 
-Options should be provided as an `Array` of `Object`s, each with a `value` and `label` property for rendering and searching.
+Options should be provided as an `Array` of `Object`s, each with a `value` and `label` property for rendering and searching. You can use a `disabled` property to indicate whether the option is disabled or not.
 
 When the value is changed, `onChange(newValue, [selectedOptions])` will fire.
 

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -189,6 +189,35 @@ var SelectedValuesField = React.createClass({
 	}
 });
 
+
+var SelectedValuesFieldDisabled = React.createClass({
+	onLabelClick: function (data, event) {
+		console.log(data, event);
+	},
+	render: function() {
+		var ops = [
+			{ label: 'Chocolate', value: 'chocolate' },
+			{ label: 'Vanilla', value: 'vanilla' },
+			{ label: 'Strawberry', value: 'strawberry' },
+			{ label: 'Caramel (You don\'t like it, apparently)', value: 'caramel', disabled: true },
+			{ label: 'Cookies and Cream', value: 'cookiescream' },
+			{ label: 'Peppermint', value: 'peppermint' }
+		];
+		return (
+			<div>
+				<label>{this.props.label}</label>
+				<Select
+					onOptionLabelClick={this.onLabelClick}
+					value="chocolate,vanilla,strawberry"
+					multi={true}
+					placeholder="Select your favourite(s)"
+					options={ops}
+					onChange={logChange} />
+			</div>
+		);
+	}
+});
+
 var SelectedValuesFieldCreate = React.createClass({
 	onLabelClick: function (data, event) {
 		console.log(data, event);
@@ -287,6 +316,7 @@ React.render(
 		<StatesField label="States (non-searchable):" searchable={false} />
 		<MultiSelectField label="Multiselect:"/>
 		<SelectedValuesField label="Clickable labels (labels as links):" />
+		<SelectedValuesFieldDisabled label="Disabled option:" />
 		<SelectedValuesFieldCreate label="Option Creation (tags mode):" />
 		<CustomRenderField label="Custom rendering for options and values:" />
 		<CustomRenderMultiField label="Custom rendering for multiple options and values:" />

--- a/src/Select.js
+++ b/src/Select.js
@@ -553,6 +553,7 @@ var Select = React.createClass({
 			var filterOption = function(op) {
 				if (this.props.multi && exclude.indexOf(op.value) > -1) return false;
 				if (this.props.filterOption) return this.props.filterOption.call(this, op, filterValue);
+				if (filterValue && op.disabled) return false;
 				var valueTest = String(op.value), labelTest = String(op.label);
 				if (this.props.ignoreCase) {
 					valueTest = valueTest.toLowerCase();
@@ -595,7 +596,9 @@ var Select = React.createClass({
 	focusAdjacentOption: function(dir) {
 		this._focusedOptionReveal = true;
 
-		var ops = this.state.filteredOptions;
+		var ops = this.state.filteredOptions.filter(function(op) {
+			return !op.disabled;
+		});
 
 		if (!this.state.isOpen) {
 			this.setState({


### PR DESCRIPTION
It will be useful to allow `{value: "some value", label: "some label", disabled: true}`.

I noticed that this is already partially implemented. A disabled option gets a classname `is-disabled` (with proper css style). And you can no longer select it by mouse click. However you can still select it using keyboard. This PR will fix it. (as described in #274)