### PR TITLE
Always pass valueArray to renderOuter

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -891,7 +891,7 @@ const Select = React.createClass({
 					{this.renderClear()}
 					{this.renderArrow()}
 				</div>
-				{isOpen ? this.renderOuter(options, !this.props.multi ? valueArray : null, focusedOption) : null}
+				{isOpen ? this.renderOuter(options, valueArray, focusedOption) : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
I am currently extending react-select to allow the options to stay visible in the dropdown menu with an indication as to whether they've been selected or not (see below). I'm able to do most of this with `filterOptions: false` and `optionsComponent: MyCustomOptionComponent`.

It appears, though, that if the `multi` option is set to `true` that the `valueArray` will not be passed down through `renderOuter` to `renderMenu`, which means that the `isSelected` value that gets passed to the `Option` components will **always** equal `null`

![image](https://cloud.githubusercontent.com/assets/1977038/15132154/688955e6-160b-11e6-8249-72cea534427c.png)
