### PR TITLE
Searching text prop (Rebased #141)

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -352,7 +352,7 @@ var Select = React.createClass({
 		}
 		event.stopPropagation();
 		event.preventDefault();
-		
+
 		// for the non-searchable select, close the dropdown when button is clicked
 		if (this.state.isOpen && !this.props.searchable) {
 			this.setState({
@@ -360,7 +360,7 @@ var Select = React.createClass({
 			}, this._unbindCloseMenuIfClickedOutside);
 			return;
 		}
-		
+
 		if (this.state.isFocused) {
 			this.setState({
 				isOpen: true
@@ -706,15 +706,15 @@ var Select = React.createClass({
 		if (ops.length) {
 			return ops;
 		} else {
-			var noResultsText = (function () {
-				if (this.state.isLoading) {
-					return this.props.searchingText;
-				} else if (this.state.inputValue || !this.props.asyncOptions) {
-					return this.props.noResultsText;
-				} else {
-					return this.props.searchPromptText;
-				}
-			}.bind(this))();
+			var noResultsText;
+			if (this.state.isLoading) {
+				noResultsText = this.props.searchingText;
+			} else if (this.state.inputValue || !this.props.asyncOptions) {
+				noResultsText = this.props.noResultsText;
+			} else {
+				noResultsText = this.props.searchPromptText;
+			}
+
 			return (
 				<div className="Select-noresults">
 					{noResultsText}

--- a/src/Select.js
+++ b/src/Select.js
@@ -47,6 +47,7 @@ var Select = React.createClass({
 		options: React.PropTypes.array,            // array of options
 		placeholder: React.PropTypes.string,       // field placeholder, displayed when there's no value
 		searchable: React.PropTypes.bool,          // whether to enable searching feature or not
+		searchingText: React.PropTypes.string,     // message to display whilst options are loading via asyncOptions
 		searchPromptText: React.PropTypes.string,  // label to prompt for search input
 		singleValueComponent: React.PropTypes.func,// single value component when multiple is set to false
 		value: React.PropTypes.any,                // initial field value
@@ -81,6 +82,7 @@ var Select = React.createClass({
 			options: undefined,
 			placeholder: 'Select...',
 			searchable: true,
+			searchingText: 'Searching...',
 			searchPromptText: 'Type to search',
 			singleValueComponent: SingleValue,
 			value: undefined,
@@ -700,11 +702,25 @@ var Select = React.createClass({
 			});
 			return optionResult;
 		}, this);
-		return ops.length ? ops : (
-			<div className="Select-noresults">
-				{this.props.asyncOptions && !this.state.inputValue ? this.props.searchPromptText : this.props.noResultsText}
-			</div>
-		);
+
+		if (ops.length) {
+			return ops;
+		} else {
+			var noResultsText = (function () {
+				if (this.state.isLoading) {
+					return this.props.searchingText;
+				} else if (this.state.inputValue || !this.props.asyncOptions) {
+					return this.props.noResultsText;
+				} else {
+					return this.props.searchPromptText;
+				}
+			}.bind(this))();
+			return (
+				<div className="Select-noresults">
+					{noResultsText}
+				</div>
+			);
+		}
 	},
 
 	handleOptionLabelClick: function (value, event) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -706,17 +706,20 @@ var Select = React.createClass({
 		if (ops.length) {
 			return ops;
 		} else {
-			var noResultsText;
+			var noResultsText, promptClass;
 			if (this.state.isLoading) {
+				promptClass = 'Select-searching';
 				noResultsText = this.props.searchingText;
 			} else if (this.state.inputValue || !this.props.asyncOptions) {
+				promptClass = 'Select-noresults';
 				noResultsText = this.props.noResultsText;
 			} else {
+				promptClass = 'Select-search-prompt';
 				noResultsText = this.props.searchPromptText;
 			}
 
 			return (
-				<div className="Select-noresults">
+				<div className={promptClass}>
 					{noResultsText}
 				</div>
 			);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2414,7 +2414,7 @@ describe('Select', function() {
 				typeSearchText('abc');
 				expect(asyncOptions, 'was called');
 				expect(React.findDOMNode(instance), 'to contain elements matching', '.Select-loading');
-				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-searching',
 					'to have text', 'Testing async loading...');
 			});
 
@@ -2423,7 +2423,7 @@ describe('Select', function() {
 				clickArrowToOpen();
 				typeSearchText('abc');
 
-				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-searching',
 					'to have text', 'Testing async loading...');
 
 				asyncOptions.args[0][1](null, {
@@ -2438,8 +2438,9 @@ describe('Select', function() {
 				clickArrowToOpen();
 				typeSearchText('abc');
 
-				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-searching',
 					'to have text', 'Testing async loading...');
+				expect(React.findDOMNode(instance), 'to contain no elements matching', '.Select-noresults');
 
 				asyncOptions.args[0][1](null, {
 					options: []
@@ -2447,6 +2448,7 @@ describe('Select', function() {
 
 				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
 					'to have text', 'Testing No results found');
+				expect(React.findDOMNode(instance), 'to contain no elements matching', '.Select-searching');
 			});
 		});
 
@@ -2469,7 +2471,7 @@ describe('Select', function() {
 				var selectArrow = React.findDOMNode(instance).querySelector('.Select-arrow');
 				TestUtils.Simulate.mouseDown(selectArrow);
 
-				expect(React.findDOMNode(instance), 'queried for', '.Select-noresults',
+				expect(React.findDOMNode(instance), 'queried for', '.Select-search-prompt',
 					'to have items satisfying',
 					'to have text', 'Unit test prompt text');
 			});
@@ -2486,6 +2488,7 @@ describe('Select', function() {
 				typeSearchText('abc');
 				expect(asyncOptions, 'was called once');
 
+				expect(React.findDOMNode(instance), 'to contain no elements matching', '.Select-prompt');
 				expect(React.findDOMNode(instance), 'to contain no elements matching', '.Select-noresults');
 			});
 		});

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2389,6 +2389,67 @@ describe('Select', function() {
 			});
 		});
 
+		describe('searchingText', function () {
+
+			var asyncOptions;
+			var asyncOptionsCallback;
+
+			beforeEach(function () {
+
+				asyncOptions = sinon.spy();
+
+				instance = createControl({
+					asyncOptions: asyncOptions,
+					autoload: false,
+					searchingText: 'Testing async loading...',
+					noResultsText: 'Testing No results found',
+					searchPromptText: 'Testing enter search query'
+				});
+			});
+
+			it('uses the searchingText whilst the asyncOptions are loading', function () {
+
+				clickArrowToOpen();
+				expect(asyncOptions, 'was not called');
+				typeSearchText('abc');
+				expect(asyncOptions, 'was called');
+				expect(React.findDOMNode(instance), 'to contain elements matching', '.Select-loading');
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+					'to have text', 'Testing async loading...');
+			});
+
+			it('clears the searchingText when results arrive', function () {
+
+				clickArrowToOpen();
+				typeSearchText('abc');
+
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+					'to have text', 'Testing async loading...');
+
+				asyncOptions.args[0][1](null, {
+					options: [{ value: 'abc', label: 'Abc' }]
+				});
+
+				expect(React.findDOMNode(instance), 'to contain no elements matching', '.Select-noresults');
+			});
+
+			it('switches the searchingText to noResultsText when options arrive, but empty', function () {
+
+				clickArrowToOpen();
+				typeSearchText('abc');
+
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+					'to have text', 'Testing async loading...');
+
+				asyncOptions.args[0][1](null, {
+					options: []
+				});
+
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-noresults',
+					'to have text', 'Testing No results found');
+			});
+		});
+
 		describe('searchPromptText', function () {
 			var asyncOptions;
 


### PR DESCRIPTION
This is a rebased version of #141 from @johnomalley, with some tests added.

This makes sense to me, if you change `autoload` to `false` in the remote options example, and type `a`, you get `No results` and a spinner for half a second, then the results come in. With the patch, it shows `Searching...`, customisable by the `searchingText` prop.

I've left the code pretty much as is (I'm with @johnomalley on it, the `if` makes it more readable). I've removed the IIFE though, as there doesn't seem any advantageous, and creates another function scope and another bind - feel free to show where I'm missing something.

Tests for the new functionality added in a separate commit.