### PR TITLE
 Default reset value to [] when multi=true

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -130,7 +130,6 @@ const Select = React.createClass({
 			pageSize: 5,
 			placeholder: 'Select...',
 			required: false,
-			resetValue: null,
 			scrollMenuIntoView: true,
 			searchable: true,
 			simpleValue: false,
@@ -580,11 +579,21 @@ const Select = React.createClass({
 		}
 		event.stopPropagation();
 		event.preventDefault();
-		this.setValue(this.props.resetValue);
+		this.setValue(this.getResetValue());
 		this.setState({
 			isOpen: false,
 			inputValue: '',
 		}, this.focus);
+	},
+
+	getResetValue() {
+		if (this.props.resetValue !== undefined) {
+			return this.props.resetValue;
+		} else if (this.props.multi) {
+			return [];
+		} else {
+			return null;
+		}
 	},
 
 	focusOption (option) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1565,6 +1565,30 @@ describe('Select', () => {
 
 	});
 
+	describe('with multi=true and clearable=true', () => {
+		beforeEach(() => {
+
+			options = [
+				{ value: 0, label: 'Zero' },
+				{ value: 1, label: 'One' }
+			];
+
+			wrapper = createControlWithWrapper({
+				value: [0],
+				options: options,
+				multi: true,
+				clearable: true
+			});
+
+		});
+
+		it('calls onChange with an empty list when cleared', () => {
+
+			TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'), { button: 0 });
+			expect(onChange, 'was called with', []);
+		});
+	});
+
 	describe('with multi=true and searchable=false', () => {
 
 		beforeEach(() => {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1720,7 +1720,7 @@ describe('Select', () => {
 
 			describe('on clicking `clear`', () => {
 				beforeEach(() => {
-					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'), { button: 0 });
 				});
 
 				it('calls onChange with empty', () => {
@@ -1771,7 +1771,7 @@ describe('Select', () => {
 				});
 
 				it('calls onChange with a custom resetValue', () => {
-					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'));
+					TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-clear'), { button: 0 });
 					expect(onChange, 'was called with', 'reset');
 				});
 			});


### PR DESCRIPTION
If `resetValue` is not set, then `onChange` is called with `[]` instead of `null` when `multi=true`, which should help with #1170.

This also fixes the other tests that clear by clicking `.Select-clear`.