### PR TITLE
Fix compile error.

### DIFF
--- a/less/spinner.less
+++ b/less/spinner.less
@@ -7,7 +7,7 @@
 	.square(@size);
 	box-sizing: border-box;
 	border-radius: 50%;
-	border: floor(@size / 8) solid @orbit;
+	border: floor((@size / 8)) solid @orbit;
 	border-right-color: @satellite;
 	display: inline-block;
 	position: relative;


### PR DESCRIPTION
Latest build causes LESS compile error.

ERROR in ./~/css-loader!./~/less-loader?strictMath&noIeCompat!./app/app.less
Module build failed: error evaluating function `floor`: argument must be a number
 @ C:\...\node_modules\react-select\less\control.less (line 137, column 1)
 near lines:
   .Select-loading {
        .Select-spinner(16, @select-input-border-color, @select-text-color);
        margin-top: -8px;
 @ ./app/app.less 4:14-136

Based on the information in this Stack Overflow question http://stackoverflow.com/questions/21228897/how-to-fix-less-error-while-compiling-bootstrap, I was able to fix the error by using double parentheses. The solution seems odd, but it works.