### PR TITLE
Focus and expand the select list #460

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -203,7 +203,7 @@ var Select = React.createClass({
 	},
 
 	focus: function() {
-		this._openAfterFocus="true";
+		this._openAfterFocus=true;
 		this.getInputNode().focus();
 	},
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -203,6 +203,7 @@ var Select = React.createClass({
 	},
 
 	focus: function() {
+		this._openAfterFocus="true";
 		this.getInputNode().focus();
 	},
 


### PR DESCRIPTION
**Issue:Focus and expand the select list #460**

This is the pull request to provide the feature of expanding the list when focus is invoked explicitly.
The solution is just setting ._openAfterFocus to true in the focus() method. This is the same action that takes place in handleMouseDown method . 

Please let me know if this can be part of the main code or i need to do more research to handle this issue.

Thanks,
Aaron
