### PR TITLE
Fix for #841 : replace isEqualNode by strict equality

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -323,7 +323,7 @@ const Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
-		if (this.refs.menu && document.activeElement.isEqualNode(this.refs.menu)) {
+		if (this.refs.menu && document.activeElement === this.refs.menu) {
 			this.focus();
 			return;
 		}


### PR DESCRIPTION
Fix for #841 IsEqualNode is not available in IE8 and cannot be shimmed.