### PR TITLE
Allow input to be updated with onInputChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ menuRenderer({ focusedOption, focusOption, labelKey, options, selectValue, value
 
 Check out the demo site for a more complete example of this.
 
+### Updating input values with onInputChange
+
+You can manipulate the input using the onInputChange and returning a new value.
+
+```js
+function cleanInput(inputValue) {
+	  // Strip all non-number characters from the input
+    return inputValue.replace(/[^0-9]/g, "");
+}   
+
+<Select
+    name="form-field-name"
+    onInputChange={cleanInput}
+/>
+```
+
 ### Further options
 
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -171,13 +171,6 @@ const Select = React.createClass({
 			this.hasScrolledToOption = false;
 		}
 
-		if (prevState.inputValue !== this.state.inputValue && this.props.onInputChange) {
-			var nextState = this.props.onInputChange(this.state.inputValue);
-			var newInput = (nextState !== undefined) ? nextState : null;
-			if (newInput !== null) {
-				this.setState({ inputValue: newInput });
-			}
-		}
 		if (this._scrollToFocusedOptionOnUpdate && this.refs.focused && this.refs.menu) {
 			this._scrollToFocusedOptionOnUpdate = false;
 			var focusedDOM = ReactDOM.findDOMNode(this.refs.focused);
@@ -347,10 +340,18 @@ const Select = React.createClass({
 	},
 
 	handleInputChange (event) {
+		let newInputValue = event.target.value;
+		if (this.state.inputValue !== event.target.value && this.props.onInputChange) {
+			let nextState = this.props.onInputChange(newInputValue);
+			// Note: != used deliberately here to catch undefined and null
+			if (nextState != null) {
+				newInputValue = '' + nextState;
+			}
+		}
 		this.setState({
 			isOpen: true,
 			isPseudoFocused: false,
-			inputValue: event.target.value,
+			inputValue: newInputValue
 		});
 	},
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -172,7 +172,11 @@ const Select = React.createClass({
 		}
 
 		if (prevState.inputValue !== this.state.inputValue && this.props.onInputChange) {
-			this.props.onInputChange(this.state.inputValue);
+			var nextState = this.props.onInputChange(this.state.inputValue);
+			var newInput = (nextState !== undefined) ? nextState : null;
+			if (newInput !== null) {
+				this.setState({ inputValue: newInput });
+			}
 		}
 		if (this._scrollToFocusedOptionOnUpdate && this.refs.focused && this.refs.menu) {
 			this._scrollToFocusedOptionOnUpdate = false;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -127,31 +127,6 @@ describe('Select', () => {
 
 	};
 
-	var createControlWithChange = (props, options) => {
-
-		options = options || {};
-
-		onChange = sinon.spy();
-		onInputChange = sinon.spy(function(inputValue) {
-			if (inputValue === '1') {
-				return '2';
-			}
-		});
-		// Render an instance of the component
-		instance = TestUtils.renderIntoDocument(
-			<Select
-				onChange={onChange}
-				onInputChange={onInputChange}
-				{...props}
-				/>
-		);
-		if (options.initialFocus !== false) {
-			findAndFocusInputControl();
-		}
-		return instance;
-
-	};
-
 	var setValueProp = value => wrapper.setPropsForChild({ value });
 
 	var createControlWithWrapper = (props, options) => {
@@ -408,6 +383,8 @@ describe('Select', () => {
 	});
 
 	describe('with a return from onInputChange', () => {
+
+		let onInputChangeOverride;
 		beforeEach(() => {
 			options = [
 				{ value: 'one', label: 'One' },
@@ -415,22 +392,46 @@ describe('Select', () => {
 				{ value: 'three', label: 'Three' }
 			];
 
-			instance = createControlWithChange({
+			onInputChangeOverride = sinon.stub();
+
+			wrapper = createControlWithWrapper({
 				name: 'field-onChange',
 				value: 'one',
 				options: options,
 				simpleValue: true,
+				onInputChange: onInputChangeOverride
 			});
 		});
 
 		it('should change the value when onInputChange returns a value', () => {
+			onInputChangeOverride.returns('2');
 			typeSearchText('1');
 			expect(instance.state.inputValue, 'to equal', '2');
 		});
 
-		it('should return the input when onInputChange does not return a value', () => {
+		it('should return the input when onInputChange returns undefined', () => {
+			onInputChangeOverride.returns(undefined);  // Not actually necessary as undefined is the default, but makes this clear
 			typeSearchText('Test');
 			expect(instance.state.inputValue, 'to equal', 'Test');
+		});
+
+		it('should return the input when onInputChange returns null', () => {
+			onInputChangeOverride.returns(null);
+			typeSearchText('Test');
+			expect(instance.state.inputValue, 'to equal', 'Test');
+		});
+
+		it('should update the input when onInputChange returns a number', () => {
+			onInputChangeOverride.returns(5);
+			typeSearchText('Test');
+			expect(instance.state.inputValue, 'to equal', '5');
+		});
+
+		it('displays the new value in the input box', () => {
+			onInputChangeOverride.returns('foo');
+			typeSearchText('Test');
+			const displayedValue = ReactDOM.findDOMNode(instance).querySelector('.Select-input input').value;
+			expect(displayedValue, 'to equal', 'foo');
 		});
 	});
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -127,6 +127,31 @@ describe('Select', () => {
 
 	};
 
+	var createControlWithChange = (props, options) => {
+
+		options = options || {};
+
+		onChange = sinon.spy();
+		onInputChange = sinon.spy(function(inputValue) {
+			if (inputValue === '1') {
+				return '2';
+			}
+		});
+		// Render an instance of the component
+		instance = TestUtils.renderIntoDocument(
+			<Select
+				onChange={onChange}
+				onInputChange={onInputChange}
+				{...props}
+				/>
+		);
+		if (options.initialFocus !== false) {
+			findAndFocusInputControl();
+		}
+		return instance;
+
+	};
+
 	var setValueProp = value => wrapper.setPropsForChild({ value });
 
 	var createControlWithWrapper = (props, options) => {
@@ -379,6 +404,33 @@ describe('Select', () => {
 			expect(inputNode, 'to have attributes', {
 				required: undefined
 			});
+		});
+	});
+
+	describe('with a return from onInputChange', () => {
+		beforeEach(() => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' }
+			];
+
+			instance = createControlWithChange({
+				name: 'field-onChange',
+				value: 'one',
+				options: options,
+				simpleValue: true,
+			});
+		});
+
+		it('should change the value when onInputChange returns a value', () => {
+			typeSearchText('1');
+			expect(instance.state.inputValue, 'to equal', '2');
+		});
+
+		it('should return the input when onInputChange does not return a value', () => {
+			typeSearchText('Test');
+			expect(instance.state.inputValue, 'to equal', 'Test');
 		});
 	});
 
@@ -1467,7 +1519,6 @@ describe('Select', () => {
 	});
 
 	describe('with props', () => {
-
 
 		describe('className', () => {
 


### PR DESCRIPTION
Allows the input to be modified by returning a value from `onInputChange`. 

Refs #893.