### PR TITLE
Stop propagation in pressing escape key

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -450,6 +450,7 @@ var Select = _react2['default'].createClass({
 				} else if (this.props.clearable && this.props.escapeClearsValue) {
 					this.clearValue(event);
 				}
+				event.stopPropagation();
 				break;
 			case 38:
 				// up


### PR DESCRIPTION
I use `react-select` on `react-modal`, but when pressing the escape key to close the `react-select` options menu, `react-modal` is also closed unexpectedly. To resolve this issue, I'd like to stop propagation in pressing escape key.
