### PR TITLE
Allow closing multi select on select

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ function onInputKeyDown(event) {
 	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
 	menuRenderer | func | undefined | Renders a custom menu with options; accepts the following named parameters: `menuRenderer({ focusedOption, focusOption, options, selectValue, valueArray })`
 	multi 		|	bool	|	undefined	|	multi-value input
+	multiCloseOnSelect 		|	bool	|	false	|	multi-value input should close after a value is selected
 	name 		|	string	|	undefined	|	field name, for hidden `<input />` tag
 	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results or a falsy value to hide it
 	onBlur 		|	func	|	undefined	|	onBlur handler: `function(event) {}`

--- a/src/Select.js
+++ b/src/Select.js
@@ -75,6 +75,7 @@ const Select = React.createClass({
 		menuRenderer: React.PropTypes.func,         // renders a custom menu with options
 		menuStyle: React.PropTypes.object,          // optional style to apply to the menu
 		multi: React.PropTypes.bool,                // multi-value input
+		multiCloseOnSelect: React.PropTypes.bool,   // multi-value input should close after a value is selected
 		name: React.PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
 		noResultsText: stringOrNode,                // placeholder displayed when there are no matching search results
 		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
@@ -138,6 +139,7 @@ const Select = React.createClass({
 			menuBuffer: 0,
 			menuRenderer: defaultMenuRenderer,
 			multi: false,
+			multiCloseOnSelect: false,
 			noResultsText: 'No results found',
 			onBlurResetsInput: true,
 			onCloseResetsInput: true,
@@ -582,7 +584,8 @@ const Select = React.createClass({
 		if (this.props.multi) {
 			this.setState({
 				inputValue: '',
-				focusedIndex: null
+				focusedIndex: null,
+				isOpen: !this.props.multiCloseOnSelect
 			}, () => {
 				this.addValue(value);
 			});


### PR DESCRIPTION
#939 Add property multiCloseOnSelect to close mutli select after the user selects a value.  The default value of false leaves the behavior of leaving the multi select open unchanged.
