### PR TITLE
Blur the input fields after an option is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	Property	|	Type		|	Default		|	Description
 :-----------------------|:--------------|:--------------|:--------------------------------
 	addLabelText	|	string	|	'Add "{label}"?'	|	text to display when `allowCreate` is true
+	autoBlur	|	bool | false | Blures the input element after a selection has been made. Handy for lowering the keyboard on mobile devices
 	allowCreate	|	bool	|	false		|	allow new options to be created in multi mode (displays an "Add \<option> ?" item when a value not already in the `options` array is entered)
 	autoload 	|	bool	|	true		|	whether to auto-load the default async options set
 	backspaceRemoves 	|	bool	|	true	|	whether pressing backspace removes the last item when there is no input value

--- a/src/Select.js
+++ b/src/Select.js
@@ -25,6 +25,7 @@ const Select = React.createClass({
 
 	propTypes: {
 		addLabelText: React.PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
+		autoBlur: React.PropTypes.bool,
 		allowCreate: React.PropTypes.bool,          // whether to allow creation of new entries
 		autofocus: React.PropTypes.bool,            // autofocus the component on mount
 		backspaceRemoves: React.PropTypes.bool,     // whether backspace removes an item if there is no text input
@@ -163,6 +164,11 @@ const Select = React.createClass({
 	focus () {
 		if (!this.refs.input) return;
 		this.refs.input.focus();
+	},
+
+	blurInput() {
+		if (!this.refs.input) return;
+		this.refs.input.blur();
 	},
 
 	handleMouseDown (event) {
@@ -348,6 +354,9 @@ const Select = React.createClass({
 	},
 
 	setValue (value) {
+		if (this.props.autoBlur){
+			this.blurInput();
+		}
 		if (!this.props.onChange) return;
 		if (this.props.simpleValue && value) {
 			value = this.props.multi ? value.map(i => i[this.props.valueKey]).join(this.props.delimiter) : value[this.props.valueKey];


### PR DESCRIPTION
Currently, when an option is selected from the options list, the input field stays focused.
This is hardly noticeable on desktop browsers but on mobile devices the keyboard stays on the screen instead of disappearing.
This results in a poor user experience forcing a manual keyboard toggle after selecting an option (of course, there is no such problem if `searchable` is set to `false`).

By setting `autoBlur` to `true` (defaults to `false` for the moment) the input field will blur automatically after a selection has been made.
When multi-select is enabled, the options menu will be closed after a single option has been selected (like requested in issue #706, this is a side effect but IMO it's a welcome one).

__This pr requires react-input-autosize version >= 0.6.7__