### PR TITLE
fixes issue with an outline appearing on the auto sized input

### DIFF
--- a/scss/control.scss
+++ b/scss/control.scss
@@ -50,6 +50,10 @@
 	&:hover {
 		box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
 	}
+
+	.Select-input:focus {
+		outline: none;
+	}
 }
 
 .is-searchable {


### PR DESCRIPTION
So with the latest code in master, if searchable is set to false, this happen when you click in the input looking element:

![screen shot 2016-06-27 at 7 14 23 am](https://cloud.githubusercontent.com/assets/444206/16377932/f5fe559c-3c36-11e6-8eec-e2ca2486ad49.png)

This is basically just the default browsers outline for the input element so I added some css to prevent this issue from happening.