### PR TITLE
Check if menu ref is not null

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -448,7 +448,7 @@ var Select = React.createClass({
 		var _this7 = this;
 
 		var menuDOM = ReactDOM.findDOMNode(this.refs.menu);
-		if (document.activeElement.isEqualNode(menuDOM)) {
+		if (menuDOM && document.activeElement.isEqualNode(menuDOM)) {
 			return;
 		}
 		this._blurTimeout = setTimeout(function () {


### PR DESCRIPTION
This fix should go to the commit with tag v0.9.1.

This fix is related to #539. I couldn't narrow the exact error but my function handleInputBlur is called twice, one with this.refs.menu set to a div element and the other to null.

Tested on IE11.
