### PR TITLE
Implemented allowCreate and more flexible add item on comma functionality

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -12,6 +12,7 @@ import Multiselect from './components/Multiselect';
 import NumericSelect from './components/NumericSelect';
 import Virtualized from './components/Virtualized';
 import States from './components/States';
+import AllowCreate from './components/AllowCreate';
 
 ReactDOM.render(
 	<div>
@@ -26,6 +27,7 @@ ReactDOM.render(
 		{/*
 		<SelectedValuesField label="Option Creation (tags mode)" options={FLAVOURS} allowCreate hint="Enter a value that's NOT in the list, then hit return" />
 		*/}
+		<AllowCreate label="Option Creation (tags mode)" allowCreate />
 	</div>,
 	document.getElementById('example')
 );

--- a/examples/src/components/AllowCreate.js
+++ b/examples/src/components/AllowCreate.js
@@ -51,7 +51,10 @@ var AllowCreate = React.createClass({
 					multi
 					placeholder="Select your favourite(s)"
 					options={this.state.options}
-					onChange={this.handleSelectChange} />
+					onChange={this.handleSelectChange}
+					addItemOnKeyCode={188}
+				/>
+
 				{this.renderHint()}
 			</div>
 		);

--- a/examples/src/components/AllowCreate.js
+++ b/examples/src/components/AllowCreate.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Select from 'react-select';
+
+const FLAVOURS = [
+	{ label: 'Chocolate', value: 'chocolate' },
+	{ label: 'Vanilla', value: 'vanilla' },
+	{ label: 'Strawberry', value: 'strawberry' },
+	{ label: 'Caramel', value: 'caramel' },
+	{ label: 'Cookies and Cream', value: 'cookiescream' },
+	{ label: 'Peppermint', value: 'peppermint' },
+];
+
+var AllowCreate = React.createClass({
+	displayName: 'AllowCreate',
+
+	propTypes: {
+		allowCreate: React.PropTypes.bool,
+		label: React.PropTypes.string,
+	},
+
+	getInitialState () {
+		return {
+			disabled: false,
+			crazy: false,
+			options: FLAVOURS,
+			value: [],
+		};
+	},
+
+	onLabelClick (data, event) {
+		console.log(data, event);
+	},
+
+	handleSelectChange (value){
+		this.setState({ value });
+	},
+
+	renderHint () {
+		return (
+			<div className="hint">Create options in tag mode</div>
+		);
+	},
+
+	render () {
+		return (
+			<div className="section">
+				<h3 className="section-heading">{this.props.label}</h3>
+				<Select
+					allowCreate={this.props.allowCreate}
+					value={this.state.value}
+					multi
+					placeholder="Select your favourite(s)"
+					options={this.state.options}
+					onChange={this.handleSelectChange} />
+				{this.renderHint()}
+			</div>
+		);
+	}
+});
+
+module.exports = AllowCreate;

--- a/src/Option.js
+++ b/src/Option.js
@@ -3,18 +3,20 @@ import classNames from 'classnames';
 
 const Option = React.createClass({
 	propTypes: {
+		addLabelText: React.PropTypes.string,               // text to display with value while creating new option
 		children: React.PropTypes.node,
-		className: React.PropTypes.string,             // className (based on mouse position)
+		className: React.PropTypes.string,                  // className (based on mouse position)
 		instancePrefix: React.PropTypes.string.isRequired,  // unique prefix for the ids (used for aria)
-		isDisabled: React.PropTypes.bool,              // the option is disabled
-		isFocused: React.PropTypes.bool,               // the option is focused
-		isSelected: React.PropTypes.bool,              // the option is selected
-		onFocus: React.PropTypes.func,                 // method to handle mouseEnter on option element
-		onSelect: React.PropTypes.func,                // method to handle click on option element
-		onUnfocus: React.PropTypes.func,               // method to handle mouseLeave on option element
-		option: React.PropTypes.object.isRequired,     // object that is base for that option
-		optionIndex: React.PropTypes.number,           // index of the option, used to generate unique ids for aria
+		isDisabled: React.PropTypes.bool,                   // the option is disabled
+		isFocused: React.PropTypes.bool,                    // the option is focused
+		isSelected: React.PropTypes.bool,                   // the option is selected
+		onFocus: React.PropTypes.func,                      // method to handle mouseEnter on option element
+		onSelect: React.PropTypes.func,                     // method to handle click on option element
+		onUnfocus: React.PropTypes.func,                    // method to handle mouseLeave on option element
+		option: React.PropTypes.object.isRequired,          // object that is base for that option
+		optionIndex: React.PropTypes.number                 // index of the option, used to generate unique ids for aria
 	},
+
 	blockEvent (event) {
 		event.preventDefault();
 		event.stopPropagation();
@@ -68,7 +70,6 @@ const Option = React.createClass({
 	render () {
 		var { option, instancePrefix, optionIndex } = this.props;
 		var className = classNames(this.props.className, option.className);
-
 		return option.disabled ? (
 			<div className={className}
 				onMouseDown={this.blockEvent}
@@ -79,7 +80,7 @@ const Option = React.createClass({
 			<div className={className}
 				style={option.style}
 				role="option"
-				 onMouseDown={this.handleMouseDown}
+				onMouseDown={this.handleMouseDown}
 				onMouseEnter={this.handleMouseEnter}
 				onMouseMove={this.handleMouseMove}
 				onTouchStart={this.handleTouchStart}
@@ -87,7 +88,7 @@ const Option = React.createClass({
 				onTouchEnd={this.handleTouchEnd}
 				id={instancePrefix + '-option-' + optionIndex}
 				title={option.title}>
-				{this.props.children}
+				{ option.create ? this.props.addLabelText.replace('{label}', option.label) : this.props.children }
 			</div>
 		);
 	}

--- a/src/Select.js
+++ b/src/Select.js
@@ -673,14 +673,17 @@ const Select = React.createClass({
 	},
 
 	createNewOption (value) {
-		if (this.props.newOptionCreator) return this.props.newOptionCreator(value);
-		let newOption = {
-			value: value,
-			label: value,
-			create: true
-		};
-		// newOption[this.props.valueKey] = value;
-		// newOption[this.props.labelKey] = value;
+		let newOption = {};
+
+		if (this.props.newOptionCreator) {
+			newOption = this.props.newOptionCreator(value);
+		} else {
+			newOption[this.props.valueKey] = value;
+			newOption[this.props.labelKey] = value;
+		}
+
+		newOption.create = true;
+
 		return newOption;
 	},
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -493,10 +493,12 @@ const Select = React.createClass({
 		if (!options) return;
 		for (var i = 0; i < options.length; i++) {
 			if (options[i][valueKey] === value) {
-				return options[i]
-			} else if (this.props.allowCreate && value !== '') {
-				return this.createNewOption(value);
+				return options[i];
 			}
+		}
+
+		if (this.props.allowCreate && value !== '') {
+			return this.createNewOption(value);
 		}
 	},
 
@@ -673,10 +675,12 @@ const Select = React.createClass({
 	createNewOption (value) {
 		if (this.props.newOptionCreator) return this.props.newOptionCreator(value);
 		let newOption = {
+			value: value,
+			label: value,
 			create: true
 		};
-		newOption[this.props.valueKey] = value;
-		newOption[this.props.labelKey] = value;
+		// newOption[this.props.valueKey] = value;
+		// newOption[this.props.labelKey] = value;
 		return newOption;
 	},
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -29,6 +29,7 @@ const Select = React.createClass({
 	displayName: 'Select',
 
 	propTypes: {
+		addItemOnKeyCode: React.PropTypes.number,   // The key code number that should trigger adding a tag if multi and allowCreate are enabled
 		addLabelText: React.PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
 		allowCreate: React.PropTypes.bool,          // whether to allow creation of new entries
 		'aria-label': React.PropTypes.string,		// Aria label (for assistive tech)
@@ -102,6 +103,7 @@ const Select = React.createClass({
 	getDefaultProps () {
 		return {
 			addLabelText: 'Add "{label}"?',
+			addItemOnKeyCode: null,
 			autosize: true,
 			allowCreate: false,
 			backspaceRemoves: true,
@@ -437,17 +439,15 @@ const Select = React.createClass({
 			break;
 			case 36: // home key
 				this.focusStartOption();
+			default:
+				if (this.props.allowCreate && this.props.multi && event.keyCode === this.props.addItemOnKeyCode) {
+					event.preventDefault();
+					event.stopPropagation();
+					this.selectFocusedOption();
+				} else {
+					return;
+				}
 			break;
-			// case 188: // ,
-			// 	if (this.props.allowCreate && this.props.multi) {
-			// 		event.preventDefault();
-			// 		event.stopPropagation();
-			// 		this.selectFocusedOption();
-			// 	} else {
-			// 		return;
-			// 	}
-			// break;
-			default: return;
 		}
 		event.preventDefault();
 	},

--- a/src/Select.js
+++ b/src/Select.js
@@ -492,7 +492,11 @@ const Select = React.createClass({
 		let { options, valueKey } = this.props;
 		if (!options) return;
 		for (var i = 0; i < options.length; i++) {
-			if (options[i][valueKey] === value) return options[i];
+			if (options[i][valueKey] === value) {
+				return options[i]
+			} else if (this.props.allowCreate && value !== '') {
+				return this.createNewOption(value);
+			}
 		}
 	},
 
@@ -543,7 +547,13 @@ const Select = React.createClass({
 
 	removeValue (value) {
 		var valueArray = this.getValueArray(this.props.value);
-		this.setValue(valueArray.filter(i => i !== value));
+		this.setValue(valueArray.filter(i => {
+			if (i.create) {
+				return i[this.props.valueKey] !== value[this.props.valueKey] && i[this.props.labelKey] !== value[this.props.labelKey];
+			} else {
+				return i !== value;
+			}
+		}));
 		this.focus();
 	},
 
@@ -658,6 +668,16 @@ const Select = React.createClass({
 		if (this._focusedOption) {
 			return this.selectValue(this._focusedOption);
 		}
+	},
+
+	createNewOption (value) {
+		if (this.props.newOptionCreator) return this.props.newOptionCreator(value);
+		let newOption = {
+			create: true
+		};
+		newOption[this.props.valueKey] = value;
+		newOption[this.props.labelKey] = value;
+		return newOption;
 	},
 
 	renderLoading () {
@@ -845,12 +865,7 @@ const Select = React.createClass({
 				}
 			});
 			if (addNewOption) {
-				let newOption = this.props.newOptionCreator ? this.props.newOptionCreator(originalFilterValue) : {
-					value: originalFilterValue,
-					label: originalFilterValue,
-					create: true
-				};
-				filteredOptions.unshift(newOption);
+				filteredOptions.unshift(this.createNewOption(originalFilterValue));
 			}
 		}
 		return filteredOptions;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1273,10 +1273,6 @@ describe('Select', () => {
 	});
 
 	describe('with allowCreate=true', () => {
-
-		// TODO: allowCreate hasn't been implemented yet in 1.x
-		return;
-
 		beforeEach(() => {
 
 			options = [
@@ -1309,17 +1305,18 @@ describe('Select', () => {
 		it('fires an onChange with the new value when selecting the Add option', () => {
 
 			typeSearchText('xyz');
-			TestUtils.Simulate.click(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option'));
+			console.log(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option').outerHTML);
+			TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option'));
 
-			expect(onChange, 'was called with', 'xyz');
+			expect(onChange, 'was called with', { value: 'xyz', label: 'xyz', create: true });
 		});
 
 		it('allows updating the options with a new label, following the onChange', () => {
 
 			typeSearchText('xyz');
-			TestUtils.Simulate.click(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option'));
+			TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option'));
 
-			expect(onChange, 'was called with', 'xyz');
+			expect(onChange, 'was called with', { value: 'xyz', label: 'xyz', create: true });
 
 			// Now the client adds the option, with a new label
 			wrapper.setPropsForChild({
@@ -1358,28 +1355,14 @@ describe('Select', () => {
 				'to have text', 'Add test to values?');
 		});
 
-		it('does not display the option label when an existing value is entered', () => {
+		it('does not display the add option label when an existing value is entered', () => {
 
 			typeSearchText('zzzzz');
 
 			expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option'),
 				'to have length', 1);
 			expect(ReactDOM.findDOMNode(instance), 'queried for first', '.Select-menu .Select-option',
-				'to have text', 'Add zzzzz to values?');
-		});
-
-		it('renders the existing option and an add option when an existing display label is entered', () => {
-
-			typeSearchText('test value');
-
-			// First item should be the add option (as the "value" is not in the collection)
-			expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option')[0],
-				'to have text', 'Add test value to values?');
-			// Second item should be the existing option with the matching label
-			expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option')[1],
 				'to have text', 'test value');
-			expect(ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option'),
-				'to have length', 2);
 		});
 	});
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -68,6 +68,10 @@ describe('Select', () => {
 		TestUtils.Simulate.keyDown(searchInputNode, { keyCode: 65, key: 'a' });
 	};
 
+	var pressCommaToAccept = ()  =>{
+		TestUtils.Simulate.keyDown(searchInputNode, { keyCode: 188, key: 'Comma' });
+	};
+
 	var pressEnterToAccept = () => {
 		TestUtils.Simulate.keyDown(searchInputNode, { keyCode: 13, key: 'Enter' });
 	};
@@ -1305,7 +1309,6 @@ describe('Select', () => {
 		it('fires an onChange with the new value when selecting the Add option', () => {
 
 			typeSearchText('xyz');
-			console.log(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option').outerHTML);
 			TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-menu .Select-option'));
 
 			expect(onChange, 'was called with', { value: 'xyz', label: 'xyz', create: true });
@@ -1366,6 +1369,37 @@ describe('Select', () => {
 		});
 	});
 
+	describe('with addItemOnKeyCode=188', () => {
+		beforeEach(() => {
+
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'got spaces', label: 'Label for spaces' },
+				{ value: 'gotnospaces', label: 'Label for gotnospaces' },
+				{ value: 'abc 123', label: 'Label for abc 123' },
+				{ value: 'three', label: 'Three' },
+				{ value: 'zzzzz', label: 'test value' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: [],
+				options: options,
+				allowCreate: true,
+				multi: true,
+				searchable: true,
+				addLabelText: 'Add {label} to values?',
+				addItemOnKeyCode: 188
+			});
+		});
+
+		it('has an "Add xyz" option when entering xyz', () => {
+			typeSearchText('xyz');
+			pressCommaToAccept();
+			expect(onChange, 'was called with', [{ value: 'xyz', label: 'xyz', create: true }]);
+		});
+	});
 
 	describe('with multi-select', () => {
 


### PR DESCRIPTION
I took the pull request #660 (which relates to #658 and #586) and re-did it as this is a huge show stopper for me on using this library and that implementation seemed a bit broken (and the 0.9.1 does not have some of the functionality that I also need the 1.0.0-beta does).  

This adds back in the allowCreate functionality with the tests reworked to pass (I also fixed an existing failing test as it seemed to be using the old `setPropselectorChild` method instead of `setPropsForChild`)

**UPDATE:**

I added another commit here to add a more flexible solution to the old add item on comma when `allowCreate` and `mutli` are enabled.  My solution allows you to specific the keyCode to use to add a new item (set with the `addItemOnKeyCode` prop).  While comma is pretty common, it is not always the best option and making it flexible like this it not that much difference in the implementation.  This also allows you to turn off this feature which was not possible in the older implementation which i think is not completely uncommon.  By default the `addItemOnKeyCode` prop is set to null so that the user need to explicitly enable this functionality.

Also, I have no idea what the @coveralls messages mean.  I did run coverage reports before and after and the coverage did not go down after my src / test updates (they actually went up on 1 or 2 src files but only marginally).

If I could get an update if this will be an acceptable PR (or if any changes are needed to get this merged) and included into a npm tagged beta release relatively soon that would be great.  Without these changes, using this library is a show stopper.  Since 0.9.1 is also missing functionality the 1.x beta version has, using that version is also a show stopper.  If these features are not going to be able to be consumable through npm relatively soon, I am going to have to publish my own version to be able to move forward with this library which I would prefer not to do.