### PR TITLE
Fixed closing of dropdown for multi select

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -300,7 +300,7 @@ var Select = React.createClass({
 			this._focusAfterUpdate = true;
 		}
 		var newState = this.getStateFromValue(value);
-		newState.isOpen = false;
+		(!this.props.multi) && newState.isOpen = false;
 		this.fireChangeEvent(newState);
 		this.setState(newState);
 	},


### PR DESCRIPTION
For multi-select, the menu should remain open for the user to select more options. Closing it after every selection counteracts the intuition to select multiple options.
