### PR TITLE
Add support for assistive technologies

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -112,8 +112,8 @@
 	white-space: nowrap;
 }
 
-.has-value.Select--single > .Select-control > .Select-value,
-.has-value.is-pseudo-focused.Select--single > .Select-control > .Select-value {
+.has-value.Select--single > .Select-control .Select-value,
+.has-value.is-pseudo-focused.Select--single > .Select-control .Select-value {
 	.Select-value-label {
 		color: @select-text-color;
 	}
@@ -240,8 +240,17 @@
 	border-top-color: @select-arrow-color-hover;
 }
 
-
-
+.Select--multi .Select-multi-value-wrapper {
+  display: inline-block;
+}
+.Select .Select-aria-only {
+  display: inline-block;
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  clip: rect(0,0,0,0);
+  overflow: hidden;
+}
 
 // Animation
 // ------------------------------

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sinon": "^1.17.3",
     "unexpected": "^10.13.2",
     "unexpected-dom": "^3.1.0",
-    "unexpected-react": "^3.1.3",
+    "unexpected-react": "^3.2.3",
     "unexpected-sinon": "^10.2.0"
   },
   "peerDependencies": {

--- a/scss/control.scss
+++ b/scss/control.scss
@@ -200,6 +200,10 @@
 	width: $select-clear-width;
 }
 
+.Select--multi .Select-multi-value-wrapper {
+  display: inline-block;
+}
+
 
 // arrow indicator
 

--- a/src/Option.js
+++ b/src/Option.js
@@ -5,6 +5,7 @@ const Option = React.createClass({
 	propTypes: {
 		children: React.PropTypes.node,
 		className: React.PropTypes.string,             // className (based on mouse position)
+		instancePrefix: React.PropTypes.string.isRequired,  // unique prefix for the ids (used for aria)
 		isDisabled: React.PropTypes.bool,              // the option is disabled
 		isFocused: React.PropTypes.bool,               // the option is focused
 		isSelected: React.PropTypes.bool,              // the option is selected
@@ -12,6 +13,7 @@ const Option = React.createClass({
 		onSelect: React.PropTypes.func,                // method to handle click on option element
 		onUnfocus: React.PropTypes.func,               // method to handle mouseLeave on option element
 		option: React.PropTypes.object.isRequired,     // object that is base for that option
+		optionIndex: React.PropTypes.number,           // index of the option, used to generate unique ids for aria
 	},
 	blockEvent (event) {
 		event.preventDefault();
@@ -64,7 +66,7 @@ const Option = React.createClass({
 		}
 	},
 	render () {
-		var { option } = this.props;
+		var { option, instancePrefix, optionIndex } = this.props;
 		var className = classNames(this.props.className, option.className);
 
 		return option.disabled ? (
@@ -76,12 +78,14 @@ const Option = React.createClass({
 		) : (
 			<div className={className}
 				style={option.style}
-				onMouseDown={this.handleMouseDown}
+				role="option"
+				 onMouseDown={this.handleMouseDown}
 				onMouseEnter={this.handleMouseEnter}
 				onMouseMove={this.handleMouseMove}
 				onTouchStart={this.handleTouchStart}
 				onTouchMove={this.handleTouchMove}
 				onTouchEnd={this.handleTouchEnd}
+				id={instancePrefix + '-option-' + optionIndex}
 				title={option.title}>
 				{this.props.children}
 			</div>

--- a/src/Value.js
+++ b/src/Value.js
@@ -8,6 +8,7 @@ const Value = React.createClass({
 	propTypes: {
 		children: React.PropTypes.node,
 		disabled: React.PropTypes.bool,               // disabled prop passed to ReactSelect
+		id: React.PropTypes.string,                   // Unique id for the value - used for aria
 		onClick: React.PropTypes.func,                // method to handle click on value label
 		onRemove: React.PropTypes.func,               // method to handle removal of the value
 		value: React.PropTypes.object.isRequired,     // the option object for this value
@@ -56,6 +57,7 @@ const Value = React.createClass({
 		if (this.props.disabled || !this.props.onRemove) return;
 		return (
 			<span className="Select-value-icon"
+				aria-hidden="true"
 				onMouseDown={this.onRemove}
 				onTouchEnd={this.handleTouchEndRemove}
 				onTouchStart={this.handleTouchStart}
@@ -72,7 +74,7 @@ const Value = React.createClass({
 				{this.props.children}
 			</a>
 		) : (
-			<span className={className}>
+			<span className={className} role="option" aria-selected="true" id={this.props.id}>
 				{this.props.children}
 			</span>
 		);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -8,10 +8,12 @@ var sinon = require('sinon');
 var unexpected = require('unexpected');
 var unexpectedDom = require('unexpected-dom');
 var unexpectedSinon = require('unexpected-sinon');
+var unexpectedReact = require('unexpected-react');
 var expect = unexpected
 	.clone()
 	.installPlugin(unexpectedDom)
 	.installPlugin(unexpectedSinon)
+	.installPlugin(unexpectedReact)
 	.installPlugin(require('../testHelpers/nodeListType'));
 
 jsdomHelper();
@@ -21,11 +23,16 @@ var ReactDOM = require('react-dom');
 var TestUtils = require('react-addons-test-utils');
 
 var Select = require('../src/Select');
+var Value = require('../src/Value');
 
 // The displayed text of the currently selected item, when items collapsed
 var DISPLAYED_SELECTION_SELECTOR = '.Select-value';
 var FORM_VALUE_SELECTOR = '.Select > input';
 var PLACEHOLDER_SELECTOR = '.Select-placeholder';
+
+var ARROW_UP = { keyCode: 38, key: 'ArrowUp' };
+var ARROW_DOWN = { keyCode: 40, key: 'ArrowDown' };
+var KEY_ENTER = { keyCode: 13, key: 'Enter' };
 
 class PropsWrapper extends React.Component {
 
@@ -518,11 +525,11 @@ describe('Select', () => {
 
 			it('selects the initial value', () => {
 
-				expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value .Select-value-label',
-					'to satisfy', [
-						expect.it('to have text', 'Two'),
-						expect.it('to have text', 'One')
-					]);
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">Two</span></div>
+                        <div><span className="Select-value-label">One</span></div>
+					</span>);
 			});
 
 			it('calls onChange with the correct value when 1 option is selected', () => {
@@ -538,11 +545,11 @@ describe('Select', () => {
 					value: [3, 4]
 				});
 
-				expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value .Select-value-label',
-					'to satisfy', [
-						expect.it('to have text', 'Three'),
-						expect.it('to have text', 'Four')
-					]);
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">Three</span></div>
+                        <div><span className="Select-value-label">Four</span></div>
+					</span>);
 			});
 
 			it('supports updating the value to a single value', () => {
@@ -551,10 +558,10 @@ describe('Select', () => {
 					value: 1
 				});
 
-				expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value .Select-value-label',
-					'to satisfy', [
-						expect.it('to have text', 'One')
-					]);
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">One</span></div>
+					</span>);
 			});
 
 			it('supports updating the value to single value of 0', () => {
@@ -564,10 +571,10 @@ describe('Select', () => {
 					value: 0
 				});
 
-				expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value .Select-value-label',
-					'to satisfy', [
-						expect.it('to have text', 'Zero')
-					]);
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">Zero</span></div>
+					</span>);
 			});
 
 			it('calls onChange with the correct values when multiple options are selected', () => {
@@ -1280,10 +1287,11 @@ describe('Select', () => {
 			it('displays both selected options', () => {
 
 				setValueProp([options[3], options[2]]);
-				expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label')[0],
-					'to have text', 'Four');
-				expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label')[1],
-					'to have text', 'Three');
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">Four</span></div>
+                        <div><span className="Select-value-label">Three</span></div>
+					</span>);
 			});
 		});
 
@@ -1303,10 +1311,11 @@ describe('Select', () => {
 			it('displays both selected options', () => {
 
 				setValueProp(['four', 'three']);
-				expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label')[0],
-					'to have text', 'Four');
-				expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label')[1],
-					'to have text', 'Three');
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">Four</span></div>
+                        <div><span className="Select-value-label">Three</span></div>
+					</span>);
 			});
 		});
 
@@ -1342,9 +1351,11 @@ describe('Select', () => {
 
 			pressBackspace();
 			expect(onChange, 'was not called');
-			var items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label');
-			expect(items[0], 'to have text', 'Four');
-			expect(items[1], 'to have text', 'Three');
+			expect(instance, 'to contain',
+				<span className="Select-multi-value-wrapper">
+                    <div><span className="Select-value-label">Four</span></div>
+                    <div><span className="Select-value-label">Three</span></div>
+                </span>);
 		});
 
 		it('removes an item when clicking on the X', () => {
@@ -1378,10 +1389,11 @@ describe('Select', () => {
 
 			pressBackspace();
 			expect(onChange, 'was not called');
-			var items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label');
-			expect(items[0], 'to have text', 'Four');
-			expect(items[1], 'to have text', 'Two');
-
+			expect(instance, 'to contain',
+				<span className="Select-multi-value-wrapper">
+                    <div><span className="Select-value-label">Four</span></div>
+                    <div><span className="Select-value-label">Two</span></div>
+                </span>);
 		});
 
 		describe('with late options', () => {
@@ -1405,15 +1417,12 @@ describe('Select', () => {
 					]
 				});
 
-				var items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value');
 
-				expect(items[0], 'queried for', '.Select-value-label',
-					'to have items satisfying',
-					'to have text', 'new label for One');
-
-				expect(items[1], 'queried for', '.Select-value-label',
-					'to have items satisfying',
-					'to have text', 'new label for Two');
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+                        <div><span className="Select-value-label">new label for One</span></div>
+                        <div><span className="Select-value-label">new label for Two</span></div>
+					</span>);
 			});
 		});
 
@@ -1454,15 +1463,14 @@ describe('Select', () => {
 
 			clickArrowToOpen();
 
-			var items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-option');
-			TestUtils.Simulate.mouseDown(items[1]);
-			items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-option');
-			TestUtils.Simulate.mouseDown(items[0]);
-
-			var selectedItems = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label');
-			expect(selectedItems[0], 'to have text', 'Two');
-			expect(selectedItems[1], 'to have text', 'One');
-			expect(selectedItems, 'to have length', 2);
+			expect(instance,
+				'with event mouseDown', 'on', <div className="Select-option">Two</div>,
+				'with event mouseDown', 'on', <div className="Select-option">One</div>,
+				'to contain',
+				<span className="Select-multi-value-wrapper">
+					<div><span className="Select-value-label">Two</span></div>
+					<div><span className="Select-value-label">One</span></div>
+				</span>);
 		});
 
 		it('calls onChange when each option is selected', () => {
@@ -1794,13 +1802,9 @@ describe('Select', () => {
 
 				it('interprets the initial options correctly', () => {
 
-					var values = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value');
-
-					expect(values[0], 'queried for', '.Select-value-label', 'to have items satisfying',
-						'to have text', 'AbcDef');
-					expect(values[1], 'queried for', '.Select-value-label', 'to have items satisfying',
-						'to have text', 'Three');
-					expect(values, 'to have length', 2);
+					expect(instance, 'to contain', <span className="Select-value-label">AbcDef</span>);
+					expect(instance, 'to contain', <span className="Select-value-label">Three</span>);
+					expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value-label', 'to have length', 2);
 				});
 
 				it('adds an additional option with the correct delimiter', () => {
@@ -1828,13 +1832,9 @@ describe('Select', () => {
 
 				it('interprets the initial options correctly', () => {
 
-					var values = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value');
-
-					expect(values[0], 'queried for', '.Select-value-label', 'to have items satisfying',
-						'to have text', 'AbcDef');
-					expect(values[1], 'queried for', '.Select-value-label', 'to have items satisfying',
-						'to have text', 'Three');
-					expect(values, 'to have length', 2);
+					expect(instance, 'to contain', <span className="Select-value-label">AbcDef</span>);
+					expect(instance, 'to contain', <span className="Select-value-label">Three</span>);
+					expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-value-label', 'to have length', 2);
 				});
 
 				it('adds an additional option with the correct delimiter', () => {
@@ -2888,7 +2888,7 @@ describe('Select', () => {
 
 				valueRenderer = (option) => {
 					return (
-						<span id={'TESTOPTION_' + option.value}>{option.label.toUpperCase()}</span>
+						<span id={'TESTOPTION_' + option.value} className="custom-render">{option.label.toUpperCase()}</span>
 					);
 				};
 
@@ -2904,7 +2904,7 @@ describe('Select', () => {
 
 			it('renders the values using the provided renderer', () => {
 
-				var labelNode = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label span');
+				var labelNode = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-value-label span.custom-render');
 				expect(labelNode[0], 'to have text', 'THREE');
 				expect(labelNode[0], 'to have attributes', {
 					id: 'TESTOPTION_three'
@@ -3105,6 +3105,151 @@ describe('Select', () => {
 			expect(keys, 'to contain', 'options');
 			expect(keys, 'to contain', 'selectValue');
 			expect(keys, 'to contain', 'valueArray');
+		});
+	});
+
+	describe('accessibility', () => {
+
+		describe('with basic searchable control', () => {
+
+			beforeEach(() => {
+
+				instance = createControl({
+					options: [
+						{ value: 'one', label: 'label one' },
+						{ value: 'two', label: 'label two' },
+						{ value: 'three', label: 'label three' }
+					],
+					value: 'two'
+				});
+			});
+
+			it('renders an input with a combobox role', () => {
+
+				expect(instance, 'to contain', <input role="combobox" />);
+			});
+
+			it('renders an input with a combobox role and without popup', () => {
+
+				expect(instance, 'to contain', <input role="combobox" aria-haspopup="false" aria-expanded="false" />);
+			});
+
+			it('renders the correct selected value id', () => {
+				expect(instance, 'queried for', <input role="combobox" />)
+					.then(input => {
+						var currentValueId = input.attributes['aria-activedescendant'].value;
+
+						return expect(ReactDOM.findDOMNode(instance),
+							'queried for', '#' + currentValueId,
+							'to satisfy', [ expect.it('to have text', 'label two') ]);
+					});
+			});
+
+			it('sets the haspopup and expanded to true when menu is shown', () => {
+				expect(instance,
+					'with event keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'to contain', <input role="combobox" aria-haspopup="true" aria-expanded="true" />);
+			});
+
+			it('sets the active descendant when the next item is highlighted', () => {
+				expect(instance,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'queried for', <input role="combobox" />)
+					.then(input => {
+						const currentHighlightId = input.attributes['aria-activedescendant'].value;
+						expect(ReactDOM.findDOMNode(instance).querySelector('#' + currentHighlightId),
+							'to have text', 'label three');
+					});
+			});
+
+			it('passes through the aria-labelledby prop', () => {
+
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one',
+					'aria-labelledby': 'test-label-id'
+				});
+
+				expect(instance,
+					'to contain', <input role="combobox" aria-labelledby="test-label-id" />);
+			});
+
+			it('passes through the aria-label prop', () => {
+
+				instance = createControl({
+					options: defaultOptions,
+					value: 'one',
+					'aria-label': 'This is a test label'
+				});
+
+				expect(instance,
+					'to contain', <input role="combobox" aria-label="This is a test label" />);
+			});
+		});
+
+		describe('with multiselect', () => {
+
+			beforeEach(() => {
+
+				wrapper = createControlWithWrapper({
+					options: [
+						{ value: 'one', label: 'label one' },
+						{ value: 'two', label: 'label two' },
+						{ value: 'three', label: 'label three' },
+						{ value: 'four', label: 'label four' },
+						{ value: 'five', label: 'label five' }
+					],
+					value: [ 'three', 'two' ],
+					multi: true
+				}, {
+					wireUpOnChangeToValue: true
+				});
+			});
+
+			it('shows the `press backspace to remove` message for the last item', () => {
+				expect(instance,
+					'to contain',
+					<span className="Select-aria-only" aria-live="assertive">
+						Press backspace to remove label two
+					</span>);
+			});
+
+			it('hides the `press backspace to remove` message on blur', () => {
+				expect(instance,
+					'with event blur', 'on', <input role="combobox" />,
+					'not to contain',
+					<span className="Select-aria-only" aria-live="assertive">
+						Press backspace to remove label two
+					</span>);
+			});
+
+			it('updates the backspace message when the selected values update', () => {
+
+				wrapper.setPropselectorChild({ value: [ 'three', 'two', 'one' ] });
+				expect(instance,
+					'to contain',
+					<span className="Select-aria-only" aria-live="assertive">
+						Press backspace to remove label one
+					</span>);
+			});
+
+			it('updates the active descendant after a selection', () => {
+
+				return expect(wrapper,
+					'with event keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'with event keyDown', KEY_ENTER, 'on', <div className="Select-control" />,
+					'queried for', <input role="combobox" />)
+					.then(input => {
+
+						// [ 'three', 'two', 'one' ] is now selected,
+						// therefore in-focus should be 'four'
+
+						const activeId = input.attributes['aria-activedescendant'].value;
+						expect(ReactDOM.findDOMNode(instance), 'queried for first', '#' + activeId, 'to have text', 'label four');
+					});
+
+			});
 		});
 	});
 });

--- a/wallaby.js
+++ b/wallaby.js
@@ -6,11 +6,14 @@ var babel = require('babel');
 
 module.exports = function (wallaby) { // eslint-disable-line no-unused-vars
 	return {
-		files: ['src/**/*.js', 'testHelpers/*.js'],
+		files: ['src/**/*.js', {
+			pattern: 'testHelpers/*.js',
+			instrument: false
+		}],
 		tests: ['test/*-test.js' ],
 		env: {
 			type: 'node',
-			runner: '/home/dave/.nvm/versions/node/v4.2.1/bin/node'
+			runner: 'node'
 		},
 		compilers: {
 			'**/*.js': wallaby.compilers.babel({


### PR DESCRIPTION
This adds support for aria. Some minor changes to the markup have been
made in order to get a better experience with a screen reader.

This should be regarded as a first step, and there will almost certainly
be more things we can do to improve this further, and fixes for other
screenreaders etc.  

There's some tidy-up I'd like to still do, particularly with the `focusedOption` / `focusedOptionIndex` tracking, as that can probably be simplified.  But I wanted to get this up for review, so we can see what else needs doing. 

I've converted some tests that started failing due to the changes to unexpected-react, as there is an extra `&nbsp;` in the label, hidden except from screenreaders - this made the tests using the label tricky with just the DOM. (I'm very biased when it comes to this lib, so completely understand if we'd rather just DOM testing :smile: - can be changed with some effort, but I think the tests are actually more readable with it - but bias and full disclosure blah blah :wink:)

I've tried this out in ChromeVox and Orca on Linux. I'd be immensely grateful for feedback from users of other screenreaders (or any regular screenreader users).

I recorded a (fairly poor sound quality) video, to show the difference - https://www.youtube.com/watch?v=Qzr1Y9CFVDk

Fixes #353 
