### PR TITLE
Fixing access to asynchronously loaded data

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -97,7 +97,7 @@ const Async = React.createClass({
 			if (_requestId !== this._currentRequestId) return;
 			this.setState({
 				isLoading: false,
-				options: data && data.options || [],
+				options: !!data ? data.options || [] : [],
 			});
 		};
 	},


### PR DESCRIPTION
This construction "options: data && data.options || []," does not work (it provides null).
It was changed to "options: !!data ? data.options || [] : [],"
