### PR TITLE
Fix failing Value.js tests

### DIFF
--- a/src/Value.js
+++ b/src/Value.js
@@ -46,7 +46,7 @@ const Value = React.createClass({
 	renderLabel () {
 		let className = 'Select-value-label';
 		return this.props.onClick || this.props.value.href ? (
-			<a className={className} href={this.props.value.href} target={this.props.value.target} onMouseDown={this.handleMouseDown} onTouchEnd={this.props.handleMouseDown}>
+			<a className={className} href={this.props.value.href} target={this.props.value.target} onMouseDown={this.handleMouseDown} onTouchEnd={this.handleMouseDown}>
 				{this.props.children}
 			</a>
 		) : (

--- a/test/Value-test.js
+++ b/test/Value-test.js
@@ -32,12 +32,12 @@ describe('Value component', function() {
 			value: OPTION,
 			onRemove: sinon.spy()
 		};
-		value = TestUtils.renderIntoDocument(<Value {...props}/>);
+		value = TestUtils.renderIntoDocument(<Value {...props}>{OPTION.label}</Value>);
 	});
 
 	it('requests its own removal when the remove icon is clicked', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-value-icon');
-		TestUtils.Simulate.click(selectItemIcon);
+		TestUtils.Simulate.mouseDown(selectItemIcon);
 		expect(props.onRemove, 'was called');
 	});
 
@@ -45,12 +45,6 @@ describe('Value component', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-value-icon');
 		TestUtils.Simulate.touchEnd(selectItemIcon);
 		expect(props.onRemove, 'was called');
-	});
-
-	it('prevents event propagation, pt 1', function() {
-		var mockEvent = { stopPropagation: sinon.spy() };
-		value.blockEvent(mockEvent);
-		expect(mockEvent.stopPropagation, 'was called');
 	});
 
 	describe('without a custom click handler', function() {


### PR DESCRIPTION
* Fixes label onTouchEnd mistake (`this.props.handleMouseDown` should be `this.handleMouseDown`)
* Drops event propagation test (method no longer exists)
* Fixes other tests