### PR TITLE
Handle touch outside to dismiss menu

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -171,6 +171,8 @@ const Select = React.createClass({
 		if (this.props.autofocus) {
 			this.focus();
 		}
+
+		document.addEventListener('touchstart', this.handleTouchOutside);
 	},
 
 	componentWillReceiveProps(nextProps) {
@@ -219,6 +221,13 @@ const Select = React.createClass({
 		}
 		if (prevProps.disabled !== this.props.disabled) {
 			this.setState({ isFocused: false }); // eslint-disable-line react/no-did-update-set-state
+			this.closeMenu();
+		}
+	},
+
+	handleTouchOutside(event) {
+		// handle touch outside on ios to dismiss menu
+		if (this.wrapper && !this.wrapper.contains(event.target)) {
 			this.closeMenu();
 		}
 	},

--- a/src/Select.js
+++ b/src/Select.js
@@ -171,8 +171,6 @@ const Select = React.createClass({
 		if (this.props.autofocus) {
 			this.focus();
 		}
-
-		document.addEventListener('touchstart', this.handleTouchOutside);
 	},
 
 	componentWillReceiveProps(nextProps) {
@@ -187,6 +185,7 @@ const Select = React.createClass({
 
 	componentWillUpdate (nextProps, nextState) {
 		if (nextState.isOpen !== this.state.isOpen) {
+			this.toggleTouchOutsideEvent(nextState.isOpen);
 			const handler = nextState.isOpen ? nextProps.onOpen : nextProps.onClose;
 			handler && handler();
 		}
@@ -222,6 +221,18 @@ const Select = React.createClass({
 		if (prevProps.disabled !== this.props.disabled) {
 			this.setState({ isFocused: false }); // eslint-disable-line react/no-did-update-set-state
 			this.closeMenu();
+		}
+	},
+
+	componentWillUnmount() {
+		document.removeEventListener('touchstart', this.handleTouchOutside);
+	},
+
+	toggleTouchOutsideEvent(enabled) {
+		if (enabled) {
+			document.addEventListener('touchstart', this.handleTouchOutside);
+		} else {
+			document.removeEventListener('touchstart', this.handleTouchOutside);
 		}
 	},
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3324,24 +3324,29 @@ describe('Select', () => {
 		});
 	});
 
-	describe('clicking outside', () => {
+	describe('outside event', () => {
 
 		beforeEach(() => {
-
 			instance = createControl({
 				options: defaultOptions
 			});
-		});
-
-		it('closes the menu', () => {
-
 			TestUtils.Simulate.mouseDown(getSelectControl(instance), { button: 0 });
 			expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-option',
 				'to have length', 4);
+		});
 
+		it('click closes the menu', () => {
 			TestUtils.Simulate.blur(searchInputNode);
 			expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching', '.Select-option');
 		});
+
+		it('touch closes the menu', () => {
+			const evt = document.createEvent('Event');
+			evt.initEvent('touchstart', true, true);
+			document.querySelector('body').dispatchEvent(evt);
+			expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching', '.Select-option');
+		});
+
 	});
 
 	describe('with autosize=false', () => {


### PR DESCRIPTION
This is so that the menu closes after you touch outside of select on touch devices

Fixes: https://github.com/JedWatson/react-select/issues/435

Note: failed test has nothing to do with this PR