### PR TITLE
Update README with autofocus prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ function cleanInput(inputValue) {
 	addLabelText	|	string	|	'Add "{label}"?'	|	text to display when `allowCreate` is true
 	allowCreate	|	bool	|	false		|	allow new options to be created in multi mode (displays an "Add \<option> ?" item when a value not already in the `options` array is entered)
 	autoBlur	|	bool | false | Blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices
+	autofocus       |       bool    |      undefined        |  autofocus the component on mount
 	autoload 	|	bool	|	true		|	whether to auto-load the default async options set
 	autosize  | bool | true  | If enabled, the input will expand as the length of its value increases
 	backspaceRemoves 	|	bool	|	true	|	whether pressing backspace removes the last item when there is no input value


### PR DESCRIPTION
**Reason for Change**

Since [beta 3](https://github.com/JedWatson/react-select/blob/master/HISTORY.md#v100-beta3--2015-11-08), we have had [autofocus](https://github.com/JedWatson/react-select/blob/master/src/Select.js#L37) as a prop
```javascript
...
		autofocus: React.PropTypes.bool,            // autofocus the component on mount
...

```

Just exposing that in the README.md.



