### PR TITLE
[WIP] option groups #59

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -5,6 +5,7 @@ import Select from 'react-select';
 
 import CustomRenderField from './components/CustomRenderField';
 import MultiSelectField from './components/MultiSelectField';
+import GroupedOptionsField from './components/GroupedOptionsField';
 import RemoteSelectField from './components/RemoteSelectField';
 import SelectedValuesField from './components/SelectedValuesField';
 import StatesField from './components/StatesField';
@@ -40,6 +41,7 @@ React.render(
 		<CustomRenderField label="Custom render options/values" />
 		<CustomRenderField label="Custom render options/values (multi)" multi delimiter="," />
 		<RemoteSelectField label="Remote Options" hint='Type anything in the remote example to asynchronously load options. Valid alternative results are "A", "AA", and "AB"' />
+    <GroupedOptionsField label="Grouping Options" />
 	</div>,
 	document.getElementById('example')
 );

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -37,11 +37,11 @@ React.render(
 		<SelectedValuesField label="Clickable labels (labels as links)" options={FLAVOURS} hint="Open the console to see click behaviour (data/event)" />
 		<SelectedValuesField label="Disabled option" options={FLAVOURS_WITH_DISABLED_OPTION} hint="You savage! Caramel is the best..." />
 		<DisabledUpsellOptions label="Disable option with an upsell link"/>
+		<GroupedOptionsField label="Option Groups" />
 		<SelectedValuesField label="Option Creation (tags mode)" options={FLAVOURS} allowCreate hint="Enter a value that's not in the list, then hit enter" />
 		<CustomRenderField label="Custom render options/values" />
 		<CustomRenderField label="Custom render options/values (multi)" multi delimiter="," />
 		<RemoteSelectField label="Remote Options" hint='Type anything in the remote example to asynchronously load options. Valid alternative results are "A", "AA", and "AB"' />
-    <GroupedOptionsField label="Grouping Options" />
 	</div>,
 	document.getElementById('example')
 );

--- a/examples/src/components/GroupedOptionsField.js
+++ b/examples/src/components/GroupedOptionsField.js
@@ -6,6 +6,9 @@ function logChange() {
 }
 
 var ops = [{
+  label: 'Black',
+  value: 'black',
+}, {
   label: 'Primary Colors',
   options: [
     { label: 'Yellow', value: 'yellow' },
@@ -19,6 +22,9 @@ var ops = [{
     { label: 'Violet', value: 'violet' },
     { label: 'Green', value: 'green' }
   ]
+}, {
+  label: 'White',
+  value: 'white',
 }];
 
 var GroupedOptionsField = React.createClass({
@@ -34,8 +40,9 @@ var GroupedOptionsField = React.createClass({
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
 				<Select
-					placeholder="Select a color"
+          open={true}
 					options={ops}
+					placeholder="Select a color"
 					onChange={logChange} />
 			</div>
 		);

--- a/examples/src/components/GroupedOptionsField.js
+++ b/examples/src/components/GroupedOptionsField.js
@@ -6,44 +6,44 @@ function logChange() {
 }
 
 var ops = [{
-  label: 'Black',
-  value: 'black',
+	label: 'Black',
+	value: 'black',
 }, {
-  label: 'Primary Colors',
-  options: [{
-    label: 'Yellow',
-    value: 'yellow'
-  }, {
-    label: 'Red',
-    value: 'red'
-  }, {
-    label: 'Blue',
-    value: 'blue'
-  }]
+	label: 'Primary Colors',
+	options: [{
+		label: 'Yellow',
+		value: 'yellow'
+	}, {
+		label: 'Red',
+		value: 'red'
+	}, {
+		label: 'Blue',
+		value: 'blue'
+	}]
 }, {
-  label: 'Secondary Colors',
-  options: [{
-    label: 'Orange',
-    value: 'orange'
-  }, {
-    label: 'Purple',
-    options: [{
-      label: 'Light Purple',
-      value: 'light_purple'
-    }, {
-      label: 'Medium Purple',
-      value: 'medium_purple'
-    }, {
-      label: 'Dark Purple',
-      value: 'dark_purple'
-    }]
-  }, {
-    label: 'Green',
-    value: 'green'
-  }]
+	label: 'Secondary Colors',
+	options: [{
+		label: 'Orange',
+		value: 'orange'
+	}, {
+		label: 'Purple',
+		options: [{
+			label: 'Light Purple',
+			value: 'light_purple'
+		}, {
+			label: 'Medium Purple',
+			value: 'medium_purple'
+		}, {
+			label: 'Dark Purple',
+			value: 'dark_purple'
+		}]
+	}, {
+		label: 'Green',
+		value: 'green'
+	}]
 }, {
-  label: 'White',
-  value: 'white',
+	label: 'White',
+	value: 'white',
 }];
 
 var GroupedOptionsField = React.createClass({

--- a/examples/src/components/GroupedOptionsField.js
+++ b/examples/src/components/GroupedOptionsField.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import Select from 'react-select';
+
+function logChange() {
+	console.log.apply(console, [].concat(['Select value changed:'], Array.prototype.slice.apply(arguments)));
+}
+
+var ops = [{
+  label: 'Primary Colors',
+  options: [
+    { label: 'Yellow', value: 'yellow' },
+    { label: 'Red', value: 'red' },
+    { label: 'Blue', value: 'blue' }
+  ]
+}, {
+  label: 'Secondary Colors',
+  options: [
+    { label: 'Orange', value: 'orange' },
+    { label: 'Violet', value: 'violet' },
+    { label: 'Green', value: 'green' }
+  ]
+}];
+
+var GroupedOptionsField = React.createClass({
+	displayName: 'GroupedOptionsField',
+	propTypes: {
+		delimiter: React.PropTypes.string,
+		label: React.PropTypes.string,
+		multi: React.PropTypes.bool,
+	},
+
+	render () {
+		return (
+			<div className="section">
+				<h3 className="section-heading">{this.props.label}</h3>
+				<Select
+					placeholder="Select a color"
+					options={ops}
+					onChange={logChange} />
+			</div>
+		);
+	}
+});
+
+module.exports = GroupedOptionsField;
+

--- a/examples/src/components/GroupedOptionsField.js
+++ b/examples/src/components/GroupedOptionsField.js
@@ -10,18 +10,37 @@ var ops = [{
   value: 'black',
 }, {
   label: 'Primary Colors',
-  options: [
-    { label: 'Yellow', value: 'yellow' },
-    { label: 'Red', value: 'red' },
-    { label: 'Blue', value: 'blue' }
-  ]
+  options: [{
+    label: 'Yellow',
+    value: 'yellow'
+  }, {
+    label: 'Red',
+    value: 'red'
+  }, {
+    label: 'Blue',
+    value: 'blue'
+  }]
 }, {
   label: 'Secondary Colors',
-  options: [
-    { label: 'Orange', value: 'orange' },
-    { label: 'Violet', value: 'violet' },
-    { label: 'Green', value: 'green' }
-  ]
+  options: [{
+    label: 'Orange',
+    value: 'orange'
+  }, {
+    label: 'Purple',
+    options: [{
+      label: 'Light Purple',
+      value: 'light_purple'
+    }, {
+      label: 'Medium Purple',
+      value: 'medium_purple'
+    }, {
+      label: 'Dark Purple',
+      value: 'dark_purple'
+    }]
+  }, {
+    label: 'Green',
+    value: 'green'
+  }]
 }, {
   label: 'White',
   value: 'white',
@@ -40,7 +59,6 @@ var GroupedOptionsField = React.createClass({
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
 				<Select
-          open={true}
 					options={ops}
 					placeholder="Select a color"
 					onChange={logChange} />

--- a/less/menu.less
+++ b/less/menu.less
@@ -61,13 +61,13 @@
 
 .Select-optionGroup-label ~ .Select-option,
 .Select-optionGroup-label ~ .Select-optionGroup {
-  margin-left: @select-padding-horizontal;
+	margin-left: @select-padding-horizontal;
 }
 
 .Select-optionGroup-label {
 	box-sizing: border-box;
 	color: @select-option-color;
-  cursor: default;
+	cursor: default;
 	display: block;
 	padding: @select-padding-vertical @select-padding-horizontal;
 }

--- a/less/menu.less
+++ b/less/menu.less
@@ -57,9 +57,20 @@
 		color: @select-option-disabled-color;
 		cursor: not-allowed;
 	}
-
 }
 
+.Select-optionGroup-label ~ .Select-option,
+.Select-optionGroup-label ~ .Select-optionGroup {
+  margin-left: @select-padding-horizontal;
+}
+
+.Select-optionGroup-label {
+	box-sizing: border-box;
+	color: @select-option-color;
+  cursor: default;
+	display: block;
+	padding: @select-padding-vertical @select-padding-horizontal;
+}
 
 // no results
 

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -28,12 +28,10 @@ var Option = React.createClass({
 	render: function() {
 		var obj = this.props.optionGroup;
 		var renderedLabel = this.props.renderFunc(obj);
-		var optionClasses = classes(this.props.className, obj.className);
-
 		return (
-      <div>
+      <div className={classes(this.props.className, 'Select-optionGroup')}>
         <div
-          className={optionClasses}
+          className="Select-optionGroup-label"
           onMouseDown={this.blockEvent}
           onClick={this.blockEvent}>
           <strong>{renderedLabel}</strong>

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -3,6 +3,7 @@ var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
+    children: React.PropTypes.any,
 		className: React.PropTypes.string,
 		optionGroup: React.PropTypes.shape({
 			label: React.PropTypes.string.isRequired,
@@ -30,11 +31,15 @@ var Option = React.createClass({
 		var optionClasses = classes(this.props.className, obj.className);
 
 		return (
-			<div className={optionClasses}
-				onMouseDown={this.blockEvent}
-				onClick={this.blockEvent}>
-				{renderedLabel}
-			</div>
+      <div>
+        <div
+          className={optionClasses}
+          onMouseDown={this.blockEvent}
+          onClick={this.blockEvent}>
+          <strong>{renderedLabel}</strong>
+        </div>
+        {this.props.children}
+      </div>
 		);
 	}
 });

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -3,7 +3,7 @@ var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
-		className: PropTypes.string,
+		className: React.PropTypes.string,
 		optionGroup: React.PropTypes.shape({
 			label: React.PropTypes.string.isRequired,
 			options: React.PropTypes.array.isRequired,

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -3,7 +3,7 @@ var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
-    children: React.PropTypes.any,
+		children: React.PropTypes.any,
 		className: React.PropTypes.string,
 		optionGroup: React.PropTypes.shape({
 			label: React.PropTypes.string.isRequired,
@@ -29,15 +29,15 @@ var Option = React.createClass({
 		var obj = this.props.optionGroup;
 		var renderedLabel = this.props.renderFunc(obj);
 		return (
-      <div className={classes(this.props.className, 'Select-optionGroup')}>
-        <div
-          className="Select-optionGroup-label"
-          onMouseDown={this.blockEvent}
-          onClick={this.blockEvent}>
-          <strong>{renderedLabel}</strong>
-        </div>
-        {this.props.children}
-      </div>
+			<div className={classes(this.props.className, 'Select-optionGroup')}>
+				<div
+					className="Select-optionGroup-label"
+					onMouseDown={this.blockEvent}
+					onClick={this.blockEvent}>
+					<strong>{renderedLabel}</strong>
+				</div>
+				{this.props.children}
+			</div>
 		);
 	}
 });

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -1,0 +1,41 @@
+var React = require('react');
+var classes = require('classnames');
+
+var Option = React.createClass({
+	propTypes: {
+		optionGroup: React.PropTypes.shape({
+      label: React.PropTypes.string.isRequired,
+      options: React.PropTypes.array.isRequired,
+    }).isRequired,     // object that is base for that option
+		renderFunc: React.PropTypes.func               // method passed to ReactSelect component to render label text
+	},
+
+	blockEvent: function(event) {
+		event.preventDefault();
+		if ((event.target.tagName !== 'A') || !('href' in event.target)) {
+			return;
+		}
+
+		if (event.target.target) {
+			window.open(event.target.href);
+		} else {
+			window.location.href = event.target.href;
+		}
+	},
+
+	render: function() {
+		var obj = this.props.optionGroup;
+		var renderedLabel = this.props.renderFunc(obj);
+		var optionClasses = classes(this.props.className, obj.className);
+
+		return (
+			<div className={optionClasses}
+				onMouseDown={this.blockEvent}
+				onClick={this.blockEvent}>
+				{renderedLabel}
+			</div>
+		);
+	}
+});
+
+module.exports = Option;

--- a/src/OptionGroup.js
+++ b/src/OptionGroup.js
@@ -3,10 +3,11 @@ var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
+		className: PropTypes.string,
 		optionGroup: React.PropTypes.shape({
-      label: React.PropTypes.string.isRequired,
-      options: React.PropTypes.array.isRequired,
-    }).isRequired,     // object that is base for that option
+			label: React.PropTypes.string.isRequired,
+			options: React.PropTypes.array.isRequired,
+		}).isRequired,     // object that is base for that option
 		renderFunc: React.PropTypes.func               // method passed to ReactSelect component to render label text
 	},
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -658,7 +658,7 @@ var Select = React.createClass({
 	focusAdjacentOption: function(dir) {
 		this._focusedOptionReveal = true;
 		var ops = this.state.filteredOptions.filter(function(op) {
-			return !op.disabled;
+			return !op.disabled && !isGroup(op);
 		});
 		if (!this.state.isOpen) {
 			this.setState({

--- a/src/Select.js
+++ b/src/Select.js
@@ -611,6 +611,7 @@ var Select = React.createClass({
 			return this.props.filterOptions.call(this, options, filterValue, exclude);
 		} else {
 			var filterOption = function(op) {
+        if (isGroup(op)) return op.options.some(filterOption, this);
 				if (this.props.multi && exclude.indexOf(op.value) > -1) return false;
 				if (this.props.filterOption) return this.props.filterOption.call(this, op, filterValue);
 				var valueTest = String(op.value), labelTest = String(op.label);

--- a/src/Select.js
+++ b/src/Select.js
@@ -13,27 +13,27 @@ var OptionGroup = require('./OptionGroup');
 var requestId = 0;
 
 function defaultLabelRenderer(op) {
-  return op.label;
+	return op.label;
 }
 
 function flattenOptions(options) {
-  if (!options) {
-    return options;
-  }
-  var flatten = function(flat, opt) {
-    if (Array.isArray(opt.options)) {
-      return flat.concat(
-        opt,
-        opt.options.reduce(flatten, [])
-      );
-    }
-    return flat.concat(opt);
-  };
-  return options.reduce(flatten, []);
+	if (!options) {
+		return options;
+	}
+	var flatten = function(flat, opt) {
+		if (Array.isArray(opt.options)) {
+			return flat.concat(
+				opt,
+				opt.options.reduce(flatten, [])
+			);
+		}
+		return flat.concat(opt);
+	};
+	return options.reduce(flatten, []);
 }
 
 function isGroup(op) {
-  return op && Array.isArray(op.options);
+	return op && Array.isArray(op.options);
 }
 
 var Select = React.createClass({
@@ -191,7 +191,7 @@ var Select = React.createClass({
 		var optionsChanged = false;
 		if (JSON.stringify(newProps.options) !== JSON.stringify(this.props.options)) {
 			optionsChanged = true;
-      var flatOptions = flattenOptions(newProps.options);
+			var flatOptions = flattenOptions(newProps.options);
 			this.setState({
 				options: flatOptions,
 				filteredOptions: this.filterOptions(flatOptions)
@@ -720,10 +720,10 @@ var Select = React.createClass({
 		}
 		var ops = Object.keys(options).map(function(key) {
 			var op = options[key];
-      if (isGroup(op)) {
-        return this.renderOptionGroup(op);
-      }
-      return this.renderOption(op, focusedValue);
+			if (isGroup(op)) {
+				return this.renderOptionGroup(op);
+			}
+			return this.renderOption(op, focusedValue);
 		}, this);
 
 		if (ops.length) {
@@ -749,44 +749,44 @@ var Select = React.createClass({
 		}
 	},
 
-  renderOption(op, focusedValue) {
+	renderOption(op, focusedValue) {
 		var renderLabel = this.props.optionRenderer || defaultLabelRenderer;
-    var isSelected = this.state.value === op.value;
-    var isFocused = focusedValue === op.value;
-    var optionClass = classes({
-      'Select-option': true,
-      'is-selected': isSelected,
-      'is-focused': isFocused,
-      'is-disabled': op.disabled
-    });
-    var ref = isFocused ? 'focused' : null;
-    var mouseEnter = this.focusOption.bind(this, op);
-    var mouseLeave = this.unfocusOption.bind(this, op);
-    var mouseDown = this.selectValue.bind(this, op);
-    return React.createElement(this.props.optionComponent, {
-      key: 'option-' + op.value,
-      className: optionClass,
-      renderFunc: renderLabel,
-      mouseEnter: mouseEnter,
-      mouseLeave: mouseLeave,
-      mouseDown: mouseDown,
-      click: mouseDown,
-      addLabelText: this.props.addLabelText,
-      option: op,
-      ref: ref
-    });
-  },
+		var isSelected = this.state.value === op.value;
+		var isFocused = focusedValue === op.value;
+		var optionClass = classes({
+			'Select-option': true,
+			'is-selected': isSelected,
+			'is-focused': isFocused,
+			'is-disabled': op.disabled
+		});
+		var ref = isFocused ? 'focused' : null;
+		var mouseEnter = this.focusOption.bind(this, op);
+		var mouseLeave = this.unfocusOption.bind(this, op);
+		var mouseDown = this.selectValue.bind(this, op);
+		return React.createElement(this.props.optionComponent, {
+			key: 'option-' + op.value,
+			className: optionClass,
+			renderFunc: renderLabel,
+			mouseEnter: mouseEnter,
+			mouseLeave: mouseLeave,
+			mouseDown: mouseDown,
+			click: mouseDown,
+			addLabelText: this.props.addLabelText,
+			option: op,
+			ref: ref
+		});
+	},
 
-  renderOptionGroup(group) {
+	renderOptionGroup(group) {
 		var renderLabel = this.props.optionGroupRenderer || defaultLabelRenderer;
-    var optionClass = classes('Select-option', 'is-disabled');
-    return React.createElement(this.props.optionGroupComponent, {
-      key: 'optionGroup-' + group.label,
-      className: optionClass,
-      renderFunc: renderLabel,
-      optionGroup: group
-    });
-  },
+		var optionClass = classes('Select-option', 'is-disabled');
+		return React.createElement(this.props.optionGroupComponent, {
+			key: 'optionGroup-' + group.label,
+			className: optionClass,
+			renderFunc: renderLabel,
+			optionGroup: group
+		});
+	},
 
 	handleOptionLabelClick: function (value, event) {
 		if (this.props.onOptionLabelClick) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -13,45 +13,45 @@ var OptionGroup = require('./OptionGroup');
 var requestId = 0;
 
 function defaultFilterOption(option, filterValue) {
-  if (!filterValue) {
-    return true;
-  }
-  var valueTest = String(option.value), labelTest = String(option.label);
-  if (this.props.ignoreCase) {
-    valueTest = valueTest.toLowerCase();
-    labelTest = labelTest.toLowerCase();
-    filterValue = filterValue.toLowerCase();
-  }
-  return (this.props.matchPos === 'start') ? (
-    (this.props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
-    (this.props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
-  ) : (
-    (this.props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
-    (this.props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
-  );
+	if (!filterValue) {
+		return true;
+	}
+	var valueTest = String(option.value), labelTest = String(option.label);
+	if (this.props.ignoreCase) {
+		valueTest = valueTest.toLowerCase();
+		labelTest = labelTest.toLowerCase();
+		filterValue = filterValue.toLowerCase();
+	}
+	return (this.props.matchPos === 'start') ? (
+		(this.props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+		(this.props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+	) : (
+		(this.props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
+		(this.props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
+	);
 }
 
 function defaultFilterOptions(options, filterValue, exclude) {
-  if (!options) {
-    return [];
-  }
-  var matchingOptions = function(matches, option) {
-    if (isGroup(option)) {
-      var groupMatches = option.options.reduce(matchingOptions, []);
-      if (groupMatches.length > 0) {
-        matches.push(Object.assign({}, option, {
-          options: groupMatches,
-        }));
-      }
-    } else if (
-      (!this.props.multi || exclude.indexOf(option.value) === -1) &&
-      (this.props.filterOption && this.props.filterOption.call(this, option, filterValue))
-    ) {
-      matches.push(option);
-    }
-    return matches;
-  }.bind(this);
-  return options.reduce(matchingOptions, []);
+	if (!options) {
+		return [];
+	}
+	var matchingOptions = function(matches, option) {
+		if (isGroup(option)) {
+			var groupMatches = option.options.reduce(matchingOptions, []);
+			if (groupMatches.length > 0) {
+				matches.push(Object.assign({}, option, {
+					options: groupMatches,
+				}));
+			}
+		} else if (
+			(!this.props.multi || exclude.indexOf(option.value) === -1) &&
+			(this.props.filterOption && this.props.filterOption.call(this, option, filterValue))
+		) {
+			matches.push(option);
+		}
+		return matches;
+	}.bind(this);
+	return options.reduce(matchingOptions, []);
 }
 
 function defaultLabelRenderer(op) {
@@ -137,8 +137,8 @@ var Select = React.createClass({
 			clearable: true,
 			delimiter: ',',
 			disabled: false,
-      filterOption: defaultFilterOption,
-      filterOptions: defaultFilterOptions,
+			filterOption: defaultFilterOption,
+			filterOptions: defaultFilterOptions,
 			ignoreCase: true,
 			inputProps: {},
 			matchPos: 'any',
@@ -177,7 +177,7 @@ var Select = React.createClass({
 			isLoading: false,
 			isOpen: false,
 			options: this.props.options,
-      flatOptions: flattenOptions(this.props.options)
+			flatOptions: flattenOptions(this.props.options)
 		};
 	},
 
@@ -234,14 +234,14 @@ var Select = React.createClass({
 
 	componentWillReceiveProps: function(newProps) {
 		var optionsChanged = false;
-    var options = newProps.options;
+		var options = newProps.options;
 		if (JSON.stringify(options) !== JSON.stringify(this.props.options)) {
 			optionsChanged = true;
 			var filteredOptions = this.filterOptions(options);
 			this.setState({
 				filteredOptions: filteredOptions,
-        flatOptions: flattenOptions(filteredOptions),
-        options: options
+				flatOptions: flattenOptions(filteredOptions),
+				options: options
 			});
 		}
 		if (newProps.value !== this.state.value || newProps.placeholder !== this.props.placeholder || optionsChanged) {
@@ -324,7 +324,7 @@ var Select = React.createClass({
 			values: values,
 			inputValue: '',
 			filteredOptions: filteredOptions,
-      flatOptions: flattenOptions(filteredOptions),
+			flatOptions: flattenOptions(filteredOptions),
 			placeholder: !this.props.multi && values.length ? values[0].label : placeholder,
 			focusedOption: focusedOption
 		};
@@ -586,7 +586,7 @@ var Select = React.createClass({
 				isOpen: true,
 				inputValue: event.target.value,
 				filteredOptions: filteredOptions,
-        flatOptions: flattenOptions(filteredOptions),
+				flatOptions: flattenOptions(filteredOptions),
 				focusedOption: this._getNewFocusedOption(filteredOptions)
 			}, this._bindCloseMenuIfClickedOutside);
 		}
@@ -613,7 +613,7 @@ var Select = React.createClass({
 					var newState = {
 						options: options,
 						filteredOptions: filteredOptions,
-            flatOptions: flattenOptions(filteredOptions),
+						flatOptions: flattenOptions(filteredOptions),
 						focusedOption: this._getNewFocusedOption(filteredOptions)
 					};
 					for (var key in state) {
@@ -640,7 +640,7 @@ var Select = React.createClass({
 			var newState = {
 				options: data.options,
 				filteredOptions: filteredOptions,
-        flatOptions: flattenOptions(filteredOptions),
+				flatOptions: flattenOptions(filteredOptions),
 				focusedOption: this._getNewFocusedOption(filteredOptions)
 			};
 			for (var key in state) {
@@ -658,8 +658,8 @@ var Select = React.createClass({
 		var exclude = (values || this.state.values).map(function(i) {
 			return i.value;
 		});
-    var result = this.props.filterOptions.call(this, options, filterValue, exclude);
-    return result;
+		var result = this.props.filterOptions.call(this, options, filterValue, exclude);
+		return result;
 	},
 
 	selectFocusedOption: function() {
@@ -750,42 +750,42 @@ var Select = React.createClass({
 			options.unshift(newOption);
 		}
 
-    if (!options.length) {
-      return this.renderNoResults();
-    }
+		if (!options.length) {
+			return this.renderNoResults();
+		}
 
-    return this.renderOptions(focusedValue, options);
+		return this.renderOptions(focusedValue, options);
 	},
 
-  renderNoResults() {
-    var noResultsText, promptClass;
-    if (this.state.isLoading) {
-      promptClass = 'Select-searching';
-      noResultsText = this.props.searchingText;
-    } else if (this.state.inputValue || !this.props.asyncOptions) {
-      promptClass = 'Select-noresults';
-      noResultsText = this.props.noResultsText;
-    } else {
-      promptClass = 'Select-search-prompt';
-      noResultsText = this.props.searchPromptText;
-    }
+	renderNoResults() {
+		var noResultsText, promptClass;
+		if (this.state.isLoading) {
+			promptClass = 'Select-searching';
+			noResultsText = this.props.searchingText;
+		} else if (this.state.inputValue || !this.props.asyncOptions) {
+			promptClass = 'Select-noresults';
+			noResultsText = this.props.noResultsText;
+		} else {
+			promptClass = 'Select-search-prompt';
+			noResultsText = this.props.searchPromptText;
+		}
 
-    return (
-      <div className={promptClass}>
-        {noResultsText}
-      </div>
-    );
-  },
+		return (
+			<div className={promptClass}>
+				{noResultsText}
+			</div>
+		);
+	},
 
-  renderOptions(focusedValue, options) {
-    console.log(options);
+	renderOptions(focusedValue, options) {
+		console.log(options);
 		return options.map(function(option) {
 			if (isGroup(option)) {
 				return this.renderOptionGroup(focusedValue, option);
 			}
 			return this.renderOption(focusedValue, option);
 		}, this);
-  },
+	},
 
 	renderOption(focusedValue, op) {
 		var renderLabel = this.props.optionRenderer || defaultLabelRenderer;
@@ -819,7 +819,7 @@ var Select = React.createClass({
 		var renderLabel = this.props.optionGroupRenderer || defaultLabelRenderer;
 		return React.createElement(this.props.optionGroupComponent, {
 			key: 'optionGroup-' + group.label,
-      children: this.renderOptions(focusedValue, group.options),
+			children: this.renderOptions(focusedValue, group.options),
 			renderFunc: renderLabel,
 			optionGroup: group
 		});

--- a/src/Select.js
+++ b/src/Select.js
@@ -234,11 +234,11 @@ var Select = React.createClass({
 
 	componentWillReceiveProps: function(newProps) {
 		var optionsChanged = false;
-		if (JSON.stringify(newProps.options) !== JSON.stringify(this.props.options)) {
+    var options = newProps.options;
+		if (JSON.stringify(options) !== JSON.stringify(this.props.options)) {
 			optionsChanged = true;
-			var filteredOptions = this.filterOptions(newProps.options);
+			var filteredOptions = this.filterOptions(options);
 			this.setState({
-				flatOptions: flattenOptions(filteredOptions),
 				filteredOptions: filteredOptions,
         flatOptions: flattenOptions(filteredOptions),
         options: options

--- a/src/Select.js
+++ b/src/Select.js
@@ -706,7 +706,6 @@ var Select = React.createClass({
 		if (this.state.filteredOptions.length > 0) {
 			focusedValue = focusedValue == null ? this.state.filteredOptions[0].value : focusedValue;
 		}
-    console.log('buildMenu-focusedValue', focusedValue);
 		// Add the current value to the filtered options in last resort
 		var options = this.state.filteredOptions;
 		if (this.props.allowCreate && this.state.inputValue.trim()) {
@@ -722,7 +721,6 @@ var Select = React.createClass({
 		var ops = Object.keys(options).map(function(key) {
 			var op = options[key];
       if (isGroup(op)) {
-        console.log('render group!');
         return this.renderOptionGroup(op);
       }
       return this.renderOption(op, focusedValue);
@@ -752,7 +750,6 @@ var Select = React.createClass({
 	},
 
   renderOption(op, focusedValue) {
-    console.log('focusedValue', focusedValue)
 		var renderLabel = this.props.optionRenderer || defaultLabelRenderer;
     var isSelected = this.state.value === op.value;
     var isFocused = focusedValue === op.value;
@@ -798,7 +795,6 @@ var Select = React.createClass({
 	},
 
 	render: function() {
-    console.log('focused', this.state.focusedOption)
 		var selectClass = classes('Select', this.props.className, {
 			'is-multi': this.props.multi,
 			'is-searchable': this.props.searchable,


### PR DESCRIPTION
Spent some time working on grouped options for #59. Still rough around the edges but far enough along to share. I'd rather get some feedback before I spend too much time on it :wink: 

![react-select-groups](https://cloud.githubusercontent.com/assets/478109/10086394/29aab208-62dc-11e5-8a11-de7616229ee6.gif)

I think I'd prefer a nested structure to a separate "groups" prop. It should work with any number of sub groups as well.

```javascript
<Select
  options={[{
    label: 'Even',
    options: [
      { label: 'two', value: 2},
      { label: 'four', value: 4 },
    ]
  }, {
    label: 'Odd',
    options: [
      { label: 'One', value: 1 }
    ]
  }]}
/>
```

**TODO**
- [ ] disabled groups
- [ ] tests
- [ ] better group styles?
- [ ] for `multi={true}` allow group selection

cc @banderson