### PR TITLE
fix(async): create new cache object for each instance by default

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -21,9 +21,11 @@ const propTypes = {
 	]),
 };
 
+const defaultCache = {};
+
 const defaultProps = {
 	autoload: true,
-	cache: {},
+	cache: defaultCache,
 	children: defaultChildren,
 	ignoreAccents: true,
 	ignoreCase: true,
@@ -42,6 +44,10 @@ export default class Async extends Component {
 		};
 
 		this._onInputChange = this._onInputChange.bind(this);
+	}
+
+	componentWillMount () {
+		this.cache = this.props.cache === defaultCache ? {} : this.props.cache;
 	}
 
 	componentDidMount () {
@@ -64,7 +70,8 @@ export default class Async extends Component {
 	}
 
 	loadOptions (inputValue) {
-		const { cache, loadOptions } = this.props;
+		const { loadOptions } = this.props;
+		const cache = this.cache;
 
 		if (
 			cache &&

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -117,6 +117,14 @@ describe('Async', () => {
 			typeSearchText('a');
 			return expect(loadOptions, 'was called times', 1);
 		});
+
+		it('should not use the same cache for every instance by default', () => {
+			createControl();
+			const instance1 = asyncInstance;
+			createControl();
+			const instance2 = asyncInstance;
+			expect(instance1.cache !== instance2.cache, 'to equal', true);
+		})
 	});
 
 	describe('loadOptions', () => {


### PR DESCRIPTION
fix #1236
Previously, the same object was being used by for async cache by
default when no cache was passed to the component. This same object
was used for every instance.
Now, an object is used to determine if the default is being used
and will create a new object for each instance in which no prop
was passed.

If the user wants to have shared cache, they will need to opt-in by providing the same object to the component via the `cache` prop.