### PR TITLE
Close opened menu if disabled becomes true

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -212,6 +212,7 @@ const Select = React.createClass({
 		}
 		if (prevProps.disabled !== this.props.disabled) {
 			this.setState({ isFocused: false }); // eslint-disable-line react/no-did-update-set-state
+			this.closeMenu();
 		}
 	},
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1904,6 +1904,15 @@ describe('Select', () => {
 				    ReactDOM.render(<Select disabled={true} searchable={true} value="three" options={defaultOptions} />, node);
 						expect(instance.state.isFocused, 'to equal', false);
 				});
+
+				it('should close the opened menu if disabled=true', function(){
+
+					findAndFocusInputControl();
+					TestUtils.Simulate.mouseDown(getSelectControl(instance));
+					expect(node, 'queried for', '.Select-option', 'to have length', 4);
+					ReactDOM.render(<Select disabled={true} searchable={true} value="three" options={defaultOptions} />, node);
+					expect(node, 'to contain no elements matching', '.Select-option');
+				});
 			});
 		});
 


### PR DESCRIPTION
This fixes #762 by invoking `this.closeMenu()` when `disabled` is changed. I also added a corresponding test. Cheers!