### PR TITLE
Fix for #208 and #434. Reset timeout before setting new one.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -186,6 +186,7 @@ var Select = React.createClass({
 	componentDidUpdate: function() {
 		if (!this.props.disabled && this._focusAfterUpdate) {
 			clearTimeout(this._blurTimeout);
+			clearTimeout(this._focusTimeout);
 			this._focusTimeout = setTimeout(() => {
 				this.getInputNode().focus();
 				this._focusAfterUpdate = false;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -902,7 +902,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')
@@ -915,7 +915,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')
@@ -928,7 +928,7 @@ describe('Select', function() {
 			pressEnterToAccept();
 			expect(onChange, 'was not called');
 			// And the menu is still open
-			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR)
+			expect(React.findDOMNode(instance), 'to contain no elements matching', DISPLAYED_SELECTION_SELECTOR);
 			expect(React.findDOMNode(instance), 'queried for' , '.Select-option',
 				'to satisfy', [
 					expect.it('to have text', 'Two')


### PR DESCRIPTION
As suggested by @voroshkov, this patch resets existing timeout before setting new one.
In fixed the problem for me. 
However I see similar pattern in handleInputBlur. It might be also worth looking at.

I ran lint on it, there are pre-existing errors in examples code and tests, changed file is OK.
Test is not included, issue is related to timing. If you know how to implement it I'd happy to add test.
