### PR TITLE
Adding the fix for missing border inside table to LESS

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -51,6 +51,8 @@
 	color: @select-text-color;
 	cursor: default;
 	display: table;
+	border-spacing: 0;
+	border-collapse: separate;
 	height: @select-input-height;
 	outline: none;
 	overflow: hidden;


### PR DESCRIPTION
The problem where the border isn't showing when the element is inside a
table was only added to the SCSS version in [this commit](https://github.com/JedWatson/react-select/commit/4b8d12832b3f5c6c9d3ca8
bd003a8c0cb8fd8aea). Adding it to the LESS version.