### PR TITLE
#392 - Prevent autoload of asyncOptions when value changes

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -177,7 +177,7 @@ var Select = React.createClass({
 					newProps.placeholder)
 				);
 			};
-			if (this.props.asyncOptions) {
+			if (this.props.asyncOptions && this.props.autoload) {
 				this.loadAsyncOptions(newProps.value, {}, setState);
 			} else {
 				setState();


### PR DESCRIPTION
When the react-select component is fed a value prop on initial render (consider a parent component's getInitialState feeding in an empty string), and then a call to some backend service is launched and changes the value in the parent state to be an option object - the asyncOptions function is fired off despite the fact that options have not been requested.  Traced the issue to componentWillReceiveProps().  When the props change on react-select, it should probably only fire asyncOptions if the autoload prop is true.