### PR TITLE
Update hidden input for default html form behavior

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -719,8 +719,14 @@ const Select = React.createClass({
 
 	renderHiddenField (valueArray) {
 		if (!this.props.name) return;
-		let value = valueArray.map(i => stringifyValue(i[this.props.valueKey])).join(this.props.delimiter);
-		return <input type="hidden" ref="value" name={this.props.name} value={value} disabled={this.props.disabled} />;
+		return valueArray.map((item, index) => {
+			return <input key={'hidden.' + index} 
+				type="hidden" 
+				ref={'value' + index} 
+				name={this.props.name} 
+				value={stringifyValue(item[this.props.valueKey])} 
+				disabled={this.props.disabled} />
+		});
 	},
 
 	getFocusableOption (selectedOption) {


### PR DESCRIPTION
When submit form with multiple select, It will be submit as an array of field, not a single value with delimiter
```
<select id="inscompSelected" name="myInput" multiple="multiple">
               <option value="1">1</option>
               <option value="2">2</option>
               <option value="3">3</option>
               <option value="4">4</option>
</select>
```
will be sumitted as 
myInput=2
myInput=3

This change make it compatible with javascipt FormData and html form submit.