### PR TITLE
Remove browserify-shim configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,6 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },
-  "browserify-shim": {
-    "classnames": "global:classNames",
-    "react": "global:React",
-    "react-input-autosize": "global:AutosizeInput"
-  },
   "scripts": {
     "build": "gulp clean && NODE_ENV=production gulp build",
     "bump": "gulp bump",


### PR DESCRIPTION
This PR removes all `browserify-shim` configuration so that we don't have to add react-select's dependencies to the global namespace. I believe it is still possible to shim those libraries from the requiring `package.json` file if necessary.

It is related to https://github.com/JedWatson/react-select/issues/270

edit: typos
