### PR TITLE
Styled options

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -20,11 +20,13 @@ var Option = React.createClass({
 		return obj.disabled ? (
 			<div className={optionClasses}>{renderedLabel}</div>
 		) : (
-			<div className={optionClasses} style={obj.style}
-				onMouseEnter={this.props.mouseEnter}
-				onMouseLeave={this.props.mouseLeave}
-				onMouseDown={this.props.mouseDown}
-				onClick={this.props.mouseDown}>
+			<div className={optionClasses}
+				 style={obj.style}
+				 onMouseEnter={this.props.mouseEnter}
+				 onMouseLeave={this.props.mouseLeave}
+				 onMouseDown={this.props.mouseDown}
+				 onClick={this.props.mouseDown}
+				 title={obj.title}>
 				{ obj.create ? this.props.addLabelText.replace('{label}', obj.label) : renderedLabel }
 			</div>
 		);

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
@@ -14,11 +15,12 @@ var Option = React.createClass({
 	render: function() {
 		var obj = this.props.option;
 		var renderedLabel = this.props.renderFunc(obj);
+		var optionClasses = classes(this.props.className, obj.className);
 
 		return obj.disabled ? (
-			<div className={this.props.className}>{renderedLabel}</div>
+			<div className={optionClasses}>{renderedLabel}</div>
 		) : (
-			<div className={this.props.className}
+			<div className={optionClasses} style={obj.style}
 				onMouseEnter={this.props.mouseEnter}
 				onMouseLeave={this.props.mouseLeave}
 				onMouseDown={this.props.mouseDown}

--- a/src/SingleValue.js
+++ b/src/SingleValue.js
@@ -10,7 +10,11 @@ var SingleValue = React.createClass({
 
 		var classNames = classes('Select-placeholder', this.props.value && this.props.value.className);
 		return (
-			<div className={classNames} style={this.props.value && this.props.value.style}>{this.props.placeholder}</div>
+			<div
+				className={classNames}
+				style={this.props.value && this.props.value.style}
+				title={this.props.value && this.props.value.title}
+				>{this.props.placeholder}</div>
 		);
 	}
 });

--- a/src/SingleValue.js
+++ b/src/SingleValue.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var classes = require('classnames');
 
 var SingleValue = React.createClass({
 	propTypes: {
@@ -6,8 +7,10 @@ var SingleValue = React.createClass({
 		value: React.PropTypes.object              // selected option
 	},
 	render: function() {
+
+		var classNames = classes('Select-placeholder', this.props.value && this.props.value.className);
 		return (
-			<div className="Select-placeholder">{this.props.placeholder}</div>
+			<div className={classNames} style={this.props.value && this.props.value.style}>{this.props.placeholder}</div>
 		);
 	}
 });

--- a/src/Value.js
+++ b/src/Value.js
@@ -35,6 +35,7 @@ var Value = React.createClass({
 				<div
 					className={classes('Select-value', this.props.option.className)}
 					style={this.props.option.style}
+					title={this.props.option.title}
 				>{label}</div>
 			);
 		}
@@ -46,7 +47,8 @@ var Value = React.createClass({
 					onMouseDown={this.blockEvent}
 					onTouchEnd={this.props.onOptionLabelClick}
 					onClick={this.props.onOptionLabelClick}
-					style={this.props.option.style}>
+					style={this.props.option.style}
+					title={this.props.option.title}>
 					{label}
 				</a>
 			);
@@ -54,7 +56,8 @@ var Value = React.createClass({
 
 		return (
 			<div className={classes('Select-item', this.props.option.className)}
-				 style={this.props.option.style}>
+				 style={this.props.option.style}
+				 title={this.props.option.title}>
 				<span className="Select-item-icon"
 					onMouseDown={this.blockEvent}
 					onClick={this.handleOnRemove}

--- a/src/Value.js
+++ b/src/Value.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var classes = require('classnames');
 
 var Value = React.createClass({
 
@@ -30,22 +31,30 @@ var Value = React.createClass({
 		}
 
 		if(!this.props.onRemove && !this.props.optionLabelClick) {
-			return <div className="Select-value">{label}</div>;
+			return (
+				<div
+					className={classes('Select-value', this.props.option.className)}
+					style={this.props.option.style}
+				>{label}</div>
+			);
 		}
 
 		if (this.props.optionLabelClick) {
+
 			label = (
-				<a className="Select-item-label__a"
+				<a className={classes('Select-item-label__a', this.props.option.className)}
 					onMouseDown={this.blockEvent}
 					onTouchEnd={this.props.onOptionLabelClick}
-					onClick={this.props.onOptionLabelClick}>
+					onClick={this.props.onOptionLabelClick}
+					style={this.props.option.style}>
 					{label}
 				</a>
 			);
 		}
 
 		return (
-			<div className="Select-item">
+			<div className={classes('Select-item', this.props.option.className)}
+				 style={this.props.option.style}>
 				<span className="Select-item-icon"
 					onMouseDown={this.blockEvent}
 					onClick={this.handleOnRemove}

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -907,6 +907,40 @@ describe('Select', function() {
 		});
 	});
 
+	describe('with styled options', function () {
+
+		beforeEach(function () {
+
+			options = [
+				{ value: 'one', label: 'One', className: 'extra-one' },
+				{ value: 'two', label: 'Two', className: 'extra-two' },
+				{ value: 'three', label: 'Three', style: { fontSize: 25 } }
+			];
+
+			instance = createControl({
+				options: options
+			});
+		});
+
+		it('uses the given className for an option', function () {
+
+			clickArrowToOpen();
+			expect(React.findDOMNode(instance).querySelectorAll('.Select-option')[0], 'to have attributes',
+				{
+					class: 'extra-one'
+				});
+		});
+
+		it('uses the given style for an option', function () {
+
+			clickArrowToOpen();
+			expect(React.findDOMNode(instance).querySelectorAll('.Select-option')[2], 'to have attributes',
+				{
+					style: { 'font-size': '25px' }
+				});
+		});
+	});
+
 	describe('with allowCreate=true', function () {
 
 		beforeEach(function () {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -912,8 +912,8 @@ describe('Select', function() {
 		beforeEach(function () {
 
 			options = [
-				{ value: 'one', label: 'One', className: 'extra-one' },
-				{ value: 'two', label: 'Two', className: 'extra-two' },
+				{ value: 'one', label: 'One', className: 'extra-one', title: 'Eins' },
+				{ value: 'two', label: 'Two', className: 'extra-two', title: 'Zwei' },
 				{ value: 'three', label: 'Three', style: { fontSize: 25 } }
 			];
 
@@ -940,6 +940,15 @@ describe('Select', function() {
 				});
 		});
 
+		it('uses the given title for an option', function () {
+
+			clickArrowToOpen();
+			expect(React.findDOMNode(instance).querySelectorAll('.Select-option')[1], 'to have attributes',
+				{
+					title: 'Zwei'
+				});
+		});
+
 		it('uses the given className for a single selection', function () {
 
 			typeSearchText('tw');
@@ -959,6 +968,16 @@ describe('Select', function() {
 					style: {
 						'font-size': '25px'
 					}
+				});
+		});
+
+		it('uses the given title for a single selection', function () {
+
+			typeSearchText('tw');
+			pressEnterToAccept();
+			expect(React.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
+				'to have attributes', {
+					title: 'Zwei'
 				});
 		});
 
@@ -989,6 +1008,16 @@ describe('Select', function() {
 						style: {
 							'font-size': '25px'
 						}
+					});
+			});
+
+			it('uses the given title for a selected value', function () {
+
+				typeSearchText('tw');
+				pressEnterToAccept();
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-item',
+					'to have attributes', {
+						title: 'Zwei'
 					});
 			});
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -917,7 +917,7 @@ describe('Select', function() {
 				{ value: 'three', label: 'Three', style: { fontSize: 25 } }
 			];
 
-			instance = createControl({
+			wrapper = createControlWithWrapper({
 				options: options
 			});
 		});
@@ -939,6 +939,61 @@ describe('Select', function() {
 					style: { 'font-size': '25px' }
 				});
 		});
+
+		it('uses the given className for a single selection', function () {
+
+			typeSearchText('tw');
+			pressEnterToAccept();
+			expect(React.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
+				'to have attributes', {
+					class: 'extra-two'
+				});
+		});
+
+		it('uses the given style for a single selection', function () {
+
+			typeSearchText('th');
+			pressEnterToAccept();
+			expect(React.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
+				'to have attributes', {
+					style: {
+						'font-size': '25px'
+					}
+				});
+		});
+
+		describe('with multi', function () {
+
+			beforeEach(function () {
+
+				wrapper.setPropsForChild({ multi: true });
+			});
+
+
+			it('uses the given className for a selected value', function () {
+
+				typeSearchText('tw');
+				pressEnterToAccept();
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-item',
+					'to have attributes', {
+						class: 'extra-two'
+					});
+			});
+
+			it('uses the given style for a selected value', function () {
+
+				typeSearchText('th');
+				pressEnterToAccept();
+				expect(React.findDOMNode(instance), 'queried for first', '.Select-item',
+					'to have attributes', {
+						style: {
+							'font-size': '25px'
+						}
+					});
+			});
+
+		});
+
 	});
 
 	describe('with allowCreate=true', function () {


### PR DESCRIPTION
This is to address #290, adding `className` and `style` support to the options objects.

Obviously, you can now do this with the renderers or custom components, however, I wanted to have the option that the default components support it.  I'm entirely agnostic about this - on the one hand it would be better to keep stuff like this up to custom renderers, on the other hand, it'd be nice that the defaults do some basics like this.

I've added `title` support too, to address #273 

Just to reiterate, I really am agnostic about this - this was a quick fix that if thrown away, really doesn't matter. I'm just trying to clear some older issues.  Either, this is merged and #290 and #273 can be closed, or this is not merged, and #290 and #273 can be closed because it can be done via the custom component props.  - Either way, 2 issues down :smile: