### PR TITLE
Node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-    - "0.10"
-    - "0.11"
-    - "0.12"
-    - "iojs-v2.5.0"
+    - "v4"
 script:
     - npm run coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,17 @@
 Thanks for your interest in React-Select. All forms of contribution are
 welcome, from issue reports to PRs and documentation / write-ups.
 
+* We use node.js v4 for development and testing. Due to incompatibilities with
+JSDOM and older versions of node.js, you'll need to use node 4 to run the
+tests.  If you can't install node v4 as your "default" node installation, you
+could try using [nvm](https://github.com/creationix/nvm) to install multiple
+versions concurrently.
+* If you're upgrading your node.js 0.x environment, it's sometimes necessary
+to remove the node_modules directory under react-select, and run npm install
+again, in order to ensure all the correct dependencies for the new version
+of node.js (as a minimum, you'll need to remove the `jsdom` module, and
+reinstall that).
+
 Before you open a PR:
 
 * If you're planning to add or change a major feature in a PR, please ensure

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-react": "^3.4.1",
     "gulp": "^3.9.0",
     "istanbul": "^0.3.20",
-    "jsdom": "^3.1.2",
+    "jsdom": "^6.5.1",
     "mocha": "^2.3.2",
     "react": ">=0.13.3 || ^0.14.0-beta",
     "react-gravatar": "^2.0.1",

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -10,7 +10,8 @@ var unexpectedSinon = require('unexpected-sinon');
 var expect = unexpected
 	.clone()
 	.installPlugin(unexpectedDom)
-	.installPlugin(unexpectedSinon);
+	.installPlugin(unexpectedSinon)
+	.installPlugin(require('../testHelpers/nodeListType'));
 
 jsdomHelper();
 
@@ -2498,7 +2499,7 @@ describe('Select', function() {
 			var ops = [
 				{ label: 'Disabled', value: 'disabled', disabled: true, link: renderLink(links[0]) },
 				{ label: 'Disabled 2', value: 'disabled_2', disabled: true, link: renderLink(links[1]) },
-				{ label: 'Enabled', value: 'enabled' },
+				{ label: 'Enabled', value: 'enabled' }
 			];
 
 			/**
@@ -2512,7 +2513,10 @@ describe('Select', function() {
 				return window_location.indexOf(path, window_location.length - path.length) !== -1;
 			};
 
+			var startUrl = 'http://dummy/startLink';
+
 			beforeEach(function () {
+				window.location.href = startUrl;
 
 				optionRenderer = function (option) {
 					return (
@@ -2552,7 +2556,7 @@ describe('Select', function() {
 					target: '_blank'
 				});
 
-				expect(isNavigated(links[0].href), 'to be true');
+				expect(isNavigated(startUrl), 'to be true');
 				TestUtils.Simulate.click(link);
 				expect(isNavigated(links[1].href), 'to be false');
 			});

--- a/testHelpers/jsdomHelper.js
+++ b/testHelpers/jsdomHelper.js
@@ -6,7 +6,7 @@ module.exports = function (html) {
 
 	var jsdom = require('jsdom').jsdom;
 	global.document = jsdom(html || '');
-	global.window = global.document.parentWindow;
+	global.window = global.document.defaultView;
 	global.navigator = {
 		userAgent: 'JSDOM'
 	};

--- a/testHelpers/nodeListType.js
+++ b/testHelpers/nodeListType.js
@@ -1,0 +1,19 @@
+
+module.exports = {
+
+	name: 'fix-nodelist-for-jsdom-6',
+
+	installInto: function (expect) {
+
+		expect.addType({
+			name: 'NodeList',
+			base: 'array-like',
+			identify: value => {
+				return typeof window !== 'undefined' &&
+					typeof window.NodeList === 'function' &&
+					value instanceof window.NodeList;
+			}
+		});
+
+	}
+};

--- a/wallaby.js
+++ b/wallaby.js
@@ -12,8 +12,10 @@ module.exports = function (wallaby) { // eslint-disable-line no-unused-vars
 			type: 'node',
 			runner: 'node'
 		},
-		preprocessors: {
-			'**/*.js': file => babel.transform(file.content, { sourceMap: true })
+		compilers: {
+			'**/*.js': wallaby.compilers.babel({
+				babel: babel
+			})
 		}
 	};
 };


### PR DESCRIPTION
This adds node-v4 compatibility for the tests (and removes node 0.x compatibility!)

It is advisable to remove the node_modules, and reinstall - at the very least, remove jsdom and redo the npm install.

Added note to CONTRIBUTING with instructions.