### PR TITLE
Add style key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.8",
   "description": "A Select control built with and for ReactJS",
   "main": "lib/Select.js",
+  "style": "dist/default.css",
   "author": "Jed Watson",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Enables usage of npm-based css imports from libraries such as [npm-css](https://github.com/defunctzombie/npm-css), [npm-less](https://github.com/Raynos/npm-less), [rework-css](https://github.com/reworkcss/rework-npm), e.g.

```
import "react-select";
```

thoughts? @JedWatson 