### PR TITLE
Added a mobile touch event handlers

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -25,17 +25,39 @@ const Option = React.createClass({
 			window.location.href = event.target.href;
 		}
 	},
+
 	handleMouseDown (event) {
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.onSelect(this.props.option, event);
 	},
+
 	handleMouseEnter (event) {
 		this.onFocus(event);
 	},
+
 	handleMouseMove (event) {
 		this.onFocus(event);
 	},
+
+	handleTouchEnd(event){
+		// Check if the view is being dragged, In this case
+		// we don't want to fire the click event (because the user only wants to scroll)
+		if(this.dragging) return;
+
+		this.handleMouseDown(event);
+	},
+
+	handleTouchMove (event) {
+		// Set a flag that the view is being dragged
+		this.dragging = true;
+	},
+
+	handleTouchStart (event) {
+		// Set a flag that the view is not being dragged
+		this.dragging = false;
+	},
+
 	onFocus (event) {
 		if (!this.props.isFocused) {
 			this.props.onFocus(this.props.option, event);
@@ -57,6 +79,9 @@ const Option = React.createClass({
 				onMouseDown={this.handleMouseDown}
 				onMouseEnter={this.handleMouseEnter}
 				onMouseMove={this.handleMouseMove}
+				onTouchStart={this.handleTouchStart}
+				onTouchMove={this.handleTouchMove}
+				onTouchEnd={this.handleTouchEnd}
 				title={option.title}>
 				{this.props.children}
 			</div>


### PR DESCRIPTION
The `Option` component's `onMouseDown` is fired with the wrong option on mobile devices.
I suspect this happens because of faulty delegation of touch events to mouse events by the browser. 
This happens primarily on Andoird devices running chrome.  
To reproduce, choose an option from the options list which is overflowing the view (see demo gif)
![Demo](http://i.imgur.com/VLi7PnL.gif)

This fix adds explicit touch events to the Option component (like in merged PR #735)