### PR TITLE
Pressing Enter on open Select should stop propagation

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -247,6 +247,7 @@ const Select = React.createClass({
 			break;
 			case 13: // enter
 				if (!this.state.isOpen) return;
+				event.stopPropagation();
 				this.selectFocusedOption();
 			break;
 			case 27: // escape


### PR DESCRIPTION
I don't expect pressing Enter on an open menu to bubble back to the Select's container.