### PR TITLE
Clarify behavior in NumericSelect example

### DIFF
--- a/examples/src/components/NumericSelect.js
+++ b/examples/src/components/NumericSelect.js
@@ -73,11 +73,11 @@ var ValuesAsNumbersField = React.createClass({
 					</label>
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" checked={this.state.matchValue} onChange={this.onChangeMatchValue} />
-						<span className="checkbox-label">Match value only</span>
+						<span className="checkbox-label">Match value</span>
 					</label>
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" checked={this.state.matchLabel} onChange={this.onChangeMatchLabel} />
-						<span className="checkbox-label">Match label only</span>
+						<span className="checkbox-label">Match label</span>
 					</label>
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" checked={this.state.matchPos === 'start'} onChange={this.onChangeMatchStart} />


### PR DESCRIPTION
The actual behavior of the example is:

```
[x] Match value only
[ ] Match label only
```
^ matches value only

```
[ ] Match value only
[x] Match label only
```
^ matches label only

```
[ ] Match value only
[ ] Match label only
```
^ matches both

```
[x] Match value only
[x] Match label only
```
^ matches both

So, the checkboxes each indicate that their respective attribute is matched or not matched, independent of the other checkbox (except when both options are unchecked).  I think removing the word "only" from the labels makes them more accurate.

Or you could make it three radio buttons:
```
(*) Match value only
( ) Match label only
( ) Match both
```