### PR TITLE
Disabled options appear in the search results

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -572,7 +572,6 @@ var Select = React.createClass({
 			var filterOption = function(op) {
 				if (this.props.multi && exclude.indexOf(op.value) > -1) return false;
 				if (this.props.filterOption) return this.props.filterOption.call(this, op, filterValue);
-				if (filterValue && op.disabled) return false;
 				var valueTest = String(op.value), labelTest = String(op.label);
 				if (this.props.ignoreCase) {
 					valueTest = valueTest.toLowerCase();

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -608,6 +608,17 @@ describe('Select', function() {
 			expect(React.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
 				'to have text', 'Select...');
 		});
+		
+		it('shows disabled results in a search', function () {
+			
+			typeSearchText('t');
+			var options = React.findDOMNode(instance).querySelectorAll('.Select-option');
+			expect(options[0], 'to have text', 'Two');
+			expect(options[0], 'to have attributes', {
+				class: 'is-disabled'
+			});
+			expect(options[1], 'to have text', 'Three');
+		});
 	});
 
 	describe('with allowCreate=true', function () {


### PR DESCRIPTION
Previously (following PR #346) a disabled option would show up in the list, until searching, then it would disappear.
This commit changes that behaviour, so that the option is still shown (when it matches the search), but still cannot be selected.

Test added.

This is a very subjective PR, so it'd be good to get a few opinions on this - I find it feels weird when you click the arrow to show the states, type 'a', and 'Alabama' disappears.  If the caller didn't want to display the option, they'd have removed it from the options, not set it to disabled, but that's just my opinion.
