### PR TITLE
Bugfix: prevents value splitting on non-multi-value select

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -265,7 +265,11 @@ var Select = React.createClass({
 	initValuesArray: function(values, options) {
 		if (!Array.isArray(values)) {
 			if (typeof values === 'string') {
-				values = values === '' ? [] : values.split(this.props.delimiter);
+				values = values === ''
+					? []
+					: this.props.multi 
+						? values.split(this.props.delimiter)
+						: [ values ];
 			} else {
 				values = values !== undefined && values !== null ? [values] : [];
 			}


### PR DESCRIPTION
Scenario:
By default, the delimiter is set to ','.
When a value contains ','. Even if props.multi is set to false/undefined, it was splitting on ','.

Solution:
Just check in a guard condition on props.multi before splitting.

cc @JedWatson 

Fixes #429 

