### PR TITLE
Prevent getFocusableOptionIndex from returning a disabled option.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -871,7 +871,7 @@ const Select = React.createClass({
 		if (!options.length) return null;
 
 		let focusedOption = this.state.focusedOption || selectedOption;
-		if (focusedOption) {
+		if (focusedOption && !focusedOption.disabled) {
 			const focusedOptionIndex = options.indexOf(focusedOption);
 			if (focusedOptionIndex !== -1) {
 				return focusedOptionIndex;


### PR DESCRIPTION
This PR prevents `getFocusableOptionIndex` from ever returning the index of a disabled option.

This resolves #1006 and prevents disabled options from ever receiving focus and becoming selectable by tab-completion.