### PR TITLE
Fixed bug with getFocusableOptionIndex that prevents selected option …

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -920,7 +920,7 @@ const Select = React.createClass({
 	},
 
 	getFocusableOptionIndex (selectedOption) {
-		let { valueKey, multi } = this.props;
+		let { valueKey } = this.props;
 		let options = this._visibleOptions;
 		if (!options.length) return null;
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -920,12 +920,16 @@ const Select = React.createClass({
 	},
 
 	getFocusableOptionIndex (selectedOption) {
-		var options = this._visibleOptions;
+		let { valueKey, multi } = this.props;
+		let options = this._visibleOptions;
 		if (!options.length) return null;
 
 		let focusedOption = this.state.focusedOption || selectedOption;
 		if (focusedOption && !focusedOption.disabled) {
-			const focusedOptionIndex = options.indexOf(focusedOption);
+			const focusedOptionIndex = options
+				.map((option) => option.hasOwnProperty(valueKey) ? option[valueKey] : option)
+				.indexOf(focusedOption.hasOwnProperty(valueKey) ? focusedOption[valueKey] : focusedOption);
+
 			if (focusedOptionIndex !== -1) {
 				return focusedOptionIndex;
 			}
@@ -934,6 +938,7 @@ const Select = React.createClass({
 		for (var i = 0; i < options.length; i++) {
 			if (!options[i].disabled) return i;
 		}
+
 		return null;
 	},
 


### PR DESCRIPTION
This fixes a bug in the getFocusableOptionIndex func where on some circumstances it would not return the appropriate focusable option.
The current indexOf check wont work for arrays of objects - it will only work if the object references are the same, example here shows it wont work correctly: http://jsfiddle.net/7B7dQ/1/).

This could be reproduced in the example page by replacing:

```
var options = STATES[this.state.country];
```

in States.js `render()` with:

```
var options = [
    { value: 'australian-capital-territory', label: 'Australian Capital Territory', className: 'State-ACT' },
    { value: 'new-south-wales', label: 'New South Wales', className: 'State-NSW' },
    { value: 'victoria', label: 'Victoria', className: 'State-Vic' },
    { value: 'queensland', label: 'Queensland', className: 'State-Qld' },
    { value: 'western-australia', label: 'Western Australia', className: 'State-WA' },
    { value: 'south-australia', label: 'South Australia', className: 'State-SA' },
    { value: 'tasmania', label: 'Tasmania', className: 'State-Tas' },
    { value: 'northern-territory', label: 'Northern Territory', className: 'State-NT' },
];
```

If you select (click) option 'Northern Territory' for example and then re-open the selector - it always focuses on the first option.
This fails because its a new reference on each render.
