### PR TITLE
Implement rolling delay before loadAsyncOptions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	clearable 			|	bool		|	should it be possible to reset value
 	clearAllText 		|	string		|	title for the "clear" control when multi: true
 	clearValueText 		|	string		|	title for the "clear" control
+	delayAsyncMs 			|	number		|	time delay before querying after an input change
 	delimiter 			|	string		|	delimiter to use to join multiple values
 	disableCache 		|	bool		|	disables the options cache for asyncOptions
 	disabled 			|	bool		|	whether the Select is disabled or not

--- a/src/Select.js
+++ b/src/Select.js
@@ -526,13 +526,13 @@ var Select = React.createClass({
 
 			this.setState({
 				isLoading: true,
-				inputValue: event.target.value
+				inputValue: this._optionsFilterString
 			});
 		} else {
 			var filteredOptions = this.filterOptions(this.state.options);
 			this.setState({
 				isOpen: true,
-				inputValue: event.target.value,
+				inputValue: this._optionsFilterString,
 				filteredOptions: filteredOptions,
 				focusedOption: this._getNewFocusedOption(filteredOptions)
 			}, this._bindCloseMenuIfClickedOutside);

--- a/src/Select.js
+++ b/src/Select.js
@@ -26,6 +26,7 @@ var Select = React.createClass({
 		clearAllText: React.PropTypes.string,      // title for the "clear" control when multi: true
 		clearValueText: React.PropTypes.string,    // title for the "clear" control
 		clearable: React.PropTypes.bool,           // should it be possible to reset value
+		delayAsyncMs: React.PropTypes.number,      // time delay before querying after a keyup
 		delimiter: React.PropTypes.string,         // delimiter to use to join multiple values
 		disabled: React.PropTypes.bool,            // whether the Select is disabled or not
 		filterOption: React.PropTypes.func,        // method to filter a single option: function(option, filterString)
@@ -68,6 +69,7 @@ var Select = React.createClass({
 			clearAllText: 'Clear all',
 			clearValueText: 'Clear value',
 			clearable: true,
+			delayAsyncMs: 0,
 			delimiter: ',',
 			disabled: false,
 			ignoreCase: true,
@@ -103,6 +105,7 @@ var Select = React.createClass({
 			 * - placeholder
 			 * - focusedOption
 			*/
+			inputTimer: undefined,
 			isFocused: false,
 			isLoading: false,
 			isOpen: false,
@@ -498,14 +501,33 @@ var Select = React.createClass({
 		}
 
 		if (this.props.asyncOptions) {
+			var callAsyncLoad = function() {
+				this.loadAsyncOptions(event.target.value, {
+					isLoading: false,
+					isOpen: true
+				}, this._bindCloseMenuIfClickedOutside);
+			}.bind(this);
+
+			if (this.props.delayAsyncMs) {
+				if (this.state.inputTimer) {
+					clearTimeout(this.state.inputTimer);
+				}
+
+				var wait = setTimeout(function() {
+					callAsyncLoad();
+				}, this.props.delayAsyncMs);
+
+				this.setState({
+					inputTimer: wait
+				});
+			} else {
+				callAsyncLoad();
+			}
+
 			this.setState({
 				isLoading: true,
 				inputValue: event.target.value
 			});
-			this.loadAsyncOptions(event.target.value, {
-				isLoading: false,
-				isOpen: true
-			}, this._bindCloseMenuIfClickedOutside);
 		} else {
 			var filteredOptions = this.filterOptions(this.state.options);
 			this.setState({

--- a/src/Select.js
+++ b/src/Select.js
@@ -26,7 +26,7 @@ var Select = React.createClass({
 		clearAllText: React.PropTypes.string,      // title for the "clear" control when multi: true
 		clearValueText: React.PropTypes.string,    // title for the "clear" control
 		clearable: React.PropTypes.bool,           // should it be possible to reset value
-		delayAsyncMs: React.PropTypes.number,      // time delay before querying after a keyup
+		delayAsyncMs: React.PropTypes.number,      // time delay before querying after an input change
 		delimiter: React.PropTypes.string,         // delimiter to use to join multiple values
 		disabled: React.PropTypes.bool,            // whether the Select is disabled or not
 		filterOption: React.PropTypes.func,        // method to filter a single option: function(option, filterString)

--- a/src/Select.js
+++ b/src/Select.js
@@ -497,12 +497,12 @@ var Select = React.createClass({
 		this._optionsFilterString = event.target.value;
 
 		if (this.props.onInputChange) {
-			this.props.onInputChange(event.target.value);
+			this.props.onInputChange(this._optionsFilterString);
 		}
 
 		if (this.props.asyncOptions) {
 			var callAsyncLoad = function() {
-				this.loadAsyncOptions(event.target.value, {
+				this.loadAsyncOptions(this._optionsFilterString, {
 					isLoading: false,
 					isOpen: true
 				}, this._bindCloseMenuIfClickedOutside);


### PR DESCRIPTION
Addresses https://github.com/JedWatson/react-select/issues/459

Adds the ability to pass in a timeout prop. react-select will now wait `delayAsyncMs` milliseconds before calling loadAsyncOptions, and keep resetting the delay on every new input change until `delayAsyncMs` milliseconds passes without an input change.

Needs tests. Sorry, didn't have time to figure that out yet, but hopefully this will be useful for somebody!
