### PR TITLE
Load options should receive original input [SUGGESTION]

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -110,8 +110,6 @@ const Async = React.createClass({
 		};
 	},
 	loadOptions (input) {
-		if (this.props.ignoreAccents) input = stripDiacritics(input);
-		if (this.props.ignoreCase) input = input.toLowerCase();
 		this._lastInput = input;
 		if (input.length < this.props.minimumInput) {
 			return this.resetState();


### PR DESCRIPTION
If the input does not receive the original input there is no way to do a proper lookup based on it.
The lookup filtering takes care of matching based on case and accent ignoring.
