### PR TITLE
Use correct parameters for loadAsyncOptions

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -167,11 +167,14 @@ var Select = React.createClass({
 			});
 		}
 		if (newProps.value !== this.state.value || newProps.placeholder !== this.props.placeholder || optionsChanged) {
-			var setState = () => {
-				this.setState(this.getStateFromValue(newProps.value, newProps.options, newProps.placeholder));
+			var setState = (newState) => {
+				this.setState(this.getStateFromValue(newProps.value,
+					(newState && newState.options) || newProps.options,
+					newProps.placeholder)
+				);
 			};
 			if (this.props.asyncOptions) {
-				this.loadAsyncOptions(newProps.value, setState);
+				this.loadAsyncOptions(newProps.value, {}, setState);
 			} else {
 				setState();
 			}
@@ -514,7 +517,7 @@ var Select = React.createClass({
 						}
 					}
 					this.setState(newState);
-					if (callback) callback.call(this, {});
+					if (callback) callback.call(this, newState);
 					return;
 				}
 			}
@@ -540,7 +543,7 @@ var Select = React.createClass({
 				}
 			}
 			this.setState(newState);
-			if (callback) callback.call(this, {});
+			if (callback) callback.call(this, newState);
 		});
 	},
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1046,7 +1046,7 @@ describe('Select', function() {
 			beforeEach(function () {
 
 				// Render an instance of the component
-				instance = createControl({
+				wrapper = createControlWithWrapper({
 					value: '',
 					asyncOptions: asyncOptions,
 					autoload: true
@@ -1134,12 +1134,20 @@ describe('Select', function() {
 					]
 				});
 
-
 				expect(function () {
 					typeSearchText('tes');
 				}, 'to throw exception', new Error('Something\'s wrong jim'));
 			});
+			
+			it('calls the asyncOptions function when the value prop changes', function () {
 
+				expect(asyncOptions, 'was called once');
+				
+				wrapper.setPropsForChild({ value: 'test2' });
+				
+				expect(asyncOptions, 'was called twice');
+			});
+			
 
 		});
 
@@ -1172,7 +1180,7 @@ describe('Select', function() {
 			beforeEach(function () {
 
 				// Render an instance of the component
-				instance = createControl({
+				wrapper = createControlWithWrapper({
 					value: '',
 					asyncOptions: asyncOptions,
 					disableCache: true
@@ -1195,6 +1203,23 @@ describe('Select', function() {
 				expect(asyncOptions, 'was called times', 4);
 
 			});
+	
+			it('updates the displayed value after changing value and refreshing from asyncOptions', function () {
+
+				asyncOptions.reset();
+				asyncOptions.callsArgWith(1, null, {
+					options: [
+						{ value: 'newValue', label: 'New Value from Server' },
+						{ value: 'test', label: 'TEST one' }
+					]
+				});
+
+				wrapper.setPropsForChild({ value: 'newValue' });
+	
+				expect(React.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
+					'to have text', 'New Value from Server');
+			});
+
 
 		});
 	});


### PR DESCRIPTION
Fix for PR #360 / #355 (the two combined cause a potential issue)

If the cache is disabled, and the value is updated, the new options received
from the callback should be used for the display value, not the options from
state.options, as the state after the callback is stale (this.setState() has
been called, but won't have taken effect due to update batching)

Tests added.