### PR TITLE
Fix scrollMenuIntoView option

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -180,7 +180,7 @@ const Select = React.createClass({
 		if (this.props.scrollMenuIntoView && this.refs.menuContainer) {
 			var menuContainerRect = this.refs.menuContainer.getBoundingClientRect();
 			if (window.innerHeight < menuContainerRect.bottom + this.props.menuBuffer) {
-				window.scrollTo(0, window.scrollY + menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);
+				window.scrollBy(0, menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);
 			}
 		}
 		if (prevProps.disabled !== this.props.disabled) {


### PR DESCRIPTION
Switching to relative scrolling avoids two problems:
 1. IE does not support window.scrollY
 2. window.scrollTo(0, ...) scrolls to the left

This fixes #799.