### PR TITLE
Fix blur handler on IE where menu ref is undefined

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -239,9 +239,10 @@ var Select = _react2['default'].createClass({
 	},
 
 	handleInputBlur: function handleInputBlur(event) {
-		if (document.activeElement.isEqualNode(this.refs.menu)) {
+		if (this.refs.menu && document.activeElement.isEqualNode(this.refs.menu)) {
 			return;
 		}
+
 		if (this.props.onBlur) {
 			this.props.onBlur(event);
 		}

--- a/src/Select.js
+++ b/src/Select.js
@@ -208,9 +208,12 @@ const Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
-		if (document.activeElement.isEqualNode(this.refs.menu)) {
-			return;
-		}
+ 		let menuDOM = ReactDOM.findDOMNode(this.refs.menu);
+
+ 		if (menuDOM && document.activeElement.isEqualNode(menuDOM)) {
+ 			return;
+ 		}
+
 		if (this.props.onBlur) {
 			this.props.onBlur(event);
 		}

--- a/src/Select.js
+++ b/src/Select.js
@@ -208,9 +208,7 @@ const Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
- 		let menuDOM = ReactDOM.findDOMNode(this.refs.menu);
-
- 		if (menuDOM && document.activeElement.isEqualNode(menuDOM)) {
+ 		if (this.refs.menu && document.activeElement.isEqualNode(this.refs.menu)) {
  			return;
  		}
 


### PR DESCRIPTION
On IE when the input is blurred it fails because on isEqualNode does not accept undefined or null values.

This re-introduces the fix on #539 and checks menuDOM is not undefined/null.