### PR TITLE
Fix the "Unknown prop `inputClassName` on <div> tag" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/JedWatson/react-select.git"
   },
   "dependencies": {
+    "blacklist": "^1.1.2",
     "classnames": "^2.2.4",
     "react-input-autosize": "^1.1.0"
   },

--- a/src/Select.js
+++ b/src/Select.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Input from 'react-input-autosize';
 import classNames from 'classnames';
+import blacklist from 'blacklist';
 
 import stripDiacritics from './utils/stripDiacritics';
 
@@ -763,9 +764,10 @@ const Select = React.createClass({
 			});
 
 			if (this.props.disabled || !this.props.searchable) {
+				const divProps = blacklist(this.props.inputProps, 'inputClassName');
 				return (
 					<div
-						{...this.props.inputProps}
+						{...divProps}
 						role="combobox"
 						aria-expanded={isOpen}
 						aria-owns={isOpen ? this._instancePrefix + '-list' : this._instancePrefix + '-value'}


### PR DESCRIPTION
By removing the `inputClassName` from the props we pass to the div we
get rid of the warning.