### PR TITLE
Remove onClick clearValue

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -843,7 +843,7 @@ var Select = React.createClass({
 
 		// clear "x" button
 		var clear = (this.props.clearable && this.state.value && !this.props.disabled && !(this.isLoading())) ? (
-			<span className="Select-clear-zone" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} onMouseDown={this.clearValue} onTouchEnd={this.clearValue} onClick={this.clearValue}>
+			<span className="Select-clear-zone" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} onMouseDown={this.clearValue} onTouchEnd={this.clearValue}>
 				<span className="Select-clear" dangerouslySetInnerHTML={{ __html: '&times;' }} />
 			</span>
 		) : null;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1871,7 +1871,7 @@ describe('Select', () => {
 
 			describe('on clicking `clear`', () => {
 				beforeEach(() => {
-					TestUtils.Simulate.click(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
 				});
 
 				it('calls onChange with empty', () => {


### PR DESCRIPTION
I made an issue about this (https://github.com/JedWatson/react-select/issues/566) but went ahead and PR'd the change because I couldn't see a drawback to changing this and I need this fix ASAP.

To summarize: having the `clearValue` bound to onClick triggers clearing on a `mouseUp` event, causing issues in my case.

I know there is a rewrite in progress for 1.0, but I'm trying to avoid having to maintain a forked version for this minor change.