### PR TITLE
Check menu node is thruthy when calling isEqualNode

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -230,7 +230,7 @@ const Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
-		if (document.activeElement.isEqualNode(this.refs.menu)) {
+		if (this.refs.menu && document.activeElement.isEqualNode(this.refs.menu)) {
 			return;
 		}
 		if (this.props.onBlur) {


### PR DESCRIPTION
calling isEqualNode with undefined in IE9 causes browser to throw `no such interface supported`