### PR TITLE
Missing onChange prop prevents setting the value.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -329,11 +329,12 @@ const Select = React.createClass({
 	},
 
 	setValue (value) {
-		if (!this.props.onChange) return;
 		if (this.props.simpleValue && value) {
 			value = this.props.multi ? value.map(i => i[this.props.valueKey]).join(this.props.delimiter) : value[this.props.valueKey];
 		}
-		this.props.onChange(value);
+		if (this.props.onChange){
+			this.props.onChange(value);
+		}
 	},
 
 	selectValue (value) {


### PR DESCRIPTION
`onChange` prop should not be mandatory. Not everybody want to track the change event.