### PR TITLE
Fix trim_trailing_whitespace in editor_config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
 
@@ -16,3 +16,6 @@ indent_size = 2
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Any reason why trim_trailing_whitespace was set to false?

After seeing the whitespace fixes in 835caa3fb, I thought there must be something wrong with my editor, but it all looked like it was configured correctly, then I spotted this :smile:

I've left it false for *.md where it might be meaningful.