### PR TITLE
Add onRemove handler to Option

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -9,6 +9,7 @@ const Option = React.createClass({
 		isFocused: React.PropTypes.bool,               // the option is focused
 		isSelected: React.PropTypes.bool,              // the option is selected
 		onFocus: React.PropTypes.func,                 // method to handle mouseEnter on option element
+		onRemove: React.PropTypes.func,                // method to handle removal of the value
 		onSelect: React.PropTypes.func,                // method to handle click on option element
 		onUnfocus: React.PropTypes.func,               // method to handle mouseLeave on option element
 		option: React.PropTypes.object.isRequired,     // object that is base for that option
@@ -30,6 +31,12 @@ const Option = React.createClass({
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.onSelect(this.props.option, event);
+	},
+
+	onRemove (event) {
+		event.preventDefault();
+		event.stopPropagation();
+		this.props.onRemove(this.props.option);
 	},
 
 	handleMouseEnter (event) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -785,6 +785,7 @@ const Select = React.createClass({
 							key={`option-${i}-${option[this.props.valueKey]}`}
 							onSelect={this.selectValue}
 							onFocus={this.focusOption}
+							onRemove={this.removeValue}
 							option={option}
 							isSelected={isSelected}
 							ref={optionRef}


### PR DESCRIPTION
I am currently extending react-select to allow the options to stay visible in the dropdown menu with an indication as to whether they've been selected or not (see below). I'm able to do most of this with `filterOptions: false` and `optionsComponent: MyCustomOptionComponent`.

I cannot, however, think of a good way to add the `removeValue` functionality to this component without this PR. I don't believe this affects any other use case, and there appears to be a precedent for adding unused-by-default functionality with `isSelected` prop on Option.

![image](https://cloud.githubusercontent.com/assets/1977038/15132154/688955e6-160b-11e6-8249-72cea534427c.png)
