### PR TITLE
IE-fix: don't blur if document.activeElement is menuDOM

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -437,6 +437,11 @@ var Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
+		var menuDOM = ReactDOM.findDOMNode(this.refs.menu);
+		if (document.activeElement.isEqualNode(menuDOM)) {
+			return;
+		}
+
 		this._blurTimeout = setTimeout(() => {
 			if (this._focusAfterUpdate || !this.isMounted()) return;
 			this.setState({


### PR DESCRIPTION
Fixes #495.

Still missing a test though: took multiple different stabs to simulate the situation #495 creates when the scrollbar is clicked (`menuDOM` is the `document.activeElement`) in a testable fashion, but couldn't find anything (at least yet) that would actually test that behavior.

Any ideas for the test? The other tests pass just fine.