### PR TITLE
Fix for Creatable doesn't allow input key down handling. Issue #1247

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -157,7 +157,7 @@ const Creatable = React.createClass({
 	},
 
 	onInputKeyDown (event) {
-		const { shouldKeyDownEventCreateNewOption } = this.props;
+		const { shouldKeyDownEventCreateNewOption, onInputKeyDown } = this.props;
 		const focusedOption = this.select.getFocusedOption();
 
 		if (
@@ -169,6 +169,8 @@ const Creatable = React.createClass({
 
 			// Prevent decorated Select from doing anything additional with this keyDown event
 			event.preventDefault();
+		} else if (onInputKeyDown) {
+			onInputKeyDown(event);
 		}
 	},
 

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -232,4 +232,9 @@ describe('Creatable', () => {
 		expect(test(188), 'to be', true);
 		expect(test(1), 'to be', false);
 	});
+
+	it('default :onInputKeyDown should run user provided handler.', (done) => {
+		createControl({ onInputKeyDown: event => done() });
+		return creatableInstance.onInputKeyDown({ keyCode: 97 });
+	});
 });


### PR DESCRIPTION
Issue  https://github.com/JedWatson/react-select/issues/1247
Creatable component has own handler of onInputKeyDown, which doesn't check if there's user's handler provided. So setting a handler for onInputKeyDown, has no effect.

Doesn't work:
`<Creatable
    onInputKeyDown={this.inputKeyDownHandler}
/>`

Creatable should call user's handler as well, otherwise it breaks defined API.
