### PR TITLE
Make input act mmore natively

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -258,6 +258,10 @@ const Select = React.createClass({
 			return;
 		}
 
+		if (event.target.tagName === 'INPUT') {
+			return;
+		}
+
 		// prevent default event handlers
 		event.stopPropagation();
 		event.preventDefault();
@@ -275,6 +279,9 @@ const Select = React.createClass({
 			// since iOS ignores programmatic calls to input.focus() that weren't triggered by a click event.
 			// Call focus() again here to be safe.
 			this.focus();
+
+			// clears value so that the cursor will be a the end of input then the component re-renders
+			this.refs.input.getInput().value = '';
 
 			// if the input is focused, ensure the menu is open
 			this.setState({


### PR DESCRIPTION
This PR allows the `react-select` input to behave more similarly to native HTML input.

1. Users can now move the cursor by clicking the text in the input.
2. Clicking empty space to the right of text moves the cursor to end of the text.