### PR TITLE
Loosened the test for :activeElement in handleInputBlur() to 

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -358,7 +358,8 @@ const Select = React.createClass({
 	},
 
 	handleInputBlur (event) {
-		if (this.refs.menu && document.activeElement === this.refs.menu) {
+		// The check for menu.contains(activeElement) is necessary to prevent IE11's scrollbar from closing the menu in certain contexts.
+		if (this.refs.menu && (this.refs.menu === document.activeElement || this.refs.menu.contains(document.activeElement))) {
 			this.focus();
 			return;
 		}


### PR DESCRIPTION
This prevents the Select from closing when the user clicks on IE11 scrollbar

Related to bvaughn/react-virtualized-select/issues/12