### PR TITLE
Add touch & drag  behaviour

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -161,6 +161,34 @@ const Select = React.createClass({
 		this.refs.input.focus();
 	},
 
+	handleTouchMove (event) {
+		// Set a flag that the view is being dragged
+		this.dragging = true;
+	},
+
+	handleTouchStart (event) {
+		// Set a flag that the view is not being dragged
+		this.dragging = false;
+	},
+
+	handleTouchEnd (event) {
+		// Check if the view is being dragged, In this case
+		// we don't want to fire the click event (because the user only wants to scroll)
+		if(this.dragging) return;
+
+		// Fire the mouse events
+		this.handleMouseDown(event);
+	},
+
+	handleTouchEndClearValue (event) {
+		// Check if the view is being dragged, In this case
+		// we don't want to fire the click event (because the user only wants to scroll)
+		if(this.dragging) return;
+
+		// Clear the value
+		this.clearValue(event);
+	},
+
 	handleMouseDown (event) {
 		// if the event was triggered by a mousedown and not the primary
 		// button, or if the component is disabled, ignore it.
@@ -543,7 +571,12 @@ const Select = React.createClass({
 	renderClear () {
 		if (!this.props.clearable || !this.props.value || (this.props.multi && !this.props.value.length) || this.props.disabled || this.props.isLoading) return;
 		return (
-			<span className="Select-clear-zone" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} onMouseDown={this.clearValue} onTouchEnd={this.clearValue}>
+			<span className="Select-clear-zone" title={this.props.multi ? this.props.clearAllText : this.props.clearValueText} 
+						aria-label={this.props.multi ? this.props.clearAllText : this.props.clearValueText} 
+						onMouseDown={this.clearValue}
+						onTouchStart={this.handleTouchStart}
+						onTouchMove={this.handleTouchMove}
+						onTouchEnd={this.handleTouchEndClearValue}>
 				<span className="Select-clear" dangerouslySetInnerHTML={{ __html: '&times;' }} />
 			</span>
 		);
@@ -673,7 +706,14 @@ const Select = React.createClass({
 		return (
 			<div ref="wrapper" className={className} style={this.props.wrapperStyle}>
 				{this.renderHiddenField(valueArray)}
-				<div ref="control" className="Select-control" style={this.props.style} onKeyDown={this.handleKeyDown} onMouseDown={this.handleMouseDown} onTouchEnd={this.handleMouseDown}>
+				<div ref="control" 
+						 className="Select-control" 
+						 style={this.props.style} 
+						 onKeyDown={this.handleKeyDown} 
+						 onMouseDown={this.handleMouseDown} 
+						 onTouchEnd={this.handleTouchEnd}
+						 onTouchStart={this.handleTouchStart}
+						 onTouchMove={this.handleTouchMove}>
 					{this.renderValue(valueArray, isOpen)}
 					{this.renderInput(valueArray)}
 					{this.renderLoading()}
@@ -682,7 +722,10 @@ const Select = React.createClass({
 				</div>
 				{isOpen ? (
 					<div ref="menuContainer" className="Select-menu-outer" style={this.props.menuContainerStyle}>
-						<div ref="menu" className="Select-menu" style={this.props.menuStyle} onScroll={this.handleMenuScroll} onMouseDown={this.handleMouseDownOnMenu}>
+						<div ref="menu" className="Select-menu" 
+								 style={this.props.menuStyle} 
+								 onScroll={this.handleMenuScroll} 
+								 onMouseDown={this.handleMouseDownOnMenu}>
 							{this.renderMenu(options, !this.props.multi ? valueArray : null, focusedOption)}
 						</div>
 					</div>

--- a/src/Value.js
+++ b/src/Value.js
@@ -33,12 +33,33 @@ const Value = React.createClass({
 		this.props.onRemove(this.props.value);
 	},
 
+	handleTouchEndRemove (event){
+		// Check if the view is being dragged, In this case
+		// we don't want to fire the click event (because the user only wants to scroll)
+		if(this.dragging) return;
+
+		// Fire the mouse events
+		this.onRemove(event);
+	},
+
+	handleTouchMove (event) {
+		// Set a flag that the view is being dragged
+		this.dragging = true;
+	},
+
+	handleTouchStart (event) {
+		// Set a flag that the view is not being dragged
+		this.dragging = false;
+	},
+
 	renderRemoveIcon () {
 		if (this.props.disabled || !this.props.onRemove) return;
 		return (
 			<span className="Select-value-icon"
 				onMouseDown={this.onRemove}
-				onTouchEnd={this.onRemove}>
+				onTouchEnd={this.handleTouchEndRemove}
+				onTouchStart={this.handleTouchStart}
+				onTouchMove={this.handleTouchMove}>
 				&times;
 			</span>
 		);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -94,7 +94,6 @@ describe('Select', () => {
 		TestUtils.Simulate.mouseDown(selectArrow);
 	};
 
-
 	var findAndFocusInputControl = () => {
 		// Focus on the input, such that mouse events are accepted
 		var searchInstance = ReactDOM.findDOMNode(instance.refs.input);
@@ -260,6 +259,21 @@ describe('Select', () => {
 				expect(onChange, 'was called with', null);
 			});
 
+		});
+
+		it('should display the options menu when tapped', function() {
+			TestUtils.Simulate.touchStart(getSelectControl(instance));
+			TestUtils.Simulate.touchEnd(getSelectControl(instance));
+			var node = ReactDOM.findDOMNode(instance);
+			expect(node, 'queried for', '.Select-option', 'to have length', 3);
+		});
+
+		it('should not display the options menu when touched and dragged', function() {
+			TestUtils.Simulate.touchStart(getSelectControl(instance));
+			TestUtils.Simulate.touchMove(getSelectControl(instance));
+			TestUtils.Simulate.touchEnd(getSelectControl(instance));
+			var node = ReactDOM.findDOMNode(instance);
+			expect(node, 'to contain no elements matching', '.Select-option');
 		});
 
 		it('should focus the first value on mouse click', () => {
@@ -1523,6 +1537,42 @@ describe('Select', () => {
 
 				it('resets the control value', () => {
 					expect(ReactDOM.findDOMNode(instance).querySelector('input').value, 'to equal', '');
+				});
+			});
+
+			describe('on tapping `clear`', () => {
+				beforeEach(() => {
+					TestUtils.Simulate.touchStart(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.touchEnd(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+				});
+
+				it('calls onChange with empty', () => {
+					expect(onChange, 'was called with', null);
+				});
+
+				it('resets the display value', () => {
+					expect(ReactDOM.findDOMNode(instance), 'queried for', PLACEHOLDER_SELECTOR,
+						'to have items satisfying', 'to have text', 'Select...');
+				});
+
+				it('resets the control value', () => {
+					expect(ReactDOM.findDOMNode(instance).querySelector('input').value, 'to equal', '');
+				});
+			});
+
+			describe('on tapping and dragging `clear`', () => {
+				beforeEach(() => {
+					TestUtils.Simulate.touchStart(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.touchMove(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.touchEnd(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+				});
+
+				it('calls onChange with empty', () => {
+					expect(onChange, 'was not called');
+				});
+
+				it('resets the display value', () => {
+					expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching', PLACEHOLDER_SELECTOR);
 				});
 			});
 		});

--- a/test/Value-test.js
+++ b/test/Value-test.js
@@ -43,8 +43,17 @@ describe('Value component', function() {
 
 	it('requests its own removal when the remove icon is touched', function() {
 		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-value-icon');
+		TestUtils.Simulate.touchStart(selectItemIcon);
 		TestUtils.Simulate.touchEnd(selectItemIcon);
 		expect(props.onRemove, 'was called');
+	});
+
+	it('ignores its own removal when the remove icon is touched and dragged', function() {
+		var selectItemIcon = TestUtils.findRenderedDOMComponentWithClass(value, 'Select-value-icon');
+		TestUtils.Simulate.touchStart(selectItemIcon);
+		TestUtils.Simulate.touchMove(selectItemIcon);
+		TestUtils.Simulate.touchEnd(selectItemIcon);
+		expect(props.onRemove, 'was not called');
 	});
 
 	describe('without a custom click handler', function() {


### PR DESCRIPTION
This fixes #244.
Iv'e noticed PR #245 but i'm not a big fan of introducing dependencies in core infrastructure components.
This is a rather clean an minimal fix that  addresses the same issue in 3 situations:
- Dragging over the input won't toggle the options menu
- Dragging over the 'clear' icon won't clear the selection
- Dragging over the remove icon of a Value won't remove the value