### PR TITLE
always open on focus option

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Check out the demo site for a more complete example of this.
 	autosize  | bool | true  | If enabled, the input will expand as the length of its value increases
 	autoBlur	|	bool | false | Blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices
 	allowCreate	|	bool	|	false		|	allow new options to be created in multi mode (displays an "Add \<option> ?" item when a value not already in the `options` array is entered)
+	alwaysOpenOnFocus | bool | false | open the options menu when the input gets focus (requires searchable = true)
 	autoload 	|	bool	|	true		|	whether to auto-load the default async options set
 	backspaceRemoves 	|	bool	|	true	|	whether pressing backspace removes the last item when there is no input value
 	cache	|	bool	|	true	|	enables the options cache for `asyncOptions` (default: `true`)

--- a/src/Select.js
+++ b/src/Select.js
@@ -29,6 +29,7 @@ const Select = React.createClass({
 	propTypes: {
 		addLabelText: React.PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
 		allowCreate: React.PropTypes.bool,          // whether to allow creation of new entries
+		alwaysOpenOnFocus: React.PropTypes.bool,		// always open options menu on focus
 		autoBlur: React.PropTypes.bool,
 		autofocus: React.PropTypes.bool,            // autofocus the component on mount
 		autosize: React.PropTypes.bool,							// whether to enable autosizing or not
@@ -310,7 +311,7 @@ const Select = React.createClass({
 	},
 
 	handleInputFocus (event) {
-		var isOpen = this.state.isOpen || this._openAfterFocus;
+		var isOpen = this.state.isOpen || this._openAfterFocus || this.props.alwaysOpenOnFocus;
 		if (this.props.onFocus) {
 			this.props.onFocus(event);
 		}


### PR DESCRIPTION
`alwaysOpenOnFocus` prop that opens the options if the input gets focus in any way (including tabbing and clicking the matching label) when set to true