### PR TITLE
prevent default behavior of key down

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -425,6 +425,7 @@ var Select = React.createClass({
 	},
 
 	handleKeyDown: function(event) {
+		event.preventDefault();
 		if (this.props.disabled) return;
 		switch (event.keyCode) {
 			case 8: // backspace


### PR DESCRIPTION
Details:

- Preventing backspace navigating to previous page

cc: @JedWatson 
