### PR TITLE
Use camel case for autofocus prop

### DIFF
--- a/examples/src/components/States.js
+++ b/examples/src/components/States.js
@@ -51,7 +51,7 @@ var StatesField = React.createClass({
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
-				<Select ref="stateSelect" autofocus options={options} simpleValue clearable={this.state.clearable} name="selected-state" disabled={this.state.disabled} value={this.state.selectValue} onChange={this.updateValue} searchable={this.state.searchable} />
+				<Select ref="stateSelect" autoFocus options={options} simpleValue clearable={this.state.clearable} name="selected-state" disabled={this.state.disabled} value={this.state.selectValue} onChange={this.updateValue} searchable={this.state.searchable} />
 
 				<div style={{ marginTop: 14 }}>
 					<button type="button" onClick={this.focusStateSelect}>Focus Select</button>

--- a/src/Select.js
+++ b/src/Select.js
@@ -30,7 +30,7 @@ const Select = React.createClass({
 		addLabelText: React.PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
 		allowCreate: React.PropTypes.bool,          // whether to allow creation of new entries
 		autoBlur: React.PropTypes.bool,
-		autofocus: React.PropTypes.bool,            // autofocus the component on mount
+		autoFocus: React.PropTypes.bool,            // autofocus the component on mount
 		backspaceRemoves: React.PropTypes.bool,     // whether backspace removes an item if there is no text input
 		className: React.PropTypes.string,          // className for the outer element
 		clearAllText: stringOrNode,                 // title for the "clear" control when multi: true
@@ -129,7 +129,7 @@ const Select = React.createClass({
 	},
 
 	componentDidMount () {
-		if (this.props.autofocus) {
+		if (this.props.autoFocus) {
 			this.focus();
 		}
 	},


### PR DESCRIPTION
Changed the autofocus prop to camelCase to match with React's `autoFocus` attribute/prop.

[React HTML attributes](https://facebook.github.io/react/docs/tags-and-attributes.html#html-attributes)
