### PR TITLE
HTML Element Placeholders

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -18,7 +18,7 @@ ReactDOM.render(
 		<Contributors label="Contributors (Async)" />
 		<NumericSelect label="Numeric Values" />
 		<CustomRender label="Custom Render Methods"/>
-		<CustomComponents label="Custom Option and Value Components" />
+		<CustomComponents label="Custom Placeholder, Option and Value Components" />
 		{/*
 		<SelectedValuesField label="Option Creation (tags mode)" options={FLAVOURS} allowCreate hint="Enter a value that's NOT in the list, then hit return" />
 		*/}

--- a/examples/src/components/CustomComponents.js
+++ b/examples/src/components/CustomComponents.js
@@ -91,6 +91,8 @@ const UsersField = React.createClass({
 		this.setState({ value });
 	},
 	render () {
+		var placeholder = <span>&#9786; Select User</span>;
+
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
@@ -98,11 +100,14 @@ const UsersField = React.createClass({
 					onChange={this.setValue}
 					optionComponent={GravatarOption}
 					options={USERS}
-					placeholder="Select user"
+					placeholder={placeholder}
 					value={this.state.value}
 					valueComponent={GravatarValue}
 					/>
-				<div className="hint">This example implements custom Option and Value components to render a Gravatar image for each user based on their email</div>
+				<div className="hint">
+					This example implements custom Option and Value components to render a Gravatar image for each user based on their email.
+					It also demonstrates rendering HTML elements as the placeholder.
+				</div>
 			</div>
 		);
 	}

--- a/src/Async.js
+++ b/src/Async.js
@@ -46,7 +46,10 @@ const Async = React.createClass({
 		loadingPlaceholder: React.PropTypes.string,     // replaces the placeholder while options are loading
 		minimumInput: React.PropTypes.number,           // the minimum number of characters that trigger loadOptions
 		noResultsText: React.PropTypes.string,          // placeholder displayed when there are no matching search results (shared with Select)
-		placeholder: React.PropTypes.string,            // field placeholder, displayed when there's no value (shared with Select)
+		placeholder: React.PropTypes.oneOfType([        // field placeholder, displayed when there's no value (shared with Select)
+			React.PropTypes.string,
+			React.PropTypes.node
+		]),
 		searchingText: React.PropTypes.string,          // message to display while options are loading
 		searchPromptText: React.PropTypes.string,       // label to prompt for search input
 	},


### PR DESCRIPTION
In order to render custom icons as a part of the Select placeholder, we need to be able to provide styled HTML elements. 

This PR:

- ~~Adds `element` to the expected `placeholder` prop types~~
- Adds `node` to the expected `placeholder` prop type for `Async`
- Adds a smiley face icon to the `CustomComponents` example in the docs

![screen shot 2015-12-01 at 4 45 54 pm](https://cloud.githubusercontent.com/assets/2237917/11493291/04cf834c-984b-11e5-92d8-3e920cfdadb0.png)

I wasn't sure if it's better to add another prop (`placeholderComponent` or `<insert better name>`) in order to keep the `placeholder` prop a consistent type. Thoughts?