### PR TITLE
Fix a focus bug on iOS

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -271,6 +271,11 @@ const Select = React.createClass({
 		}
 
 		if (this.state.isFocused) {
+			// On iOS, we can get into a state where we think the input is focused but it isn't really,
+			// since iOS ignores programmatic calls to input.focus() that weren't triggered by a click event.
+			// Call focus() again here to be safe.
+			this.focus();
+
 			// if the input is focused, ensure the menu is open
 			this.setState({
 				isOpen: true,


### PR DESCRIPTION
The bug meant that calling `focus()` programmatically (or using `autofocus={true}`) could render the select component useless on iOS, since it refused to focus on a tap event if it thought it was already focused.

There are some other ways to fix this, like using `document.activeElement` to detect if the input is focused rather than maintaining `isFocused` in the component state, but I wasn't sure if there could be downsides to that approach or if there was a reason that was not done in the first place. This seemed like the simplest change.

I'm also not sure if there's a great way to unit test this, since it's a fairly iOS specific issue. I'm open to suggestions and discussion.