### PR TITLE
IE8 compatibility fixes

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -869,7 +869,7 @@ const Select = React.createClass({
 
 			if (this.props.autosize) {
 				return (
-					<AutosizeInput {...inputProps} minWidth="5px" />
+					<AutosizeInput {...inputProps} minWidth="5" />
 				);
 			}
 			return (

--- a/src/Select.js
+++ b/src/Select.js
@@ -236,14 +236,26 @@ const Select = React.createClass({
 	},
 
 	componentWillUnmount() {
-		document.removeEventListener('touchstart', this.handleTouchOutside);
+		if (!document.removeEventListener && document.detachEvent) {
+			document.detachEvent('ontouchstart', this.handleTouchOutside);
+		} else {
+			document.removeEventListener('touchstart', this.handleTouchOutside);
+		}
 	},
 
 	toggleTouchOutsideEvent(enabled) {
 		if (enabled) {
-			document.addEventListener('touchstart', this.handleTouchOutside);
+			if (!document.addEventListener && document.attachEvent) {
+				document.attachEvent('ontouchstart', this.handleTouchOutside);
+			} else {
+				document.addEventListener('touchstart', this.handleTouchOutside);				
+			}
 		} else {
-			document.removeEventListener('touchstart', this.handleTouchOutside);
+			if (!document.removeEventListener && document.detachEvent) {
+				document.detachEvent('ontouchstart', this.handleTouchOutside);
+			} else {
+				document.removeEventListener('touchstart', this.handleTouchOutside);
+			}
 		}
 	},
 


### PR DESCRIPTION
Use attachEvent/detachEvent when ie8.
Remove units from minWidth attr, because ie8 throws the exception "Invalid argument" when try to set width = 5pxpx