### PR TITLE
AsyncCreatable HOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,24 @@ Property | Type | Description
 `shouldKeyDownEventCreateNewOption` | function | Decides if a keyDown event (eg its `keyCode`) should result in the creation of a new option. ENTER, TAB and comma keys create new options by dfeault. Expected signature: `({ keyCode: number }): boolean` |
 `promptTextCreator` | function | Factory for overriding default option creator prompt label. By default it will read 'Create option "{label}"'. Expected signature: `(label: String): String` |
 
+### Combining Async and Creatable
+
+Use the `AsyncCreatable` HOC if you want both _async_ and _creatable_ functionality.
+It ties `Async` and `Creatable` components together and supports a union of their properties (listed above).
+Use it as follows:
+
+```jsx
+import React from 'react';
+import { AsyncCreatable } from 'react-select';
+
+function render (props) {
+  // props can be a mix of Async, Creatable, and Select properties
+  return (
+    <AsyncCreatable {...props} />
+  );
+}
+```
+
 ### Filtering options
 
 You can control how options are filtered with the following properties:

--- a/examples/src/components/GithubUsers.js
+++ b/examples/src/components/GithubUsers.js
@@ -40,11 +40,20 @@ const GithubUsers = React.createClass({
 	gotoUser (value, event) {
 		window.open(value.html_url);
 	},
+	toggleCreatable () {
+		this.setState({
+			creatable: !this.state.creatable
+		});
+	},
 	render () {
+		const AsyncComponent = this.state.creatable
+			? Select.AsyncCreatable
+			: Select.Async;
+
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
-				<Select.Async multi={this.state.multi} value={this.state.value} onChange={this.onChange} onValueClick={this.gotoUser} valueKey="id" labelKey="login" loadOptions={this.getUsers} minimumInput={1} backspaceRemoves={false} />
+				<AsyncComponent multi={this.state.multi} value={this.state.value} onChange={this.onChange} onValueClick={this.gotoUser} valueKey="id" labelKey="login" loadOptions={this.getUsers} minimumInput={1} backspaceRemoves={false} />
 				<div className="checkbox-list">
 					<label className="checkbox">
 						<input type="radio" className="checkbox-control" checked={this.state.multi} onChange={this.switchToMulti}/>
@@ -53,6 +62,12 @@ const GithubUsers = React.createClass({
 					<label className="checkbox">
 						<input type="radio" className="checkbox-control" checked={!this.state.multi} onChange={this.switchToSingle}/>
 						<span className="checkbox-label">Single Value</span>
+					</label>
+				</div>
+				<div className="checkbox-list">
+					<label className="checkbox">
+					   <input type="checkbox" className="checkbox-control" checked={this.state.creatable} onChange={this.toggleCreatable} />
+					   <span className="checkbox-label">Creatable?</span>
 					</label>
 				</div>
 				<div className="hint">This example uses fetch.js for showing Async options with Promises</div>

--- a/src/Async.js
+++ b/src/Async.js
@@ -127,7 +127,7 @@ const Async = React.createClass({
 			return this.resetState();
 		}
 		let cacheResult = getFromCache(this.state.cache, input);
-		if (cacheResult) {
+		if (cacheResult && Array.isArray(cacheResult.options)) {
 			return this.setState({
 				options: cacheResult.options,
 			});

--- a/src/AsyncCreatable.js
+++ b/src/AsyncCreatable.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Select from './Select';
+
+function AsyncCreatable (props) {
+	return (
+		<Select.Async {...props}>
+			{(asyncProps) => (
+				<Select.Creatable {...props}>
+					{(creatableProps) => (
+						<Select
+							{...asyncProps}
+							{...creatableProps}
+							onInputChange={(input) => {
+								creatableProps.onInputChange(input);
+								return asyncProps.onInputChange(input);
+							}}
+							ref={(ref) => {
+								creatableProps.ref(ref);
+								asyncProps.ref(ref);
+							}}
+						/>
+					)}
+				</Select.Creatable>
+			)}
+		</Select.Async>
+	);
+};
+
+module.exports = AsyncCreatable;

--- a/src/AsyncCreatable.js
+++ b/src/AsyncCreatable.js
@@ -1,29 +1,33 @@
 import React from 'react';
 import Select from './Select';
 
-function AsyncCreatable (props) {
-	return (
-		<Select.Async {...props}>
-			{(asyncProps) => (
-				<Select.Creatable {...props}>
-					{(creatableProps) => (
-						<Select
-							{...asyncProps}
-							{...creatableProps}
-							onInputChange={(input) => {
-								creatableProps.onInputChange(input);
-								return asyncProps.onInputChange(input);
-							}}
-							ref={(ref) => {
-								creatableProps.ref(ref);
-								asyncProps.ref(ref);
-							}}
-						/>
-					)}
-				</Select.Creatable>
-			)}
-		</Select.Async>
-	);
-};
+const AsyncCreatable = React.createClass({
+	displayName: 'AsyncCreatableSelect',
+
+	render () {
+		return (
+			<Select.Async {...this.props}>
+				{(asyncProps) => (
+					<Select.Creatable {...this.props}>
+						{(creatableProps) => (
+							<Select
+								{...asyncProps}
+								{...creatableProps}
+								onInputChange={(input) => {
+									creatableProps.onInputChange(input);
+									return asyncProps.onInputChange(input);
+								}}
+								ref={(ref) => {
+									creatableProps.ref(ref);
+									asyncProps.ref(ref);
+								}}
+							/>
+						)}
+					</Select.Creatable>
+				)}
+			</Select.Async>
+		);
+	}
+});
 
 module.exports = AsyncCreatable;

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -87,8 +87,9 @@ const Creatable = React.createClass({
 	filterOptions (...params) {
 		const { filterOptions, isValidNewOption, options, promptTextCreator } = this.props;
 
-		// Check selected options as well.
+		// TRICKY Check currently selected options as well.
 		// Don't display a create-prompt for a value that's selected.
+		// This covers async edge-cases where a newly-created Option isn't yet in the async-loaded array.
 		const excludeOptions = params[2] || [];
 
 		const filteredOptions = filterOptions(...params);

--- a/src/Select.js
+++ b/src/Select.js
@@ -14,6 +14,7 @@ import defaultFilterOptions from './utils/defaultFilterOptions';
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
 
 import Async from './Async';
+import AsyncCreatable from './AsyncCreatable';
 import Creatable from './Creatable';
 import Option from './Option';
 import Value from './Value';
@@ -111,7 +112,7 @@ const Select = React.createClass({
 		wrapperStyle: React.PropTypes.object,       // optional style to apply to the component wrapper
 	},
 
-	statics: { Async, Creatable },
+	statics: { Async, AsyncCreatable, Creatable },
 
 	getDefaultProps () {
 		return {

--- a/test/AsyncCreatable-test.js
+++ b/test/AsyncCreatable-test.js
@@ -1,0 +1,63 @@
+'use strict';
+/* global describe, it, beforeEach */
+/* eslint react/jsx-boolean-value: 0 */
+
+// Copied from Async-test verbatim; may need to be reevaluated later.
+var jsdomHelper = require('../testHelpers/jsdomHelper');
+jsdomHelper();
+var unexpected = require('unexpected');
+var unexpectedDom = require('unexpected-dom');
+var unexpectedReact = require('unexpected-react');
+var expect = unexpected
+	.clone()
+	.installPlugin(unexpectedDom)
+	.installPlugin(unexpectedReact);
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+var sinon = require('sinon');
+var Select = require('../src/Select');
+
+describe('AsyncCreatable', () => {
+	let creatableInstance, creatableNode, filterInputNode, loadOptions, renderer;
+
+	beforeEach(() => {
+		loadOptions = sinon.stub();
+		renderer = TestUtils.createRenderer();
+	});
+
+	function createControl (props = {}) {
+		props.loadOptions = props.loadOptions || loadOptions;
+		creatableInstance = TestUtils.renderIntoDocument(
+			<Select.AsyncCreatable {...props} />
+		);
+		creatableNode = ReactDOM.findDOMNode(creatableInstance);
+		findAndFocusInputControl();
+	};
+
+	function findAndFocusInputControl () {
+		filterInputNode = creatableNode.querySelector('input');
+		if (filterInputNode) {
+			TestUtils.Simulate.focus(filterInputNode);
+		}
+	};
+
+	it('should create an inner Select', () => {
+		createControl();
+		expect(creatableNode, 'to have attributes', {
+			class: ['Select']
+		});
+	});
+
+	it('should render a decorated Select (with passed through properties)', () => {
+		createControl({
+			inputProps: {
+				className: 'foo'
+			}
+		});
+		expect(creatableNode.querySelector('.Select-input'), 'to have attributes', {
+			class: ['foo']
+		});
+	});
+});

--- a/test/AsyncCreatable-test.js
+++ b/test/AsyncCreatable-test.js
@@ -2,7 +2,6 @@
 /* global describe, it, beforeEach */
 /* eslint react/jsx-boolean-value: 0 */
 
-// Copied from Async-test verbatim; may need to be reevaluated later.
 var jsdomHelper = require('../testHelpers/jsdomHelper');
 jsdomHelper();
 var unexpected = require('unexpected');

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -76,6 +76,32 @@ describe('Creatable', () => {
 		expect(creatableNode.querySelector('.Select-menu-outer').textContent, 'not to equal', Select.Creatable.promptTextCreator('existing'));
 	});
 
+	it('should filter the "create..." prompt using both filtered options and currently-selected options', () => {
+		let isOptionUniqueParams;
+		createControl({
+			filterOptions: () => [
+				{ value: 'one', label: 'One' }
+			],
+			isOptionUnique: (params) => {
+				isOptionUniqueParams = params;
+			},
+			multi: true,
+			options: [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' }
+			],
+			value: [
+				{ value: 'three', label: 'Three' }
+			]
+		});
+		typeSearchText('test');
+		const { options } = isOptionUniqueParams;
+		const values = options.map(option => option.value);
+		expect(values, 'to have length', 2);
+		expect(values, 'to contain', 'one');
+		expect(values, 'to contain', 'three');
+	});
+
 	it('should not show a "create..." prompt if current filter text is not a valid option (as determined by :isValidNewOption prop)', () => {
 		createControl({
 			isValidNewOption: () => false


### PR DESCRIPTION
Resolves issue #1200.

### Summary

Combining `Async` and `Creatable` HOCs turned out to be more tricky than I had initially expected. It is not sufficient to simple nest one within the other. To this end, I propose a new `AsyncCreatable` HOC that neatly ties the other two together (keeping the complexity out of user-land).

In general, async and composition is an area that we should probably put a lot of thought into before version 2 ships (so as to avoid some of the hackiness in this PR). Maybe this is good enough for v1 though?

I've updated the example site so that the Github users (Async) demo has a "creatable?" checkbox that can be used to test the Async + Creatable combination.

### Syntax

```jsx
import React from 'react';
import { AsyncCreatable } from 'react-select';

function render (props) {
  return (
    <AsyncCreatable {...props} />
  );
}
```

### Demo
<img src="https://cloud.githubusercontent.com/assets/29597/18430286/662a48de-790a-11e6-879a-8a4201c66eef.gif" width="320" height="208" />