### PR TITLE
Export Async

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -861,3 +861,4 @@ const Select = React.createClass({
 });
 
 export default Select;
+export Async;


### PR DESCRIPTION
Documentation suggests using `Select.Async` component but the `Async` is not exported by default.