### PR TITLE
Feature to scroll the viewport to display the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	labelKey	|	string	|	'label'		|	the option property to use for the label
 	matchPos 	|	string	|	'any'		|	(any, start) match the start or entire string when filtering
 	matchProp 	|	string	|	'any'		|	(any, label, value) which option property to filter on
+	scrollMenuIntoView |	bool	|	true		|	whether the viewport will shift to display the entire menu when engaged
+	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport	
 	multi 		|	bool	|	undefined	|	multi-value input
 	name 		|	string	|	undefined	|	field name, for hidden `<input />` tag
 	newOptionCreator	|	func	|	undefined	|	factory to create new options when `allowCreate` is true

--- a/src/Select.js
+++ b/src/Select.js
@@ -44,6 +44,7 @@ const Select = React.createClass({
 		labelKey: React.PropTypes.string,           // path of the label value in option objects
 		matchPos: React.PropTypes.string,           // (any|start) match the start or entire string when filtering
 		matchProp: React.PropTypes.string,          // (any|label|value) which option property to filter on
+		scrollMenuIntoView: React.PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
 		menuBuffer: React.PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
 		menuStyle: React.PropTypes.object,          // optional style to apply to the menu
 		menuContainerStyle: React.PropTypes.object, // optional style to apply to the menu container
@@ -91,6 +92,7 @@ const Select = React.createClass({
 			labelKey: 'label',
 			matchPos: 'any',
 			matchProp: 'any',
+			scrollMenuIntoView: true,
 			menuBuffer: 0,
 			multi: false,
 			noResultsText: 'No results found',
@@ -133,7 +135,7 @@ const Select = React.createClass({
 				menuDOM.scrollTop = (focusedDOM.offsetTop + focusedDOM.clientHeight - menuDOM.offsetHeight);
 			}
 		}
-		if ( this.refs.menuContainer ) {
+		if ( this.props.scrollMenuIntoView && this.refs.menuContainer ) {
 			var menuContainerRect = this.refs.menuContainer.getBoundingClientRect();
 			if (window.innerHeight < menuContainerRect.bottom + this.props.menuBuffer) {
 				window.scrollTo(0, window.scrollY + menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);

--- a/src/Select.js
+++ b/src/Select.js
@@ -44,6 +44,7 @@ const Select = React.createClass({
 		labelKey: React.PropTypes.string,           // path of the label value in option objects
 		matchPos: React.PropTypes.string,           // (any|start) match the start or entire string when filtering
 		matchProp: React.PropTypes.string,          // (any|label|value) which option property to filter on
+		menuBuffer: React.PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
 		menuStyle: React.PropTypes.object,          // optional style to apply to the menu
 		menuContainerStyle: React.PropTypes.object, // optional style to apply to the menu container
 		multi: React.PropTypes.bool,                // multi-value input
@@ -90,6 +91,7 @@ const Select = React.createClass({
 			labelKey: 'label',
 			matchPos: 'any',
 			matchProp: 'any',
+			menuBuffer: 0,
 			multi: false,
 			noResultsText: 'No results found',
 			optionComponent: Option,
@@ -129,6 +131,12 @@ const Select = React.createClass({
 			var menuRect = menuDOM.getBoundingClientRect();
 			if (focusedRect.bottom > menuRect.bottom || focusedRect.top < menuRect.top) {
 				menuDOM.scrollTop = (focusedDOM.offsetTop + focusedDOM.clientHeight - menuDOM.offsetHeight);
+			}
+		}
+		if ( this.refs.menuContainer ) {
+			var menuContainerRect = this.refs.menuContainer.getBoundingClientRect();
+			if (window.innerHeight < menuContainerRect.bottom + this.props.menuBuffer) {
+				window.scrollTo(0, window.scrollY + menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);
 			}
 		}
 	},


### PR DESCRIPTION
Our project required the menu of an enabled dropdown to always be in view when the menu is activated. This PR introduces this feature. The viewport will only be shifted if the menu isn't in focus. 

We discussed different implementations such as the dropdown menu displaying above the select box. This implementation required the least amount of change to the code.

The implementation also uses a prop to calculate how much space to place below the menu and the viewport base. We discussed whether or not this should be calculated dynamically from css rather then a prop (incorporating any margin-bottom thats applied to .Select-menu) as this is arguably a styling concern but this semantically might not make sense as margins don't apply to elements taken out of document flow. 

If you are interested in this feature but would like some changes please let us know!