### PR TITLE
Issue #200 - calling loadAsyncOptions when receiving new props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage
 
 # Dependency directory
 node_modules
+bower_components
 
 # Publish directory
 .publish

--- a/src/Select.js
+++ b/src/Select.js
@@ -172,7 +172,17 @@ var Select = React.createClass({
 			});
 		}
 		if (newProps.value !== this.state.value || newProps.placeholder !== this.props.placeholder || optionsChanged) {
-			this.setState(this.getStateFromValue(newProps.value, newProps.options, newProps.placeholder));
+
+			var setState = function(){
+				this.setState(this.getStateFromValue(newProps.value, newProps.options, newProps.placeholder))
+			};
+
+			if (this.props.asyncOptions) {
+					this.loadAsyncOptions(newProps.value, setState);
+			}
+			else {
+				setState();
+			}
 		}
 	},
 
@@ -228,7 +238,7 @@ var Select = React.createClass({
 
 		var values = this.initValuesArray(value, options),
 			filteredOptions = this.filterOptions(options, values);
-		
+
 		var focusedOption;
 		if (!this.props.multi && values.length) {
 			focusedOption = values[0];

--- a/src/Select.js
+++ b/src/Select.js
@@ -164,6 +164,7 @@ var Select = React.createClass({
 
 	componentWillReceiveProps: function(newProps) {
 		var optionsChanged = false;
+		var self = this;
 		if (JSON.stringify(newProps.options) !== JSON.stringify(this.props.options)) {
 			optionsChanged = true;
 			this.setState({
@@ -174,7 +175,7 @@ var Select = React.createClass({
 		if (newProps.value !== this.state.value || newProps.placeholder !== this.props.placeholder || optionsChanged) {
 
 			var setState = function(){
-				this.setState(this.getStateFromValue(newProps.value, newProps.options, newProps.placeholder))
+				self.setState(self.getStateFromValue(newProps.value, newProps.options, newProps.placeholder))
 			};
 
 			if (this.props.asyncOptions) {


### PR DESCRIPTION
This resolves issue #200

When passing new props to component, asyncOptions are fetched, because the passed values are not guaranteed to be contained in the current options cache.