### PR TITLE
Add option for custom input renderer function

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -45,6 +45,7 @@ const Select = React.createClass({
 		ignoreAccents: React.PropTypes.bool,        // whether to strip diacritics when filtering
 		ignoreCase: React.PropTypes.bool,           // whether to perform case-insensitive filtering
 		inputProps: React.PropTypes.object,         // custom attributes for the Input
+		inputRenderer: React.PropTypes.func,        // returns a custom input component
 		isLoading: React.PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
 		joinValues: React.PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
 		labelKey: React.PropTypes.string,           // path of the label value in option objects
@@ -607,49 +608,53 @@ const Select = React.createClass({
 	},
 
 	renderInput (valueArray) {
-		var className = classNames('Select-input', this.props.inputProps.className);
-		if (this.props.disabled || !this.props.searchable) {
+		if (this.props.inputRenderer) {
+			return this.props.inputRenderer();
+		} else {
+			var className = classNames('Select-input', this.props.inputProps.className);
+			if (this.props.disabled || !this.props.searchable) {
+				return (
+					<div
+						{...this.props.inputProps}
+						className={className}
+						tabIndex={this.props.tabIndex || 0}
+						onBlur={this.handleInputBlur}
+						onFocus={this.handleInputFocus}
+						ref="input"
+						style={{ border: 0, width: 1, display:'inline-block' }}/>
+				);
+			}
+			if (this.props.autosize) {
+				return (
+					<Input
+						{...this.props.inputProps}
+						className={className}
+						tabIndex={this.props.tabIndex}
+						onBlur={this.handleInputBlur}
+						onChange={this.handleInputChange}
+						onFocus={this.handleInputFocus}
+						minWidth="5"
+						ref="input"
+						required={this.state.required}
+						value={this.state.inputValue}
+					/>
+				);
+			}
 			return (
-				<div
-					{...this.props.inputProps}
-					className={className}
-					tabIndex={this.props.tabIndex || 0}
-					onBlur={this.handleInputBlur}
-					onFocus={this.handleInputFocus}
-					ref="input"
-					style={{ border: 0, width: 1, display:'inline-block' }}/>
+				<div className={ className }>
+					<input
+						{...this.props.inputProps}
+						tabIndex={this.props.tabIndex}
+						onBlur={this.handleInputBlur}
+						onChange={this.handleInputChange}
+						onFocus={this.handleInputFocus}
+						ref="input"
+						required={this.state.required}
+						value={this.state.inputValue}
+					/>
+				</div>
 			);
 		}
-		if (this.props.autosize) {
-			return (
-				<Input
-					{...this.props.inputProps}
-					className={className}
-					tabIndex={this.props.tabIndex}
-					onBlur={this.handleInputBlur}
-					onChange={this.handleInputChange}
-					onFocus={this.handleInputFocus}
-					minWidth="5"
-					ref="input"
-					required={this.state.required}
-					value={this.state.inputValue}
-				/>
-			);
-		}
-		return (
-			<div className={ className }>
-				<input
-					{...this.props.inputProps}
-					tabIndex={this.props.tabIndex}
-					onBlur={this.handleInputBlur}
-					onChange={this.handleInputChange}
-					onFocus={this.handleInputFocus}
-					ref="input"
-					required={this.state.required}
-					value={this.state.inputValue}
-				/>
-			</div>
-		);
 	},
 
 	renderClear () {


### PR DESCRIPTION
This partially mimics the menuRenderer, valueRenderer and optionRenderer props and allows the user to use a custom input in place of the existing `renderInput()` code. The existing behavior is retained verbatim if the inputRenderer prop is not set, and delegates to the provided function otherwise. Changes in behavior should be minimal and isolated.

I haven't provided updates to the documentation for this change as yet. If the maintainers want to pull this change into master, I'll gladly make the necessary changes myself.