### PR TITLE
Fix IE11 issue where focus is lost when scrolling through options

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -311,6 +311,7 @@ const Select = React.createClass({
 
 	handleInputBlur (event) {
  		if (this.refs.menu && document.activeElement.isEqualNode(this.refs.menu)) {
+			this.focus();
  			return;
  		}
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2252,6 +2252,31 @@ describe('Select', () => {
 				TestUtils.Simulate.blur(searchInputNode);
 				expect(onBlur, 'was called once');
 			});
+
+			it( 'should focus on the input when the menu is active', () => {
+				instance = createControl({
+					options: defaultOptions
+				});
+
+				clickArrowToOpen();
+				instance.refs.menu.focus();
+
+				var inputFocus = sinon.spy( instance.refs.input, "focus" );
+				instance.handleInputBlur();
+
+				expect( instance.refs.input.focus, 'was called once' );
+			} );
+
+			it( 'should not focus the input when menu is not active', () => {
+				instance = createControl({
+					options: defaultOptions
+				});
+
+				var inputFocus = sinon.spy( instance.refs.input, "focus" );
+				instance.handleInputBlur();
+
+				expect( instance.refs.input.focus, 'was not called' );
+			} );
 		});
 
 		describe('with onBlurResetsInput=true', () => {


### PR DESCRIPTION
This PR fixes issue #848 and the following animated gif shows the fix in action...

![bruc7pz2bb-after](https://cloud.githubusercontent.com/assets/86454/14000158/e3cef74c-f10d-11e5-938e-bcee06d3adc7.gif)

You can read more about the details of the bug in the related #848 issue and watch the broken behavior there (animated gif) 