### PR TITLE
Peg version of io.js to 2.5.0 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
     - "0.10"
     - "0.11"
     - "0.12"
-    - "iojs"
+    - "iojs-v2.5.0"
 before_script:
     - npm install


### PR DESCRIPTION
Currently issue brianmcd/contextify#173 of contextify is causing all PRs to fail on io.js.
Until this issue is resolved, I'd recommend pinning the io.js version to v2.5.0 (the last in the 2.x line), such that we get accurate status from travis.

This can be reverted when the issue with contextify is resolved.

I can't test this actually works, but the version matches what `nvm ls-remote` returns as the last supported 2.x version.