### PR TITLE
Remove minWidth prop from autosized inputs. See issue #1063.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -784,7 +784,7 @@ const Select = React.createClass({
 
 			if (this.props.autosize) {
 				return (
-					<Input {...inputProps} minWidth="5px" />
+					<Input {...inputProps} />
 				);
 			}
 			return (


### PR DESCRIPTION
In version 15.2.1 of React, the adding a minWidth prop to an input produces a warning like this:

warning.js:44 Warning: Unknown prop `minWidth` on <input> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in input (created by AutosizeInput)
    in div (created by AutosizeInput)
    in AutosizeInput (created by Select)
    in div (created by Select)
    in div (created by Select)
    in Select (created by PatientSelectInput)