### PR TITLE
Promise bug 984

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -138,7 +138,7 @@ const Async = React.createClass({
 		let inputPromise = thenPromise(this.props.loadOptions(input, responseHandler), responseHandler);
 		return inputPromise ? inputPromise.then(() => {
 			return input;
-		}) : inputPromise; 
+		}) : input;
 	},
 	render () {
 		let { noResultsText } = this.props;

--- a/src/Async.js
+++ b/src/Async.js
@@ -135,7 +135,10 @@ const Async = React.createClass({
 			isLoading: true,
 		});
 		let responseHandler = this.getResponseHandler(input);
-		return thenPromise(this.props.loadOptions(input, responseHandler), responseHandler);
+		let inputPromise = thenPromise(this.props.loadOptions(input, responseHandler), responseHandler);
+		return inputPromise ? inputPromise.then(() => {
+			return input;
+		}) : inputPromise; 
 	},
 	render () {
 		let { noResultsText } = this.props;


### PR DESCRIPTION
This feels a bit hacky to me, but I think it works.  Long term, it might be better to throw if `thenPromise` gets something that's not a promise?

EDIT:  I believe there is currently a single, failing test on master, which this change doesn't address.