### PR TITLE
Added ability to override resetValue when clearing the control

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Check out the demo site for a more complete example of this.
 	clearable 	|	bool	|	true		|	should it be possible to reset value
 	clearAllText 	|	string	|	'Clear all'	|	title for the "clear" control when `multi` is true
 	clearValueText 	|	string	|	'Clear value'	|	title for the "clear" control
+	resetValue 	|	any	|	null	|	value to use when you clear the control
 	delimiter 	|	string	|	','		|	delimiter to use to join multiple values
 	disabled 	|	bool	|	false		|	whether the Select is disabled or not
 	filterOption 	|	func	|	undefined	|	method to filter a single option: `function(option, filterString)`

--- a/src/Select.js
+++ b/src/Select.js
@@ -75,6 +75,7 @@ const Select = React.createClass({
 		options: React.PropTypes.array,             // array of options
 		placeholder: stringOrNode,                  // field placeholder, displayed when there's no value
 		required: React.PropTypes.bool,             // applies HTML5 required attribute when needed
+		resetValue: React.PropTypes.any,						// value to use when you clear the control
 		scrollMenuIntoView: React.PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
 		searchable: React.PropTypes.bool,           // whether to enable searching feature or not
 		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
@@ -119,6 +120,7 @@ const Select = React.createClass({
 			optionComponent: Option,
 			placeholder: 'Select...',
 			required: false,
+			resetValue: null,
 			scrollMenuIntoView: true,
 			searchable: true,
 			simpleValue: false,
@@ -500,7 +502,7 @@ const Select = React.createClass({
 		}
 		event.stopPropagation();
 		event.preventDefault();
-		this.setValue(null);
+		this.setValue(this.props.resetValue);
 		this.setState({
 			isOpen: false,
 			inputValue: '',

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1560,6 +1560,25 @@ describe('Select', () => {
 				});
 			});
 
+			describe('on clicking `clear` with a custom resetValue', () => {
+				beforeEach(() => {
+					createControlWithWrapper({
+						clearable: true,
+						options: defaultOptions,
+						value: 'three',
+						resetValue: 'reset'
+					});
+
+					expect(ReactDOM.findDOMNode(instance), 'queried for', DISPLAYED_SELECTION_SELECTOR,
+						'to have items satisfying', 'to have text', 'Three');
+				});
+
+				it('calls onChange with a custom resetValue', () => {
+					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					expect(onChange, 'was called with', 'reset');
+				});
+			});
+
 			describe('on tapping and dragging `clear`', () => {
 				beforeEach(() => {
 					TestUtils.Simulate.touchStart(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));


### PR DESCRIPTION
Currently when you clear the control it sets the value to null, which is a little bit opinionated. I think it would be useful to be able to override the value with props.

I had a use case when I needed to set the value to 'unset'. I also assume that it may be required to reset to 0 or ''.