### PR TITLE
Add option to allow tab not to be considered a select action

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -74,6 +74,7 @@ const Select = React.createClass({
 		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
 		style: React.PropTypes.object,              // optional style to apply to the control
 		tabIndex: React.PropTypes.string,           // optional tab index of the control
+		tabSelectsValue: React.PropTypes.bool,      // whether to treat tabbing out while focused to be value selection
 		value: React.PropTypes.any,                 // initial field value
 		valueComponent: React.PropTypes.func,       // value component to render
 		valueKey: React.PropTypes.string,           // path of the label value in option objects
@@ -112,6 +113,7 @@ const Select = React.createClass({
 			scrollMenuIntoView: true,
 			searchable: true,
 			simpleValue: false,
+			tabSelectsValue: true,
 			valueComponent: Value,
 			valueKey: 'value',
 		};
@@ -334,7 +336,7 @@ const Select = React.createClass({
 				}
 			return;
 			case 9: // tab
-				if (event.shiftKey || !this.state.isOpen) {
+				if (event.shiftKey || !this.state.isOpen || !this.props.tabSelectsValue) {
 					return;
 				}
 				this.selectFocusedOption();

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2696,6 +2696,25 @@ describe('Select', () => {
 			});
 		});
 
+		describe('with tabSelectsValue=false', () => {
+
+			beforeEach(() => {
+
+				instance = createControl({
+					options: defaultOptions,
+					tabSelectsValue: false
+				});
+			});
+
+			it('should not accept when tab is pressed', () => {
+
+				// Search 'h', should only show 'Three'
+				typeSearchText('h');
+				pressTabToAccept();
+				expect(onChange, 'was not called');
+			});
+		});
+
 		describe('valueRenderer', () => {
 
 			var valueRenderer;


### PR DESCRIPTION
I am attempting to build a widget that has much of the keyboard interaction in common with this react-select widget (especially the multi-select variant).  The one piece that differs in my use case is that tabbing should not be considered selecting the focused option.

This pull request adds the ability to configure whether or not tabbing out of a select should be considered selecting the option.

I attempted to follow contribution guidelines, let me know if I need to change anything else.