### PR TITLE
v0.6.x - Keep multi-select open after selection

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -308,7 +308,9 @@ var Select = React.createClass({
 			this._focusAfterUpdate = true;
 		}
 		var newState = this.getStateFromValue(value);
-		newState.isOpen = false;
+		if (!this.props.multi) {
+			newState.isOpen = false;
+		}
 		this.fireChangeEvent(newState);
 		this.setState(newState);
 	},

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1607,8 +1607,6 @@ describe('Select', function() {
 
 			var items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			TestUtils.Simulate.mouseDown(items[1]);
-			// The menu is now closed, click the arrow to open it again
-			clickArrowToOpen();
 			items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			TestUtils.Simulate.mouseDown(items[0]);
 
@@ -1628,9 +1626,6 @@ describe('Select', function() {
 			expect(onChange, 'was called with', 'two', [{ value: 'two', label: 'Two' }]);
 
 			// Second item
-
-			// The menu is now closed, click the arrow to open it again
-			clickArrowToOpen();
 			items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			TestUtils.Simulate.mouseDown(items[0]);
 			expect(onChange, 'was called twice');
@@ -1649,7 +1644,6 @@ describe('Select', function() {
 
 			// Now get the list again,
 			// The menu is now closed, click the arrow to open it again
-			clickArrowToOpen();
 			items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			expect(items[0], 'to have text', 'One');
 			expect(items[1], 'to have text', 'Three');
@@ -1660,8 +1654,6 @@ describe('Select', function() {
 			TestUtils.Simulate.mouseDown(items[0]);
 
 			expect(onChange, 'was called times', 2);
-			// The menu is now closed, click the arrow to open it again
-			clickArrowToOpen();
 			items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			expect(items[0], 'to have text', 'Three');
 			expect(items[1], 'to have text', 'Four');
@@ -1671,8 +1663,6 @@ describe('Select', function() {
 			TestUtils.Simulate.mouseDown(items[1]);
 			expect(onChange, 'was called times', 3);
 
-			// The menu is now closed, click the arrow to open it again
-			clickArrowToOpen();
 			items = React.findDOMNode(instance).querySelectorAll('.Select-option');
 			expect(items[0], 'to have text', 'Three');
 			expect(items, 'to have length', 1);


### PR DESCRIPTION
This pull request is to keep the drop-down open for multi-selects after a selection. If you could make a release for the v0.6.x branch, that would be great. I fixed the tests to replicate the dropdown staying open. If there is anything else you need, let me know.
