### PR TITLE
Add or clear current input value on blur and allow auto select on tab (for new values)

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -312,6 +312,19 @@ var Select = React.createClass({
 		this.setValue(this.state.values.concat(value));
 	},
 
+	addOrClearInputValue: function() {
+		var inputValue = this.state.inputValue;
+		if((inputValue || '').length === 0) {
+			return;
+		}
+		if (this.props.allowCreate) {
+			this.setValue(this.state.values.concat(inputValue), false);
+		}
+		else {
+			this.setState({ inputValue: null });
+		}
+	},
+
 	popValue: function() {
 		this.setValue(this.state.values.slice(0, this.state.values.length - 1));
 	},
@@ -412,6 +425,7 @@ var Select = React.createClass({
 	},
 
 	handleInputBlur: function(event) {
+		this.addOrClearInputValue();
 		this._blurTimeout = setTimeout(() => {
 			if (this._focusAfterUpdate) return;
 			this.setState({
@@ -433,7 +447,7 @@ var Select = React.createClass({
 				}
 			return;
 			case 9: // tab
-				if (event.shiftKey || !this.state.isOpen || !this.state.focusedOption) {
+				if (!this.state.isOpen) {
 					return;
 				}
 				this.selectFocusedOption();

--- a/src/Select.js
+++ b/src/Select.js
@@ -675,6 +675,13 @@ var Select = React.createClass({
 		}
 	},
 
+	inputValueExists : function() {
+		var matches = this.state.filteredOptions.filter(function(option) {
+			return String(option.value) === this.state.inputValue;
+		}, this);
+		return matches.length > 0;
+	},
+
 	buildMenu: function() {
 		var focusedValue = this.state.focusedOption ? this.state.focusedOption.value : null;
 		var renderLabel = this.props.optionRenderer || function(op) {
@@ -685,7 +692,7 @@ var Select = React.createClass({
 		}
 		// Add the current value to the filtered options in last resort
 		var options = this.state.filteredOptions;
-		if (this.props.allowCreate && this.state.inputValue.trim()) {
+		if (this.props.allowCreate && this.state.inputValue.trim() && !this.inputValueExists()) {
 			var inputValue = this.state.inputValue;
 			options = options.slice();
 			var newOption = this.props.newOptionCreator ? this.props.newOptionCreator(inputValue) : {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -902,7 +902,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')
@@ -915,7 +915,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')
@@ -928,7 +928,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')
@@ -1157,14 +1157,14 @@ describe('Select', function() {
 				'to have text', 'Add test to values?');
 		});
 
-		it('does not display the option label when an existing value is entered', function () {
+		it('does not display add option when an existing value is entered', function () {
 
 			typeSearchText('zzzzz');
 
 			expect(React.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option'),
 				'to have length', 1);
 			expect(React.findDOMNode(instance), 'queried for first', '.Select-menu .Select-option',
-				'to have text', 'Add zzzzz to values?');
+				'to have text', 'test value');
 		});
 
 		it('renders the existing option and an add option when an existing display label is entered', function () {


### PR DESCRIPTION
When new values are allowed:
1. On blur, add the current input value, so when the user clicks away, it will be automatically added.
2. On tab key press, add the current input value.

When new values are NOT allowed:
1. On blur, clear the current input value.
