### PR TITLE
Allowing to pass options to Select.Async

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -55,6 +55,7 @@ const Async = React.createClass({
 		placeholder: stringOrNode,                      // field placeholder, displayed when there's no value (shared with Select)
 		searchPromptText: stringOrNode,       // label to prompt for search input
 		searchingText: React.PropTypes.string,          // message to display while options are loading
+		options: React.PropTypes.array,                 // initial options, usefull if you want to do a preselection and your minimumInput is > 0
 	},
 	getDefaultProps () {
 		return {
@@ -85,6 +86,14 @@ const Async = React.createClass({
 			this.setState({
 				cache: initCache(nextProps.cache),
 			});
+		}
+
+		if (nextProps.options !== this.props.options) {
+			if (nextProps.options && nextProps.options.length > 0) {
+				this.setState({
+					options: nextProps.options,
+				});
+			}
 		}
 	},
 	focus () {


### PR DESCRIPTION
With this PR you are able to pass default options to Select.Async. This allows you to set a default value without calling the Async promise.

See Issue #1138

Example:
```js
     const options = [{
        name: "My selected value",
        id: "1",
      }];

    const asyncOptions = {
      options,
      value: "1",
      // loadOptions: fetchFn,
    };

    return <Select.Async { ...asyncOptions } />;
```