### PR TITLE
Adding back ref that was removed in rc2

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -138,7 +138,8 @@ export default class Async extends Component {
 		const props = {
 			noResultsText: isLoading ? loadingPlaceholder : searchPromptText,
 			placeholder: isLoading ? loadingPlaceholder : placeholder,
-			options: isLoading ? [] : options
+			options: isLoading ? [] : options,
+			ref: (ref) => (this.select = ref)
 		};
 
 		return children({


### PR DESCRIPTION
Seems like ref to `Select` was removed from `Async` in rc2 - adding it back
I have needed it for my use case for a while.

I know this only caters for the 1 select - can modify to cater for all children if necessary.

I can kind of get around this by doing something like:
```
<Select.Async
    {...this.props}
 >
    {(asyncProps) => (
        <Select
            {...asyncProps}
            ref={(ref) => (this.selectRef = ref)}
        />
     )}
</Select.Async>
```

But I feel this seems now is a clunky way to setting a ref for the default `Select`