### PR TITLE
Hide noResultsText when value is falsy

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,15 +227,15 @@ For multi-select inputs, when providing a custom `filterOptions` method, remembe
 	inputProps 	|	object	|	{}		|	custom attributes for the Input (in the Select-control) e.g: `{'data-foo': 'bar'}`
 	isLoading	|	bool	|	false		|	whether the Select is loading externally or not (such as options being loaded)
 	labelKey	|	string	|	'label'		|	the option property to use for the label
-	loadOptions	|	func	|	undefined	|	function that returns a promise or calls a callback with the options: `function(input, [callback])` 
+	loadOptions	|	func	|	undefined	|	function that returns a promise or calls a callback with the options: `function(input, [callback])`
 	matchPos 	|	string	|	'any'		|	(any, start) match the start or entire string when filtering
 	matchProp 	|	string	|	'any'		|	(any, label, value) which option property to filter on
 	scrollMenuIntoView |	bool	|	true		|	whether the viewport will shift to display the entire menu when engaged
-	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport	
+	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
 	multi 		|	bool	|	undefined	|	multi-value input
 	name 		|	string	|	undefined	|	field name, for hidden `<input />` tag
 	newOptionCreator	|	func	|	undefined	|	factory to create new options when `allowCreate` is true
-	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results
+	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results or a falsy value to hide it
 	onBlur 		|	func	|	undefined	|	onBlur handler: `function(event) {}`
 	onBlurResetsInput	|	bool	|	true	|	whether to clear input on blur or not
 	onChange 	|	func	|	undefined	|	onChange handler: `function(newValue) {}`

--- a/src/Select.js
+++ b/src/Select.js
@@ -621,13 +621,15 @@ const Select = React.createClass({
 					</Option>
 				);
 			});
-		} else {
+		} else if (this.props.noResultsText) {
 			return (
 				<div className="Select-noresults">
 					{this.props.noResultsText}
 				</div>
 			);
-		}
+		} else {
+            return null;
+        }
 	},
 
 	renderHiddenField (valueArray) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -628,8 +628,8 @@ const Select = React.createClass({
 				</div>
 			);
 		} else {
-            return null;
-        }
+			return null;
+		}
 	},
 
 	renderHiddenField (valueArray) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1762,7 +1762,7 @@ describe('Select', () => {
 				});
 
 				it('should set the isFocused state to false if disabled=true', function(){
-					
+
 						expect(instance.state.isFocused, 'to equal', false);
 						findAndFocusInputControl();
 						expect(instance.state.isFocused, 'to equal', true);
@@ -1984,7 +1984,7 @@ describe('Select', () => {
 
 			// TODO: Disabled inputs no longer have an <input>, let's wait until that settles
 			// down before updating this test to match.
-			
+
 			// describe('and disabled', () => {
 			//
 			// 	beforeEach(() => {
@@ -2147,6 +2147,17 @@ describe('Select', () => {
 				typeSearchText('DOES NOT EXIST');
 				expect(ReactDOM.findDOMNode(instance).querySelector('.Select-menu'),
 					'to have text', 'No results unit test');
+			});
+
+			it('doesn\'t displays the text when no results are found and noResultsText is falsy', () => {
+
+				wrapper.setPropsForChild({
+					noResultsText: ''
+				});
+
+				typeSearchText('DOES NOT EXIST');
+				expect(ReactDOM.findDOMNode(instance),
+					'to contain no elements matching', '.Select-noresults');
 			});
 
 			it('supports updating the text', () => {


### PR DESCRIPTION
When the `noResultsText` prop is a falsy value, don't show it when typing.

References #717