### PR TITLE
Update required when Select gets new props

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -138,6 +138,14 @@ const Select = React.createClass({
 		}
 	},
 
+	componentWillReceiveProps(nextProps) {
+		if (this.props.value !== nextProps.value && nextProps.required) {
+			this.setState({
+				required: this.handleRequired(nextProps.value, nextProps.multi),
+			});
+		}
+	},
+
 	componentWillUpdate (nextProps, nextState) {
 		if (nextState.isOpen !== this.state.isOpen) {
 			const handler = nextState.isOpen ? nextProps.onOpen : nextProps.onClose;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2816,6 +2816,18 @@ describe('Select', () => {
 				expect(instance.state.required, 'to be true');
 			});
 
+			it('input should not have required attribute after updating the component with a value', () => {
+				wrapper = createControlWithWrapper({
+					options: defaultOptions,
+					value: '',
+					required: true
+				});
+
+				expect(instance.state.required, 'to be true');
+				wrapper.setPropsForChild({ value: 'one' });
+				expect(instance.state.required, 'to be false');
+			});
+
 		});
 
 		describe('required with multi=true', () => {


### PR DESCRIPTION
**Bug**: updating props on the Select does not update `required` in the component's state. This means that if a Select is marked as required, initially mounted with an empty value, and then a subsequent render updates the value, the field is improperly marked as being invalid upon submit.

**Solution**: when the component receives new props, re-evaluate `handleRequired` and update 'required' in the component's state.