### PR TITLE
Make sure the selected option is immediately visible when the menu is open

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -136,6 +136,16 @@ const Select = React.createClass({
 	},
 
 	componentDidUpdate (prevProps, prevState) {
+		// focus to the selected option
+		if (this.refs.menu && this.refs.focused && this.state.isOpen && !this.hasScrolledToOption) {
+			let focusedOptionNode = ReactDOM.findDOMNode(this.refs.focused);
+			let menuNode = ReactDOM.findDOMNode(this.refs.menu);
+			menuNode.scrollTop = focusedOptionNode.offsetTop;
+			this.hasScrolledToOption = true;
+		} else if (!this.state.isOpen) {
+			this.hasScrolledToOption = false;
+		}
+
 		if (prevState.inputValue !== this.state.inputValue && this.props.onInputChange) {
 			this.props.onInputChange(this.state.inputValue);
 		}
@@ -220,6 +230,7 @@ const Select = React.createClass({
 			isPseudoFocused: this.state.isFocused && !this.props.multi,
 			inputValue: '',
 		});
+		this.hasScrolledToOption = false;
 	},
 
 	handleInputFocus (event) {
@@ -356,6 +367,7 @@ const Select = React.createClass({
 	},
 
 	selectValue (value) {
+		this.hasScrolledToOption = false;
 		if (this.props.multi) {
 			this.addValue(value);
 			this.setState({
@@ -595,6 +607,7 @@ const Select = React.createClass({
 		if (options && options.length) {
 			let Option = this.props.optionComponent;
 			let renderLabel = this.props.optionRenderer || this.getOptionLabel;
+
 			return options.map((option, i) => {
 				let isSelected = valueArray && valueArray.indexOf(option) > -1;
 				let isFocused = option === focusedOption;
@@ -605,6 +618,7 @@ const Select = React.createClass({
 					'is-focused': isFocused,
 					'is-disabled': option.disabled,
 				});
+
 				return (
 					<Option
 						className={optionClass}

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -178,7 +178,7 @@ describe('Async', () => {
 				noResultsText="Searching..."
 				placeholder="Loading..."
 			/>);
-		})
+		});
 	});
 
 	describe('with a cache', () => {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1762,14 +1762,14 @@ describe('Select', () => {
 				});
 
 				it('should set the isFocused state to false if disabled=true', function(){
-					
+
 						expect(instance.state.isFocused, 'to equal', false);
 						findAndFocusInputControl();
 						expect(instance.state.isFocused, 'to equal', true);
 				    ReactDOM.render(<Select disabled={true} searchable={true} value="three" options={defaultOptions} />, node);
 						expect(instance.state.isFocused, 'to equal', false);
 				});
-			})
+			});
 		});
 
 		describe('custom filterOption function', () => {
@@ -1984,7 +1984,7 @@ describe('Select', () => {
 
 			// TODO: Disabled inputs no longer have an <input>, let's wait until that settles
 			// down before updating this test to match.
-			
+
 			// describe('and disabled', () => {
 			//
 			// 	beforeEach(() => {


### PR DESCRIPTION
Makes sure that when you select an option, next time you open the menu that selected option is immediately visible. 
I made sure it doesn't unnecessarily re-render

I noticed a few people asking for this - hopefully its as per guidelines :+1:  

Also included fixing existing linting errors