### PR TITLE
Don't render backspaceToRemoveMessage if backspaceRemoves is set to false

### DIFF
--- a/examples/src/components/GithubUsers.js
+++ b/examples/src/components/GithubUsers.js
@@ -44,7 +44,7 @@ const GithubUsers = React.createClass({
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
-				<Select.Async multi={this.state.multi} value={this.state.value} onChange={this.onChange} onValueClick={this.gotoUser} valueKey="id" labelKey="login" loadOptions={this.getUsers} minimumInput={1} />
+				<Select.Async multi={this.state.multi} value={this.state.value} onChange={this.onChange} onValueClick={this.gotoUser} valueKey="id" labelKey="login" loadOptions={this.getUsers} minimumInput={1} backspaceRemoves={false} />
 				<div className="checkbox-list">
 					<label className="checkbox">
 						<input type="radio" className="checkbox-control" checked={this.state.multi} onChange={this.switchToMulti}/>

--- a/src/Select.js
+++ b/src/Select.js
@@ -932,7 +932,8 @@ const Select = React.createClass({
 			!this.props.disabled &&
 			valueArray.length &&
 			!this.state.inputValue &&
-			this.state.isFocused) {
+			this.state.isFocused &&
+			this.props.backspaceRemoves) {
 			removeMessage = (
 				<span id={this._instancePrefix + '-backspace-remove-message'} className="Select-aria-only" aria-live="assertive">
 					{this.props.backspaceToRemoveMessage.replace('{label}', valueArray[valueArray.length - 1][this.props.labelKey])}


### PR DESCRIPTION
Currently if the backspaceRemoves is set to false, the backspaceToRemoveMessage it still displayed which is bad (since backspace won't remove the last item).  this just adds an additional check on the backspaceRemoves to wether it should render that message.