### PR TITLE
Placeholder tests

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -161,7 +161,7 @@ var Select = React.createClass({
 				filteredOptions: this.filterOptions(newProps.options)
 			});
 		}
-		if (newProps.value !== this.state.value || newProps.placeholder !== this.state.placeholder || optionsChanged) {
+		if (newProps.value !== this.state.value || newProps.placeholder !== this.props.placeholder || optionsChanged) {
 			this.setState(this.getStateFromValue(newProps.value, newProps.options, newProps.placeholder));
 		}
 	},


### PR DESCRIPTION
Adds tests for the placeholder functionality, including the fix in the recent PR (#334)

Also corrects the comparison - this was causing extra unnecessary work by comparing
to state.placeholder instead of props.placeholder