### PR TITLE
Fix backspace handling for non-multi select controls. Fixes #638

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -457,7 +457,7 @@ const Select = React.createClass({
 		var valueArray = this.getValueArray();
 		if (!valueArray.length) return;
 		if (valueArray[valueArray.length-1].clearableValue === false) return;
-		this.setValue(valueArray.slice(0, valueArray.length - 1));
+		this.setValue(this.props.multi ? valueArray.slice(0, valueArray.length - 1) : null);
 	},
 
 	removeValue (value) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1308,6 +1308,19 @@ describe('Select', () => {
 			]);
 		});
 
+		it('removes the last item with backspace', () => {
+
+			wrapper.setPropsForChild({
+				multi: false,
+				value: 'one'
+			});
+			onChange.reset();  // Ignore previous onChange calls
+
+			pressBackspace();
+
+			expect(onChange, 'was called with', null);
+		});
+
 		it('doesn\'t show the X if clearableValue=false', () => {
 
 			setValueProp(['two']);


### PR DESCRIPTION
**Merging this PR will resolve the following issues: #638, #746, #1596, #1680, #1215**

REPRO STEPS:

1. `npm start`
2. `open http://localhost:8000`
3. Scroll down to "Contributors (Async)". This issue impacts components with the following props: `<Select multi={false} simpleValue={false} />`
4. Check "Single Value"
5. Change the dropdown selection
6. Press backspace

EXPECTED:

<img width="434" alt="screen shot 2017-06-13 at 11 56 08 am" src="https://user-images.githubusercontent.com/2754163/27094319-56e3e086-502f-11e7-80da-b46d4d0911d7.png">

ACTUAL:

<img width="1035" alt="screen shot 2017-06-13 at 11 54 26 am" src="https://user-images.githubusercontent.com/2754163/27094288-404703c6-502f-11e7-8b2b-ad6553e39eca.png">

RESOLUTION:

Non-multi select controls return an empty array in the onChange event instead of the expected `null` value when you press backspace to clear the selection.

This is @slestang's implementation from #638 and I've added a unit test.
