### PR TITLE
Allow customization of menu option background color

### DIFF
--- a/less/menu.less
+++ b/less/menu.less
@@ -38,6 +38,7 @@
 
 .Select-option {
 	box-sizing: border-box;
+	background-color: @select-option-bg;
 	color: @select-option-color;
 	cursor: pointer;
 	display: block;

--- a/less/select.less
+++ b/less/select.less
@@ -33,6 +33,7 @@
 @select-menu-max-height:           200px;
 
 @select-option-color:              lighten(@select-text-color, 20%);
+@select-option-bg:                 @select-input-bg;
 @select-option-focused-color:      @select-text-color;
 @select-option-focused-bg:         fade(@select-primary-color, 8%);
 @select-option-disabled-color:     lighten(@select-text-color, 60%);

--- a/scss/menu.scss
+++ b/scss/menu.scss
@@ -38,6 +38,7 @@
 
 .Select-option {
 	box-sizing: border-box;
+	background-color: $select-option-bg;
 	color: $select-option-color;
 	cursor: pointer;
 	display: block;

--- a/scss/select.scss
+++ b/scss/select.scss
@@ -30,6 +30,7 @@ $select-menu-zindex:               1000 !default;
 $select-menu-max-height:           200px !default;
 
 $select-option-color:              lighten($select-text-color, 20%) !default;
+$select-option-bg:                 $select-input-bg !default;
 $select-option-focused-color:      $select-text-color !default;
 $select-option-focused-bg:         #f2f9fc !default; // pale blue
 $select-option-disabled-color:     lighten($select-text-color, 60%) !default;


### PR DESCRIPTION
Introduces a new variable, $select-option-bg that defaults to the value
of $select-input-bg to maintain existing behavior.