### PR TITLE
feature(.props.required): add HTML5 required attribute capabilities

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -75,6 +75,7 @@ const Select = React.createClass({
 			React.PropTypes.string,
 			React.PropTypes.node
 		]),                                         // field placeholder, displayed when there's no value
+		required: React.PropTypes.bool,             // applies HTML5 required attribute when needed
 		searchable: React.PropTypes.bool,           // whether to enable searching feature or not
 		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
 		style: React.PropTypes.object,              // optional style to apply to the control
@@ -112,6 +113,7 @@ const Select = React.createClass({
 			onBlurResetsInput: true,
 			optionComponent: Option,
 			placeholder: 'Select...',
+			required: false,
 			searchable: true,
 			simpleValue: false,
 			valueComponent: Value,
@@ -126,6 +128,7 @@ const Select = React.createClass({
 			isLoading: false,
 			isOpen: false,
 			isPseudoFocused: false,
+			required: this.props.required && this.handleRequired(this.props.value, this.props.multi)
 		};
 	},
 
@@ -320,6 +323,11 @@ const Select = React.createClass({
 		}
 	},
 
+	handleRequired (value, multi) {
+		if (!value) return true;
+		return (multi ? value.length === 0 : Object.keys(value).length === 0);
+	},
+
 	getOptionLabel (op) {
 		return op[this.props.labelKey];
 	},
@@ -349,6 +357,10 @@ const Select = React.createClass({
 
 	setValue (value) {
 		if (!this.props.onChange) return;
+		if (this.props.required) {
+			const required = this.handleRequired(value, this.props.multi);
+			this.setState({required});
+		}
 		if (this.props.simpleValue && value) {
 			value = this.props.multi ? value.map(i => i[this.props.valueKey]).join(this.props.delimiter) : value[this.props.valueKey];
 		}
@@ -529,6 +541,7 @@ const Select = React.createClass({
 				onFocus={this.handleInputFocus}
 				minWidth="5"
 				ref="input"
+				required={this.state.required}
 				value={this.state.inputValue}
 			/>
 		);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -359,6 +359,12 @@ describe('Select', () => {
 			expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching', '.Select-option');
 		});
 
+		it('the input should not have a required attribute', () => {
+			var inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+			expect(inputNode, 'to have attributes', {
+				required: undefined
+			})
+		});
 	});
 
 	describe('with values as numbers', () => {
@@ -719,6 +725,13 @@ describe('Select', () => {
 			expect(ReactDOM.findDOMNode(instance), 'queried for', DISPLAYED_SELECTION_SELECTOR,
 				'to have items satisfying', 'to have text', 'New item in the options');
 
+		});
+
+		it('the input should not have a required attribute', () => {
+			var inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+			expect(inputNode, 'to have attributes', {
+				required: undefined
+			})
 		});
 	});
 
@@ -2643,6 +2656,122 @@ describe('Select', () => {
 				});
 			});
 		});
+
+		describe('required', () => {
+
+			it('input should have required attribute if value is empty', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: '',
+					required: true
+				});
+
+				const inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+				expect(inputNode, 'to have attributes', {
+					required: true
+				})
+			});
+
+			it('input should have required attribute after adding a value', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: '',
+					required: true
+				});
+
+				expect(instance.state.required, 'to be true');
+				typeSearchText('three');
+				pressEnterToAccept();
+				expect(instance.state.required, 'to be false');
+			});
+
+			it('input should not have required attribute if value is present', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one',
+					required: true
+				});
+
+				const inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+				expect(inputNode, 'to have attributes', {
+					required: undefined
+				})
+			});
+
+			it('input should have required attribute after removing the value', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one',
+					required: true
+				});
+
+				expect(instance.state.required, 'to be false');
+				instance.setValue([]);
+				expect(instance.state.required, 'to be true');
+			});
+
+		});
+
+		describe('required with multi=true', () => {
+
+			it('input should have required attribute if value is empty', () => {
+
+				instance = createControl({
+					options: defaultOptions,
+					value: '',
+					multi: true,
+					required: true
+				});
+
+				const inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+				expect(inputNode, 'to have attributes', {
+					required: true
+				})
+			});
+
+			it('input should not have required attribute after adding values', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: '',
+					multi: true,
+					required: true
+				});
+
+				expect(instance.state.required, 'to be true');
+				typeSearchText('three');
+				pressEnterToAccept();
+				expect(instance.state.required, 'to be false');
+			});
+
+			it('input should not have required attribute if value is present', () => {
+
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one,two',
+					multi: true,
+					required: true
+				});
+
+				const inputNode = ReactDOM.findDOMNode(instance).querySelector('input');
+				expect(inputNode, 'to have attributes', {
+					required: undefined
+				})
+			});
+
+			it('input should have required attribute after removing values', () => {
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one,two',
+					multi: true,
+					required: true
+				});
+
+				expect(instance.state.required, 'to be false');
+				instance.setValue([]);
+				expect(instance.state.required, 'to be true');
+			});
+
+		})
 	});
 
 	describe('clicking outside', () => {


### PR DESCRIPTION
This PR adds the ability to specify a prop named `required` on the `Select` component that make use of the HTML5 required attribute in order to ensure that at least one input has been submitted.

The logic is pretty straightforward: I basically add and remove the `required` attribute from the `Input` component of `react-input-autosize`, which in turn applies it and removes it from the real `<input />`.

It obviously defaults to `false`, and I've added quite a few tests in order to make sure I didn't break any existing behaviour and that the thing I wrote actually works.

You can see a live example using the new feature here:
https://nextpodio.dk/webforms/14728164/987369

**Note:**
In the specs that are testing mutations (adding and removing values) I couldn't test on the real HTML attribute because React doesn't update it, when using `TestUtils` to change the node.
I had to resort on testing `.state.required` which is suboptimal, but better than nothing