### PR TITLE
update npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![NPM](https://badge.fury.io/js/react-select.png)](https://www.npmjs.com/package/react-select)
+[![NPM](https://img.shields.io/npm/v/react-select.svg)](https://www.npmjs.com/package/react-select)
 [![Build Status](https://travis-ci.org/JedWatson/react-select.svg?branch=master)](https://travis-ci.org/JedWatson/react-select)
 [![Coverage Status](https://coveralls.io/repos/JedWatson/react-select/badge.svg?branch=master&service=github)](https://coveralls.io/github/JedWatson/react-select?branch=master)
 


### PR DESCRIPTION
Using shields gives an svg which looks much better (especially on retina screens):

before:

<img width="383" alt="screen shot 2016-07-25 at 2 07 45 pm" src="https://cloud.githubusercontent.com/assets/1500684/17115643/8a053440-5271-11e6-8e9e-d53d645d4fa1.png">

after:

<img width="375" alt="screen shot 2016-07-25 at 2 09 42 pm" src="https://cloud.githubusercontent.com/assets/1500684/17115637/840371ce-5271-11e6-94e8-324e64a52d84.png">
