### PR TITLE
Change input back to div

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -477,17 +477,14 @@ const Select = React.createClass({
 		var className = classNames('Select-input', this.props.inputProps.className);
 		if (this.props.disabled || !this.props.searchable) {
 			return (
-				<input
+				<div
 					{...this.props.inputProps}
 					className={className}
-					tabIndex={this.props.tabIndex}
+					tabIndex={this.props.tabIndex || 0}
 					onBlur={this.handleInputBlur}
 					onFocus={this.handleInputFocus}
-					type="search"
-					autoComplete="off"
-					readOnly="true"
 					ref="input"
-					style={{ border: 0 }}/>
+					style={{ border: 0, width: 1, display:'inline-block' }}/>
 			);
 		}
 		return (


### PR DESCRIPTION
This essentially reverts the change made here
https://github.com/JedWatson/react-select/pull/595 By applying a tabIndex on a
div element allows it to be focused. This was the reason the div was changed to
an input, by putting it back to a div mobile devices display consistent behaviour
when the select box recieves focus. IOS would display a chrome at the bottom
of the page where as chrome wouldn't.