### PR TITLE
On focus check whether input ref is a real input or an input component

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -292,8 +292,14 @@ const Select = React.createClass({
 			// Call focus() again here to be safe.
 			this.focus();
 
+			let input = this.refs.input;
+			if (typeof input.getInput === 'function') {
+				// Get the actual DOM input if the ref is an <Input /> component
+				input = input.getInput();
+			}
+
 			// clears value so that the cursor will be a the end of input then the component re-renders
-			this.refs.input.getInput().value = '';
+			input.value = '';
 
 			// if the input is focused, ensure the menu is open
 			this.setState({


### PR DESCRIPTION
Fixes an issue where configuring react-select with `autosize` off causes an error to be emitted when clicking on the already focused input:

```
Uncaught TypeError: this.refs.input.getInput is not a function
```

It looks like the change in #946 was based on `this.refs.input` being an `Input` instance, but [if `autosize` is disabled it's just a plain HTML input](https://github.com/JedWatson/react-select/blob/master/src/Select.js#L785).