### PR TITLE
only prevent default if there is no input

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -435,9 +435,10 @@ var Select = React.createClass({
 		switch (event.keyCode) {
 			case 8: // backspace
 				if (!this.state.inputValue && this.props.backspaceRemoves) {
+					event.preventDefault();
 					this.popValue();
 				}
-			break;
+			return;
 			case 9: // tab
 				if (event.shiftKey || !this.state.isOpen || !this.state.focusedOption) {
 					return;


### PR DESCRIPTION
details:

- If there's an input value, break will continue the flow and eventually call preventDefault, which will prevent the removal of the input characters
- Therefore, only prevent default if there is no input value, and so it will not return to previous screen

cc: @JedWatson 

NB: This should be the final fix. Tested and run.