### PR TITLE
Removed event.stopPropagation() from Select's clearValue

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -390,7 +390,6 @@ const Select = React.createClass({
 		if (event && event.type === 'mousedown' && event.button !== 0) {
 			return;
 		}
-		event.stopPropagation();
 		event.preventDefault();
 		this.setValue(null);
 		this.setState({


### PR DESCRIPTION
See Issue #671. 

It wasn't clear to me why both stopPropagation and preventDefault were being called on this event. Removing stopPropagation allowed the event to make it to the adjacent field's blur providing the expected behavior. The examples continue to work as expected and the tests all pass. If stopPropagation is necessary for a case that I'm unfamiliar with I'd be happy to try a different approach. Thanks for the awesome components!
