### PR TITLE
Add "select all text" functionality Shift+Home|Del

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -496,9 +496,15 @@ const Select = React.createClass({
 				this.focusPageDownOption();
 			break;
 			case 35: // end key
+				if (event.shiftKey) {
+					return;
+				}
 				this.focusEndOption();
 			break;
 			case 36: // home key
+				if (event.shiftKey) {
+					return;
+				}
 				this.focusStartOption();
 			break;
 			default: return;


### PR DESCRIPTION
Use-case:

I've written a long text in the Select input-box
I want to clear all text: I press Shift+Home to select all text, and then Delete to clear it.
^ It doesn't work.