### PR TITLE
fix value check in renderClear

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -866,7 +866,7 @@ var Select = _react2['default'].createClass({
 	},
 
 	renderClear: function renderClear() {
-		if (!this.props.clearable || !this.props.value || this.props.multi && !this.props.value.length || this.props.disabled || this.props.isLoading) return;
+		if (!this.props.clearable || !this.props.value && this.props.value !== 0 || this.props.multi && !this.props.value.length || this.props.disabled || this.props.isLoading) return;
 		return _react2['default'].createElement(
 			'span',
 			{ className: 'Select-clear-zone', title: this.props.multi ? this.props.clearAllText : this.props.clearValueText,


### PR DESCRIPTION
I assume that it is common case that some one use options array with value started from 0:

Then we need to render clear button when the 0 value is chosen.
e.g. 

```
[
  {value:0,label:'Aachen [Aix-la-Chapelle]',state:'NW'},
  {value:1,label:'Aalen',state:'BW'},
]
```
