### PR TITLE
feat(Option): support addition className

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -66,6 +66,7 @@ const Select = React.createClass({
 		onMenuScrollToBottom: React.PropTypes.func, // fires when the menu is scrolled to the bottom; can be used to paginate options
 		onOpen: React.PropTypes.func,               // fires when the menu is opened
 		onValueClick: React.PropTypes.func,         // onClick handler for value labels: function (value, event) {}
+		optionClassName: React.PropTypes.string,    // additional class(es) to apply to the <Option /> elements
 		optionComponent: React.PropTypes.func,      // option component to render in dropdown
 		optionRenderer: React.PropTypes.func,       // optionRenderer: function (option) {}
 		options: React.PropTypes.array,             // array of options
@@ -711,7 +712,7 @@ const Select = React.createClass({
 				let isSelected = valueArray && valueArray.indexOf(option) > -1;
 				let isFocused = option === focusedOption;
 				let optionRef = isFocused ? 'focused' : null;
-				let optionClass = classNames({
+				let optionClass = classNames(this.props.optionClassName, {
 					'Select-option': true,
 					'is-selected': isSelected,
 					'is-focused': isFocused,


### PR DESCRIPTION
Hello @JedWatson 

I'm using https://github.com/ftlabs/fastclick to remove the 300ms click delay on iOS devices, but I'm getting incompatibilities with `react-select` which is listening on `touchEnd` event.

Fastclick can ignore certain elements but they need a `needsclick` class (https://github.com/ftlabs/fastclick#ignore-certain-elements-with-needsclick)

This PR adds the support to pass custom classnames to the Option element, I could have used the `optionComponent` prop but I find it overkill for this use case :+1: