### PR TITLE
extend to support usage as input field

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -9,6 +9,7 @@ import GithubUsers from './components/GithubUsers';
 import CustomComponents from './components/CustomComponents';
 import CustomRender from './components/CustomRender';
 import Multiselect from './components/Multiselect';
+import SearchField from './components/SearchField';
 import NumericSelect from './components/NumericSelect';
 import Virtualized from './components/Virtualized';
 import States from './components/States';
@@ -23,6 +24,7 @@ ReactDOM.render(
 		<NumericSelect label="Numeric Values" />
 		<CustomRender label="Custom Render Methods"/>
 		<CustomComponents label="Custom Placeholder, Option and Value Components" />
+    <SearchField label="Searchfield with suggestions" />
 		{/*
 		<SelectedValuesField label="Option Creation (tags mode)" options={FLAVOURS} allowCreate hint="Enter a value that's NOT in the list, then hit return" />
 		*/}

--- a/examples/src/components/SearchField.js
+++ b/examples/src/components/SearchField.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import Select from 'react-select';
+
+const FLAVOURS = [
+	{ label: 'Chocolate', value: 'chocolate' },
+	{ label: 'Vanilla', value: 'vanilla' },
+	{ label: 'Strawberry', value: 'strawberry' },
+	{ label: 'Caramel', value: 'caramel' },
+	{ label: 'Cookies and Cream', value: 'cookiescream' },
+	{ label: 'Peppermint', value: 'peppermint' },
+];
+
+const WHY_WOULD_YOU = [
+	{ label: 'Chocolate (are you crazy?)', value: 'chocolate', disabled: true },
+].concat(FLAVOURS.slice(1));
+
+var SearchField = React.createClass({
+	displayName: 'SearchField',
+	propTypes: {
+		label: React.PropTypes.string,
+	},
+	getInitialState () {
+		return {
+			disabled: false,
+			crazy: false,
+			options: FLAVOURS,
+			value: [],
+		};
+	},
+	handleSelectChange (value) {
+		console.log('You\'ve selected:', value);
+		this.setState({ value });
+	},
+	toggleDisabled (e) {
+		this.setState({ disabled: e.target.checked });
+	},
+	toggleChocolate (e) {
+		let crazy = e.target.checked;
+		this.setState({
+			crazy: crazy,
+			options: crazy ? WHY_WOULD_YOU : FLAVOURS,
+		});
+	},
+  handleValueSubmit () {
+    console.log('Submitted value: ', this.state.value, '. Do something interesting with it ...');
+  },
+	render () {
+		return (
+			<div className="section">
+				<h3 className="section-heading">{this.props.label}</h3>
+				<Select multi simpleValue disabled={this.state.disabled} value={this.state.value} placeholder="Select your favourite(s)" options={this.state.options} onChange={this.handleSelectChange} minCharsToOpen={1} showArrow={false} onValueSubmit={this.handleValueSubmit} />
+
+				<div className="checkbox-list">
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" checked={this.state.disabled} onChange={this.toggleDisabled} />
+						<span className="checkbox-label">Disable the control</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" checked={this.state.crazy} onChange={this.toggleChocolate} />
+						<span className="checkbox-label">I do not like Chocolate (disabled the option)</span>
+					</label>
+				</div>
+			</div>
+		);
+	}
+});
+
+module.exports = SearchField;

--- a/less/select.less
+++ b/less/select.less
@@ -48,7 +48,7 @@
 @select-clear-size:                floor((@select-input-height / 2));
 @select-clear-color:               #999;
 @select-clear-hover-color:         #D0021B; // red
-@select-clear-width:               (@select-input-internal-height / 2);
+@select-clear-width:               25px;
 
 // arrow indicator
 @select-arrow-color:               #999;


### PR DESCRIPTION
I needed something like React-Select, except I wanted it to behave more like an input field. I wanted to have more control on when suggestions open, like sending the minimum number of chars in the suggestion need before showing up. Also, when the field is populated with one or more values, the enter key press calls a handler provided in the props, which can do stuff like search operations.
