### PR TITLE
Document promptTextCreator property of Creatable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Property | Type | Description
 `isValidNewOption` | function | Determines if the current input text represents a valid option. By default any non-empty string will be considered valid. Expected signature: `({ label: string }): boolean` |
 `newOptionCreator` | function | Factory to create new option. Expected signature: `({ label: string, labelKey: string, valueKey: string }): Object` |
 `shouldKeyDownEventCreateNewOption` | function | Decides if a keyDown event (eg its `keyCode`) should result in the creation of a new option. ENTER, TAB and comma keys create new options by dfeault. Expected signature: `({ keyCode: number }): boolean` |
+`promptTextCreator` | function | Factory for overriding default option creator prompt label. By default it will read 'Create option "{label}"'. Expected signature: `(label: String): String` |
 
 ### Filtering options
 


### PR DESCRIPTION
Documents ability to override default prompt label for the `Creatable` component.

https://github.com/JedWatson/react-select/issues/1202#issuecomment-246130181