### PR TITLE
Update aria-only class to have absolute positioning

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -249,6 +249,7 @@
   display: inline-block;
 }
 .Select .Select-aria-only {
+  position: absolute;
   display: inline-block;
   height: 1px;
   width: 1px;


### PR DESCRIPTION
When the component is restyled using flex, the width of the aria-only box causes the width of the `Select-multi-value-wrapper` to fluctuate when clicking into the input, and starting to type. Making this `position: absolute` removes it from the flow of flex, and thus solves this issue.

This seems to be a standard way to do this, while keeping it accessible. See:
http://a11yproject.com/posts/how-to-hide-content/
http://itstiredinhere.com/accessibility/

Error case:
![image](https://git.hubteam.com/storage/user/115/files/162779e2-525e-11e6-8b55-d716ecedcf58)
