### PR TITLE
Enter selects and retains focus, Tab selects and shifts focus

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -291,7 +291,7 @@ var Select = _react2['default'].createClass({
 					return;
 				}
 				this.selectFocusedOption();
-				break;
+				return;
 			case 13:
 				// enter
 				if (!this.state.isOpen) return;


### PR DESCRIPTION
Hi, the Tab behavior is really confusing users, since in all other Form Controls, "Tab" will switch focus, but for this one single control alone a user has to press Tab twice. Almost every user so far has asked "Why?" when I've asked them to press tab twice here.

I propose a simple enhancement (or rather simplification):

* Enter selects and keeps focus
* Tab selects and shifts focus

Simple and clear. That's how all forms work. Even goodness Excel and LibreOffice!

Fixes #643