### PR TITLE
Add back onInputChange

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -19,6 +19,7 @@ const propTypes = {
 		React.PropTypes.string,
 		React.PropTypes.node
 	]),
+	onInputChange: React.PropTypes.func,             // optional for keeping track of what is being typed
 };
 
 const defaultProps = {
@@ -118,7 +119,7 @@ export default class Async extends Component {
 	}
 
 	_onInputChange (inputValue) {
-		const { ignoreAccents, ignoreCase } = this.props;
+		const { ignoreAccents, ignoreCase, onInputChange } = this.props;
 
 		if (ignoreAccents) {
 			inputValue = stripDiacritics(inputValue);
@@ -126,6 +127,10 @@ export default class Async extends Component {
 
 		if (ignoreCase) {
 			inputValue = inputValue.toLowerCase();
+		}
+
+		if (onInputChange) {
+			onInputChange(inputValue);
 		}
 
 		return this.loadOptions(inputValue);

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -354,4 +354,15 @@ describe('Async', () => {
 			expect(asyncNode.className, 'to contain', 'Select');
 		});
 	});
+
+	describe('with onInputChange', () => {
+		it('should call onInputChange', () => {
+			const onInputChange = sinon.stub();
+			createControl({
+				onInputChange,
+			});
+			typeSearchText('a');
+			return expect(onInputChange, 'was called times', 1);
+		});
+	});
 });


### PR DESCRIPTION
Seems like user specified `onInputChange` was removed in rc2 (gets overridden) for `Select.Async`
Need it for my use case as i use it for async `react-highlight-words` which needs this func to keep track of whats typed

At the moment its a breaking change as I have no work around (that im aware of anyway)- only choice is to revert back to `rc1` to get this functionality working again :'( 