### PR TITLE
Include built CSS file in bower.json's main block.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "react-select",
-  "main": "dist/react-select.min.js",
+  "main": [
+    "dist/react-select.min.js",
+    "dist/default.css"
+  ],
   "version": "0.6.4",
   "homepage": "https://github.com/JedWatson/react-select",
   "authors": [


### PR DESCRIPTION
The `main` field is used by build tools to bring in the right resources; as it stands the default CSS is not included and leads to all kinds of mangled UI if your bower + build system setup depends on files being listed in `main`.