### PR TITLE
Add support for searchingLabel props.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ function cleanInput(inputValue) {
 	placeholder 	|	string\|node	|	'Select ...'	|	field placeholder, displayed when there's no value
 	scrollMenuIntoView |	bool	|	true		|	whether the viewport will shift to display the entire menu when engaged
 	searchable 	|	bool	|	true		|	whether to enable searching feature or not
-	searchingText	|	string	|	'Searching...'	|	message to display whilst options are loading via asyncOptions, or when `isLoading` is true
+	searchingLabel	|	string\|node	|	'Searching...'	|	message to display whilst options are loading via asyncOptions, or when `isLoading` is true
 	searchPromptLabel |	string\|node	|	'Type to search'	|	label to prompt for search input
 	tabSelectsValue	|	bool	|	true	|	whether to select the currently focused value when the `[tab]` key is pressed
 	value 		|	any	|	undefined	|	initial field value

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ function cleanInput(inputValue) {
 	multi 		|	bool	|	undefined	|	multi-value input
 	name 		|	string	|	undefined	|	field name, for hidden `<input />` tag
 	newOptionCreator	|	func	|	undefined	|	factory to create new options when `allowCreate` is true
-	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results or a falsy value to hide it
+	noResultsLabel 	|	string\|node |	'No results found'	|	placeholder displayed when there are no matching search results or a falsy value to hide it
 	onBlur 		|	func	|	undefined	|	onBlur handler: `function(event) {}`
 	onBlurResetsInput	|	bool	|	true	|	whether to clear input on blur or not
 	onChange 	|	func	|	undefined	|	onChange handler: `function(newValue) {}`
@@ -318,7 +318,7 @@ function cleanInput(inputValue) {
 	scrollMenuIntoView |	bool	|	true		|	whether the viewport will shift to display the entire menu when engaged
 	searchable 	|	bool	|	true		|	whether to enable searching feature or not
 	searchingText	|	string	|	'Searching...'	|	message to display whilst options are loading via asyncOptions, or when `isLoading` is true
-	searchPromptText |	string\|node	|	'Type to search'	|	label to prompt for search input
+	searchPromptLabel |	string\|node	|	'Type to search'	|	label to prompt for search input
 	tabSelectsValue	|	bool	|	true	|	whether to select the currently focused value when the `[tab]` key is pressed
 	value 		|	any	|	undefined	|	initial field value
 	valueKey	|	string	|	'value'		|	the option property to use for the value

--- a/lib/Async.js
+++ b/lib/Async.js
@@ -68,6 +68,7 @@ var Async = _react2['default'].createClass({
 		placeholder: stringOrNode, // field placeholder, displayed when there's no value (shared with Select)
 		searchPromptText: stringOrNode, // label to prompt for search input
 		searchPromptLabel: stringOrNode, // label to prompt for search input
+		searchingLabel: stringOrNode, // message to display while options are loading
 		searchingText: _react2['default'].PropTypes.string },
 	// message to display while options are loading
 	getDefaultProps: function getDefaultProps() {
@@ -77,7 +78,7 @@ var Async = _react2['default'].createClass({
 			ignoreCase: true,
 			loadingPlaceholder: 'Loading...',
 			minimumInput: 0,
-			searchingText: 'Searching...',
+			searchingLabel: 'Searching...',
 			searchPromptLabel: 'Type to search'
 		};
 	},
@@ -92,6 +93,10 @@ var Async = _react2['default'].createClass({
 		this._lastInput = '';
 	},
 	componentDidMount: function componentDidMount() {
+		if (this.props.searchingText) {
+			console.warn('searchingText is deprecated and will be removed. Please use searchingLabel');
+		}
+
 		if (this.props.searchPromptText) {
 			console.warn('searchPromptText is deprecated and will be removed. Please use searchPromptLabel');
 		}
@@ -157,11 +162,14 @@ var Async = _react2['default'].createClass({
 		return thenPromise(this.props.loadOptions(input, responseHandler), responseHandler);
 	},
 	render: function render() {
+		var searchingText = this.props.searchingText;
+		var searchingLabel = this.props.searchingLabel;
 		var noResultsText = this.props.noResultsText;
 		var noResultsLabel = this.props.noResultsLabel;
 		var searchPromptText = this.props.searchPromptText;
 		var searchPromptLabel = this.props.searchPromptLabel;
 
+		if (!searchingLabel) searchingLabel = searchingText;
 		if (!noResultsLabel) noResultsLabel = noResultsText;
 		if (!searchPromptLabel) searchPromptLabel = searchPromptText;
 
@@ -173,9 +181,8 @@ var Async = _react2['default'].createClass({
 		var placeholder = isLoading ? this.props.loadingPlaceholder : this.props.placeholder;
 		if (!options.length) {
 			if (this._lastInput.length < this.props.minimumInput) noResultsLabel = searchPromptLabel;
-			if (isLoading) noResultsLabel = this.props.searchingText;
+			if (isLoading) noResultsLabel = searchingLabel;
 		}
-
 		return _react2['default'].createElement(_Select2['default'], _extends({}, this.props, {
 			ref: 'select',
 			isLoading: isLoading,

--- a/lib/Async.js
+++ b/lib/Async.js
@@ -63,9 +63,11 @@ var Async = _react2['default'].createClass({
 		loadingPlaceholder: _react2['default'].PropTypes.string, // replaces the placeholder while options are loading
 		minimumInput: _react2['default'].PropTypes.number, // the minimum number of characters that trigger loadOptions
 		noResultsText: stringOrNode, // placeholder displayed when there are no matching search results (shared with Select)
+		noResultsLabel: stringOrNode, // placeholder displayed when there are no matching search results (shared with Select)
 		onInputChange: _react2['default'].PropTypes.func, // onInputChange handler: function (inputValue) {}
 		placeholder: stringOrNode, // field placeholder, displayed when there's no value (shared with Select)
 		searchPromptText: stringOrNode, // label to prompt for search input
+		searchPromptLabel: stringOrNode, // label to prompt for search input
 		searchingText: _react2['default'].PropTypes.string },
 	// message to display while options are loading
 	getDefaultProps: function getDefaultProps() {
@@ -76,7 +78,7 @@ var Async = _react2['default'].createClass({
 			loadingPlaceholder: 'Loading...',
 			minimumInput: 0,
 			searchingText: 'Searching...',
-			searchPromptText: 'Type to search'
+			searchPromptLabel: 'Type to search'
 		};
 	},
 	getInitialState: function getInitialState() {
@@ -90,6 +92,10 @@ var Async = _react2['default'].createClass({
 		this._lastInput = '';
 	},
 	componentDidMount: function componentDidMount() {
+		if (this.props.searchPromptText) {
+			console.warn('searchPromptText is deprecated and will be removed. Please use searchPromptLabel');
+		}
+
 		this.loadOptions('');
 	},
 	componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
@@ -152,6 +158,13 @@ var Async = _react2['default'].createClass({
 	},
 	render: function render() {
 		var noResultsText = this.props.noResultsText;
+		var noResultsLabel = this.props.noResultsLabel;
+		var searchPromptText = this.props.searchPromptText;
+		var searchPromptLabel = this.props.searchPromptLabel;
+
+		if (!noResultsLabel) noResultsLabel = noResultsText;
+		if (!searchPromptLabel) searchPromptLabel = searchPromptText;
+
 		var _state = this.state;
 		var isLoading = _state.isLoading;
 		var options = _state.options;
@@ -159,13 +172,14 @@ var Async = _react2['default'].createClass({
 		if (this.props.isLoading) isLoading = true;
 		var placeholder = isLoading ? this.props.loadingPlaceholder : this.props.placeholder;
 		if (!options.length) {
-			if (this._lastInput.length < this.props.minimumInput) noResultsText = this.props.searchPromptText;
-			if (isLoading) noResultsText = this.props.searchingText;
+			if (this._lastInput.length < this.props.minimumInput) noResultsLabel = searchPromptLabel;
+			if (isLoading) noResultsLabel = this.props.searchingText;
 		}
+
 		return _react2['default'].createElement(_Select2['default'], _extends({}, this.props, {
 			ref: 'select',
 			isLoading: isLoading,
-			noResultsText: noResultsText,
+			noResultsLabel: noResultsLabel,
 			onInputChange: this.loadOptions,
 			options: options,
 			placeholder: placeholder

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -87,6 +87,7 @@ var Select = _react2['default'].createClass({
 		name: _react2['default'].PropTypes.string, // generates a hidden <input /> tag with this field name for html forms
 		newOptionCreator: _react2['default'].PropTypes.func, // factory to create new options when allowCreate set
 		noResultsText: stringOrNode, // placeholder displayed when there are no matching search results
+		noResultsLabel: stringOrNode, // placeholder displayed when there are no matching search results
 		onBlur: _react2['default'].PropTypes.func, // onBlur handler: function (event) {}
 		onBlurResetsInput: _react2['default'].PropTypes.bool, // whether input is cleared on blur
 		onChange: _react2['default'].PropTypes.func, // onChange handler: function (newValue) {}
@@ -143,7 +144,7 @@ var Select = _react2['default'].createClass({
 			matchProp: 'any',
 			menuBuffer: 0,
 			multi: false,
-			noResultsText: 'No results found',
+			noResultsLabel: 'No results found',
 			onBlurResetsInput: true,
 			openAfterFocus: false,
 			optionComponent: _Option2['default'],
@@ -181,6 +182,10 @@ var Select = _react2['default'].createClass({
 	},
 
 	componentDidMount: function componentDidMount() {
+		if (this.props.noResultsText) {
+			console.warn('noResultsText is deprecated and will be removed. Please use noResultsLabel');
+		}
+
 		if (this.props.autofocus) {
 			this.focus();
 		}
@@ -785,6 +790,10 @@ var Select = _react2['default'].createClass({
 		}
 	},
 
+	noResultsLabel: function noResultsLabel() {
+		return this.props.noResultsText ? this.props.noResultsText : this.props.noResultsLabel;
+	},
+
 	renderMenu: function renderMenu(options, valueArray, focusedOption) {
 		var _this4 = this;
 
@@ -836,11 +845,11 @@ var Select = _react2['default'].createClass({
 
 				if (typeof _ret === 'object') return _ret.v;
 			}
-		} else if (this.props.noResultsText) {
+		} else if (this.noResultsLabel()) {
 			return _react2['default'].createElement(
 				'div',
 				{ className: 'Select-noresults' },
-				this.props.noResultsText
+				this.noResultsLabel()
 			);
 		} else {
 			return null;

--- a/src/Async.js
+++ b/src/Async.js
@@ -54,8 +54,9 @@ const Async = React.createClass({
 		noResultsLabel: stringOrNode,                    // placeholder displayed when there are no matching search results (shared with Select)
 		onInputChange: React.PropTypes.func,            // onInputChange handler: function (inputValue) {}
 		placeholder: stringOrNode,                      // field placeholder, displayed when there's no value (shared with Select)
-		searchPromptText: stringOrNode,			        // label to prompt for search input
+		searchPromptText: stringOrNode,       // label to prompt for search input
 		searchPromptLabel: stringOrNode,			    // label to prompt for search input
+		searchingLabel: stringOrNode,          // message to display while options are loading
 		searchingText: React.PropTypes.string,          // message to display while options are loading
 	},
 	getDefaultProps () {
@@ -65,7 +66,7 @@ const Async = React.createClass({
 			ignoreCase: true,
 			loadingPlaceholder: 'Loading...',
 			minimumInput: 0,
-			searchingText: 'Searching...',
+			searchingLabel: 'Searching...',
 			searchPromptLabel: 'Type to search'
 		};
 	},
@@ -80,6 +81,10 @@ const Async = React.createClass({
 		this._lastInput = '';
 	},
 	componentDidMount () {
+		if (this.props.searchingText) {
+			console.warn('searchingText is deprecated and will be removed. Please use searchingLabel');
+		}
+
 		if(this.props.searchPromptText){
 			console.warn('searchPromptText is deprecated and will be removed. Please use searchPromptLabel');
 		}
@@ -143,11 +148,14 @@ const Async = React.createClass({
 		return thenPromise(this.props.loadOptions(input, responseHandler), responseHandler);
 	},
 	render () {
+		let { searchingText } = this.props;
+		let { searchingLabel } = this.props;
 		let { noResultsText } = this.props;
 		let { noResultsLabel } = this.props;
 		let { searchPromptText } = this.props;
 		let { searchPromptLabel } = this.props;
 
+		if (!searchingLabel) searchingLabel =  searchingText;
 		if (!noResultsLabel) noResultsLabel = noResultsText;
 		if (!searchPromptLabel) searchPromptLabel = searchPromptText;
 
@@ -156,9 +164,8 @@ const Async = React.createClass({
 		let placeholder = isLoading ? this.props.loadingPlaceholder : this.props.placeholder;
 		if (!options.length) {
 			if (this._lastInput.length < this.props.minimumInput) noResultsLabel = searchPromptLabel;
-			if (isLoading) noResultsLabel = this.props.searchingText;
+			if (isLoading) noResultsLabel = searchingLabel;
 		}
-
 		return (
 			<Select
 				{...this.props}

--- a/src/Async.js
+++ b/src/Async.js
@@ -51,9 +51,11 @@ const Async = React.createClass({
 		loadingPlaceholder: React.PropTypes.string,     // replaces the placeholder while options are loading
 		minimumInput: React.PropTypes.number,           // the minimum number of characters that trigger loadOptions
 		noResultsText: stringOrNode,                    // placeholder displayed when there are no matching search results (shared with Select)
+		noResultsLabel: stringOrNode,                    // placeholder displayed when there are no matching search results (shared with Select)
 		onInputChange: React.PropTypes.func,            // onInputChange handler: function (inputValue) {}
 		placeholder: stringOrNode,                      // field placeholder, displayed when there's no value (shared with Select)
-		searchPromptText: stringOrNode,       // label to prompt for search input
+		searchPromptText: stringOrNode,			        // label to prompt for search input
+		searchPromptLabel: stringOrNode,			    // label to prompt for search input
 		searchingText: React.PropTypes.string,          // message to display while options are loading
 	},
 	getDefaultProps () {
@@ -64,7 +66,7 @@ const Async = React.createClass({
 			loadingPlaceholder: 'Loading...',
 			minimumInput: 0,
 			searchingText: 'Searching...',
-			searchPromptText: 'Type to search',
+			searchPromptLabel: 'Type to search'
 		};
 	},
 	getInitialState () {
@@ -78,6 +80,10 @@ const Async = React.createClass({
 		this._lastInput = '';
 	},
 	componentDidMount () {
+		if(this.props.searchPromptText){
+			console.warn('searchPromptText is deprecated and will be removed. Please use searchPromptLabel');
+		}
+
 		this.loadOptions('');
 	},
 	componentWillReceiveProps (nextProps) {
@@ -138,19 +144,27 @@ const Async = React.createClass({
 	},
 	render () {
 		let { noResultsText } = this.props;
+		let { noResultsLabel } = this.props;
+		let { searchPromptText } = this.props;
+		let { searchPromptLabel } = this.props;
+
+		if (!noResultsLabel) noResultsLabel = noResultsText;
+		if (!searchPromptLabel) searchPromptLabel = searchPromptText;
+
 		let { isLoading, options } = this.state;
 		if (this.props.isLoading) isLoading = true;
 		let placeholder = isLoading ? this.props.loadingPlaceholder : this.props.placeholder;
 		if (!options.length) {
-			if (this._lastInput.length < this.props.minimumInput) noResultsText = this.props.searchPromptText;
-			if (isLoading) noResultsText = this.props.searchingText;
+			if (this._lastInput.length < this.props.minimumInput) noResultsLabel = searchPromptLabel;
+			if (isLoading) noResultsLabel = this.props.searchingText;
 		}
+
 		return (
 			<Select
 				{...this.props}
 				ref="select"
 				isLoading={isLoading}
-				noResultsText={noResultsText}
+				noResultsLabel={noResultsLabel}
 				onInputChange={this.loadOptions}
 				options={options}
 				placeholder={placeholder}

--- a/src/Select.js
+++ b/src/Select.js
@@ -59,6 +59,7 @@ const Select = React.createClass({
 		name: React.PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
 		newOptionCreator: React.PropTypes.func,     // factory to create new options when allowCreate set
 		noResultsText: stringOrNode,                // placeholder displayed when there are no matching search results
+		noResultsLabel: stringOrNode,                // placeholder displayed when there are no matching search results
 		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
 		onBlurResetsInput: React.PropTypes.bool,    // whether input is cleared on blur
 		onChange: React.PropTypes.func,             // onChange handler: function (newValue) {}
@@ -115,7 +116,7 @@ const Select = React.createClass({
 			matchProp: 'any',
 			menuBuffer: 0,
 			multi: false,
-			noResultsText: 'No results found',
+			noResultsLabel: 'No results found',
 			onBlurResetsInput: true,
 			openAfterFocus: false,
 			optionComponent: Option,
@@ -153,6 +154,10 @@ const Select = React.createClass({
 	},
 
 	componentDidMount () {
+		if(this.props.noResultsText){
+			console.warn('noResultsText is deprecated and will be removed. Please use noResultsLabel');
+		}
+
 		if (this.props.autofocus) {
 			this.focus();
 		}
@@ -739,6 +744,10 @@ const Select = React.createClass({
 		}
 	},
 
+	noResultsLabel: function noResultsLabel() {
+		return this.props.noResultsText ? this.props.noResultsText : this.props.noResultsLabel;
+	},
+
 	renderMenu (options, valueArray, focusedOption) {
 		if (options && options.length) {
 			if (this.props.menuRenderer) {
@@ -782,10 +791,10 @@ const Select = React.createClass({
 					);
 				});
 			}
-		} else if (this.props.noResultsText) {
+		} else if (this.noResultsLabel()) {
 			return (
 				<div className="Select-noresults">
-					{this.props.noResultsText}
+					{this.noResultsLabel()}
 				</div>
 			);
 		} else {

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -60,7 +60,7 @@ describe('Async', () => {
 		it('renders the select with no options', () => {
 
 			return expect(renderer, 'to have rendered',
-				<Select options={ [] } noResultsText="Type to search"/>);
+				<Select options={ [] } noResultsLabel="Type to search"/>);
 		});
 
 		it('calls the loadOptions for each input', () => {
@@ -78,7 +78,7 @@ describe('Async', () => {
 				<Select
 					isLoading
 					placeholder="Loading..."
-					noResultsText="Searching..."
+					noResultsLabel="Searching..."
 				/>);
 		});
 
@@ -99,7 +99,7 @@ describe('Async', () => {
 					<Select
 						isLoading={false}
 						placeholder="Select..."
-						noResultsText="No results found"
+						noResultsLabel="No results found"
 						options={ [ { value: 1, label: 'test' } ] }
 					/>);
 			});
@@ -130,7 +130,7 @@ describe('Async', () => {
 					<Select
 						isLoading={false}
 						placeholder="Select..."
-						noResultsText="No results found"
+						noResultsLabel="No results found"
 						options={ [ { value: 2, label: 'test' } ] }
 					/>);
 			});
@@ -199,7 +199,7 @@ describe('Async', () => {
 			return expect(renderer, 'to have rendered',
 			<Select
 				isLoading
-				noResultsText="Searching..."
+				noResultsLabel="Searching..."
 				placeholder="Loading..."
 			/>);
 		});
@@ -335,7 +335,7 @@ describe('Async', () => {
 				<Select
 					isLoading={false}
 					placeholder="Select..."
-					noResultsText="No results found"
+					noResultsLabel="No results found"
 					options={ [ { value: 1, label: 'test callback' } ] }
 				/>);
 		});
@@ -357,7 +357,7 @@ describe('Async', () => {
 				<Select
 					isLoading={false}
 					placeholder="Select..."
-					noResultsText="No results found"
+					noResultsLabel="No results found"
 					options={ [ { value: 2, label: 'test callback 2' } ] }
 				/>);
 		});
@@ -380,7 +380,7 @@ describe('Async', () => {
 				<Select
 					isLoading={false}
 					placeholder="Select..."
-					noResultsText="No results found"
+					noResultsLabel="No results found"
 					options={ [ { value: 2, label: 'test callback 2' } ] }
 				/>);
 		});
@@ -477,7 +477,7 @@ describe('Async', () => {
 					<Select
 						options={ [] }
 						placeholder="Select..."
-						noResultsText="Type to search"
+						noResultsLabel="Type to search"
 					/>);
 
 			});

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2266,14 +2266,14 @@ describe('Select', () => {
 			});
 		});
 
-		describe('noResultsText', () => {
+		describe('noResultsLabel', () => {
 
 			beforeEach(() => {
 
 				wrapper = createControlWithWrapper({
 					searchable: true,
 					options: defaultOptions,
-					noResultsText: 'No results unit test'
+					noResultsLabel: 'No results unit test'
 				});
 			});
 
@@ -2284,10 +2284,10 @@ describe('Select', () => {
 					'to have text', 'No results unit test');
 			});
 
-			it('doesn\'t displays the text when no results are found and noResultsText is falsy', () => {
+			it('doesn\'t displays the text when no results are found and noResultsLabel is falsy', () => {
 
 				wrapper.setPropsForChild({
-					noResultsText: ''
+					noResultsLabel: ''
 				});
 
 				typeSearchText('DOES NOT EXIST');
@@ -2298,7 +2298,7 @@ describe('Select', () => {
 			it('doesn\'t displays outer when menu is null', () => {
 
 				wrapper.setPropsForChild({
-					noResultsText: ''
+					noResultsLabel: ''
 				});
 
 				typeSearchText('DOES NOT EXIST');
@@ -2309,7 +2309,7 @@ describe('Select', () => {
 			it('supports updating the text', () => {
 
 				wrapper.setPropsForChild({
-					noResultsText: 'Updated no results text'
+					noResultsLabel: 'Updated no results text'
 				});
 
 				typeSearchText('DOES NOT EXIST');
@@ -2735,8 +2735,8 @@ describe('Select', () => {
 					asyncOptions: asyncOptions,
 					autoload: false,
 					searchingText: 'Testing async loading...',
-					noResultsText: 'Testing No results found',
-					searchPromptText: 'Testing enter search query'
+					noResultsLabel: 'Testing No results found',
+					searchPromptLabel: 'Testing enter search query'
 				});
 			});
 
@@ -2766,7 +2766,7 @@ describe('Select', () => {
 				expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching', '.Select-noresults');
 			});
 
-			it('switches the searchingText to noResultsText when options arrive, but empty', () => {
+			it('switches the searchingText to noResultsLabel when options arrive, but empty', () => {
 
 				clickArrowToOpen();
 				typeSearchText('abc');
@@ -2785,7 +2785,7 @@ describe('Select', () => {
 			});
 		});
 
-		describe('searchPromptText', () => {
+		describe('searchPromptLabel', () => {
 
 			// TODO: Need to use the new Select.Async control for this
 			return;
@@ -2799,11 +2799,11 @@ describe('Select', () => {
 				instance = createControl({
 					asyncOptions: asyncOptions,
 					autoload: false,
-					searchPromptText: 'Unit test prompt text'
+					searchPromptLabel: 'Unit test prompt text'
 				});
 			});
 
-			it('uses the searchPromptText before text is entered', () => {
+			it('uses the searchPromptLabel before text is entered', () => {
 
 				var selectArrow = ReactDOM.findDOMNode(instance).querySelector('.Select-arrow');
 				TestUtils.Simulate.mouseDown(selectArrow);
@@ -2813,7 +2813,7 @@ describe('Select', () => {
 					'to have text', 'Unit test prompt text');
 			});
 
-			it('clears the searchPromptText when results arrive', () => {
+			it('clears the searchPromptLabel when results arrive', () => {
 
 				asyncOptions.callsArgWith(1, null, {
 					options: [{ value: 'abcd', label: 'ABCD' }]


### PR DESCRIPTION
In order to render html as a part of the Select, we need to be able to provide styled HTML elements for the props searchingText. We also should then rename the props to indicate their new type.

This PR:
- adds a new prop searchingLabel
- adds a deprecation warning for prop searchingText

As per comment on #930, most of this code can be removed after version 2 of react select is released.
See also #932 
