### PR TITLE
Add onBlurResetsInput prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	newOptionCreator	|	func	|	undefined	|	factory to create new options when `allowCreate` is true
 	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results
 	onBlur 		|	func	|	undefined	|	onBlur handler: `function(event) {}`
+	onBlurResetsInput	|	bool	|	true	|	whether to clear input on blur or not
 	onChange 	|	func	|	undefined	|	onChange handler: `function(newValue) {}`
 	onFocus 	|	func	|	undefined	|	onFocus handler: `function(event) {}`
 	onInputChange	|	func	|	undefined	|	onInputChange handler: `function(inputValue) {}`

--- a/src/Select.js
+++ b/src/Select.js
@@ -51,6 +51,7 @@ const Select = React.createClass({
 		newOptionCreator: React.PropTypes.func,     // factory to create new options when allowCreate set
 		noResultsText: React.PropTypes.string,      // placeholder displayed when there are no matching search results
 		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
+		onBlurResetsInput: React.PropTypes.bool,    // whether input is cleared on blur
 		onChange: React.PropTypes.func,             // onChange handler: function (newValue) {}
 		onFocus: React.PropTypes.func,              // onFocus handler: function (event) {}
 		onInputChange: React.PropTypes.func,        // onInputChange handler: function (inputValue) {}
@@ -91,6 +92,7 @@ const Select = React.createClass({
 			matchProp: 'any',
 			multi: false,
 			noResultsText: 'No results found',
+			onBlurResetsInput: true,
 			optionComponent: Option,
 			placeholder: 'Select...',
 			searchable: true,
@@ -211,12 +213,13 @@ const Select = React.createClass({
 		if (this.props.onBlur) {
 			this.props.onBlur(event);
 		}
-		this.setState({
-			inputValue: '',
+		var onBlurredState = {
 			isFocused: false,
 			isOpen: false,
 			isPseudoFocused: false,
-		});
+		};
+		if (this.props.onBlurResetsInput) onBlurredState.inputValue = '';
+		this.setState(onBlurredState);
 	},
 
 	handleInputChange (event) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2537,6 +2537,36 @@ describe('Select', () => {
 			});
 		});
 
+		describe('with onBlurResetsInput=true', () => {
+			beforeEach(() => {
+				instance = createControl({
+					options: defaultOptions,
+					onBlurResetsInput: true
+				});
+				typeSearchText('test');
+			});
+
+			it('should clear the search input after calling onBlur', () => {
+				TestUtils.Simulate.blur(searchInputNode);
+				expect(ReactDOM.findDOMNode(instance).querySelector('input').value, 'to equal', '');
+			});
+		});
+
+		describe('with onBlurResetsInput=false', () => {
+			beforeEach(() => {
+				instance = createControl({
+					options: defaultOptions,
+					onBlurResetsInput: false
+				});
+				typeSearchText('test');
+			});
+
+			it('shouldn\'t clear the search input after calling onBlur', () => {
+				TestUtils.Simulate.blur(searchInputNode);
+				expect(ReactDOM.findDOMNode(instance).querySelector('input').value, 'to equal', 'test');
+			});
+		});
+
 		describe('onFocus', () => {
 
 			var onFocus;


### PR DESCRIPTION
Add an `onBlurResetsInput` prop that, if set to `false`, would keep user input in search box on `onBlur`.
Defaults to `true`.
Fixes #588