### PR TITLE
Fix searchingText bug

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -141,9 +141,10 @@ const Async = React.createClass({
 		let { isLoading, options } = this.state;
 		if (this.props.isLoading) isLoading = true;
 		let placeholder = isLoading ? this.props.loadingPlaceholder : this.props.placeholder;
-		if (!options.length) {
-			if (this._lastInput.length < this.props.minimumInput) noResultsText = this.props.searchPromptText;
-			if (isLoading) noResultsText = this.props.searchingText;
+		if (isLoading) {
+			noResultsText = this.props.searchingText;
+		} else if (!options.length && this._lastInput.length < this.props.minimumInput) {
+			noResultsText = this.props.searchPromptText;
 		}
 		return (
 			<Select

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -82,7 +82,6 @@ describe('Async', () => {
 				/>);
 		});
 
-
 		it('shows the returns options when the result returns', () => {
 
 			// Unexpected comes with promises built in - we'll use them
@@ -105,6 +104,26 @@ describe('Async', () => {
 			});
 		});
 
+		it('shows "Loading..." after typing if refined search matches none of the previous results', () => {
+
+			loadOptions.returns(expect.promise((resolve, reject) => {
+				resolve({ options: [{ value: 1, label: 'test' }] });
+			}));
+
+			typeSearchText('te');
+
+			return loadOptions.firstCall.returnValue.then(() => {
+
+				typeSearchText('ten');
+
+				return expect(renderer, 'to have rendered',
+					<Select
+						isLoading
+						placeholder="Loading..."
+						noResultsText="Searching..."
+					/>);
+			});
+		});
 
 		it('ignores the result of an earlier call, when the responses come in the wrong order', () => {
 


### PR DESCRIPTION
When using the Async component with a large number of options, it's possible that refining the search input doesn't match any previously loaded results, but may match new results returned by the server. There was a bug in the text that's displayed

For example, let's say a search of "a" asynchronously returned options

- "aardvark"
- ...
- "aaz"

The user then refines their search to "ab"
This shows a loading spinner and no options, while it makes an asynchronous request with the new search query.
There was a bug where "No results found" was displayed under the search input while waiting for a response, instead of "Searching...". This PR fixes that bug.

I'd be happy to clarify what the bug is if it's still not clear to anyone.

(https://github.com/JedWatson/react-select/pull/941 or similar should get merged first since that fixes a more general bug with async)