### PR TITLE
Expose focus() in the Async component. Fix #676

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -84,6 +84,9 @@ const Async = React.createClass({
 			});
 		}
 	},
+	focus () {
+		this._select.focus();
+	},
 	resetState () {
 		this._currentRequestId = -1;
 		this.setState({
@@ -135,6 +138,7 @@ const Async = React.createClass({
 		return (
 			<Select
 				{...this.props}
+				ref={select => {this._select = select;}}
 				isLoading={isLoading}
 				noResultsText={noResultsText}
 				onInputChange={this.loadOptions}


### PR DESCRIPTION
I didn't add any test, didn't really know how to do so, since the `<Select />.focus()` method is not tested either. If someone (@bruderstein?) can advise me on that, I'll gladly do so.

I've seen that you use string refs in this project, however, the React team considers this approach as [mostly legacy](https://facebook.github.io/react/docs/more-about-refs.html) now. So I used one of their [example](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) as a reference.