### PR TITLE
update required prop based on nextProps on update. closes #1077

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -169,7 +169,7 @@ const Select = React.createClass({
 	},
 
 	componentWillReceiveProps(nextProps) {
-		const valueArray = this.getValueArray(nextProps.value);
+		const valueArray = this.getValueArray(nextProps.value, nextProps);
 
 		if (nextProps.required) {
 			this.setState({
@@ -477,22 +477,35 @@ const Select = React.createClass({
 		return op[this.props.labelKey];
 	},
 
-	getValueArray (value) {
-		if (this.props.multi) {
-			if (typeof value === 'string') value = value.split(this.props.delimiter);
+	/**
+	 * Turns a value into an array from the given options
+	 * @param {String|Number|Array} value - the value of the select input
+	 * @param {Object} nextProps - optionally specify the nextProps so the returned array uses the latest configuration
+	 * @returns {Array} the value of the select represented in an array
+	 */
+	getValueArray (value, nextProps) {
+		/** support optionally passing in the `nextProps` so `componentWillReceiveProps` updates will function as expected */
+		const props = typeof nextProps === 'object' ? nextProps : this.props;
+		if (props.multi) {
+			if (typeof value === 'string') value = value.split(props.delimiter);
 			if (!Array.isArray(value)) {
 				if (value === null || value === undefined) return [];
 				value = [value];
 			}
-			return value.map(this.expandValue).filter(i => i);
+			return value.map(value => this.expandValue(value, props)).filter(i => i);
 		}
-		var expandedValue = this.expandValue(value);
+		var expandedValue = this.expandValue(value, props);
 		return expandedValue ? [expandedValue] : [];
 	},
 
-	expandValue (value) {
+	/**
+	 * Retrieve a value from the given options and valueKey
+	 * @param	{String|Number|Array} value - the selected value(s)
+	 * @param	{Object} props - the Select component's props (or nextProps)
+	 */
+	expandValue (value, props) {
 		if (typeof value !== 'string' && typeof value !== 'number') return value;
-		let { options, valueKey } = this.props;
+		let { options, valueKey } = props;
 		if (!options) return;
 		for (var i = 0; i < options.length; i++) {
 			if (options[i][valueKey] === value) return options[i];

--- a/src/Select.js
+++ b/src/Select.js
@@ -479,9 +479,9 @@ const Select = React.createClass({
 
 	/**
 	 * Turns a value into an array from the given options
-	 * @param {String|Number|Array} value - the value of the select input
-	 * @param {Object} nextProps - optionally specify the nextProps so the returned array uses the latest configuration
-	 * @returns {Array} the value of the select represented in an array
+	 * @param	{String|Number|Array}	value		- the value of the select input
+	 * @param	{Object}		nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
+	 * @returns	{Array}	the value of the select represented in an array
 	 */
 	getValueArray (value, nextProps) {
 		/** support optionally passing in the `nextProps` so `componentWillReceiveProps` updates will function as expected */
@@ -500,8 +500,8 @@ const Select = React.createClass({
 
 	/**
 	 * Retrieve a value from the given options and valueKey
-	 * @param	{String|Number|Array} value - the selected value(s)
-	 * @param	{Object} props - the Select component's props (or nextProps)
+	 * @param	{String|Number|Array}	value	- the selected value(s)
+	 * @param	{Object}		props	- the Select component's props (or nextProps)
 	 */
 	expandValue (value, props) {
 		if (typeof value !== 'string' && typeof value !== 'number') return value;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -403,7 +403,7 @@ describe('Select', () => {
 				value: 'one',
 				options: longerListOptions,
 				simpleValue: true,
-			});	
+			});
 
 			var selectControl = getSelectControl(longerListInstance);
 			TestUtils.Simulate.mouseDown(selectControl);
@@ -421,7 +421,7 @@ describe('Select', () => {
 				options: longerListOptions,
 				simpleValue: true,
 				pageSize: 7
-			});	
+			});
 
 			var selectControl = getSelectControl(longerListInstance);
 			TestUtils.Simulate.mouseDown(selectControl);
@@ -448,7 +448,7 @@ describe('Select', () => {
 				value: 'one',
 				options: longerListOptions,
 				simpleValue: true,
-			});	
+			});
 
 			var selectControl = getSelectControl(longerListInstance);
 			TestUtils.Simulate.mouseDown(selectControl);
@@ -467,7 +467,7 @@ describe('Select', () => {
 				options: longerListOptions,
 				simpleValue: true,
 				pageSize: 7
-			});	
+			});
 
 			var selectControl = getSelectControl(longerListInstance);
 			TestUtils.Simulate.mouseDown(selectControl);
@@ -890,8 +890,6 @@ describe('Select', () => {
 			expect(node, 'queried for', DISPLAYED_SELECTION_SELECTOR,
 				'to have items satisfying', 'to have text', 'One');
 		});
-
-
 
 		it('supports setting the value via prop', () => {
 
@@ -1382,7 +1380,6 @@ describe('Select', () => {
 				'to have length', 2);
 		});
 	});
-
 
 	describe('with multi-select', () => {
 
@@ -3127,6 +3124,23 @@ describe('Select', () => {
 
 				expect(instance.state.required, 'to be true');
 				wrapper.setPropsForChild({ value: 'one' });
+				expect(instance.state.required, 'to be false');
+			});
+
+			it('input should not have required attribute after updating the component with a value and options', () => {
+				wrapper = createControlWithWrapper({
+					options: defaultOptions,
+					value: 'one',
+					required: true
+				});
+
+				expect(instance.state.required, 'to be false');
+				wrapper.setPropsForChild({
+					value: 'newValue',
+					options: [
+						{ value: 'newValue', label: 'New value, new options' }
+					]
+				});
 				expect(instance.state.required, 'to be false');
 			});
 


### PR DESCRIPTION
This resolves the issue where the required prop (and the `valueArray`) retrieved during `componentWillReceiveProps` failed to reflect the values in `nextProps` due to relying on `this.props` properties.

I wrote a test case that failed before my change, and now it passes as expected.

The basic premise is that if you use the `required` attribute while _updating_ props like `value`, `options`, `valueKey`, it may get improperly set on the typeahead input. For instance, if you change the `value` and `options` to a completely different set the method `this.getValueArray` fails to find the value within the old set of options and despite rendering the appropriate selection text from the nextProps on `render`, the input gets the `required` attribute applied during `componentWillReceiveProps`'s `handledRequired` call.

Not sure what style of documentation you prefer, but I figured I would also add some jsdoc comments for these two methods that I touched.