### PR TITLE
Custom scrollable container, fix for the #1267

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ function onInputKeyDown(event) {
 	options 	|	array	|	undefined	|	array of options
 	placeholder 	|	string\|node	|	'Select ...'	|	field placeholder, displayed when there's no value
 	scrollMenuIntoView |	bool	|	true		|	whether the viewport will shift to display the entire menu when engaged
+	scrollableParentId |	string	|	undefined		|	parent Id that should be scroled when options menu goes outside the viewport. By default component scrolls window.
 	searchable 	|	bool	|	true		|	whether to enable searching feature or not
 	searchPromptText |	string\|node	|	'Type to search'	|	label to prompt for search input
 	tabSelectsValue	|	bool	|	true	|	whether to select the currently focused value when the `[tab]` key is pressed

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -145,6 +145,7 @@ var Select = _react2['default'].createClass({
 		required: _react2['default'].PropTypes.bool, // applies HTML5 required attribute when needed
 		resetValue: _react2['default'].PropTypes.any, // value to use when you clear the control
 		scrollMenuIntoView: _react2['default'].PropTypes.bool, // boolean to enable the viewport to shift so that the full menu fully visible when engaged
+		scrollableParentId: _react2['default'].PropTypes.string, // string that holds parent Id that should be scroled when options menu goes outside the viewport. By default component scrolls window.
 		searchable: _react2['default'].PropTypes.bool, // whether to enable searching feature or not
 		simpleValue: _react2['default'].PropTypes.bool, // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
 		style: _react2['default'].PropTypes.object, // optional style to apply to the control
@@ -267,10 +268,19 @@ var Select = _react2['default'].createClass({
 				menuDOM.scrollTop = focusedDOM.offsetTop + focusedDOM.clientHeight - menuDOM.offsetHeight;
 			}
 		}
+
 		if (this.props.scrollMenuIntoView && this.menuContainer) {
 			var menuContainerRect = this.menuContainer.getBoundingClientRect();
-			if (window.innerHeight < menuContainerRect.bottom + this.props.menuBuffer) {
-				window.scrollBy(0, menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);
+			var _props = this.props;
+			var scrollableParentId = _props.scrollableParentId;
+			var menuBuffer = _props.menuBuffer;
+
+			var container = scrollableParentId && document.getElementById(scrollableParentId);
+
+			if (container && container.clientHeight < menuContainerRect.bottom + menuBuffer) {
+				container.scrollTop += menuContainerRect.bottom + menuBuffer - container.clientHeight;
+			} else if (window.innerHeight < menuContainerRect.bottom + menuBuffer) {
+				window.scrollBy(0, menuContainerRect.bottom + menuBuffer - window.innerHeight);
 			}
 		}
 		if (prevProps.disabled !== this.props.disabled) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -101,6 +101,7 @@ const Select = React.createClass({
 		required: React.PropTypes.bool,             // applies HTML5 required attribute when needed
 		resetValue: React.PropTypes.any,            // value to use when you clear the control
 		scrollMenuIntoView: React.PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
+		scrollableParentId: React.PropTypes.string, // string that holds parent Id that should be scroled when options menu goes outside the viewport. By default component scrolls window.
 		searchable: React.PropTypes.bool,           // whether to enable searching feature or not
 		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
 		style: React.PropTypes.object,              // optional style to apply to the control
@@ -223,10 +224,16 @@ const Select = React.createClass({
 				menuDOM.scrollTop = (focusedDOM.offsetTop + focusedDOM.clientHeight - menuDOM.offsetHeight);
 			}
 		}
+
 		if (this.props.scrollMenuIntoView && this.menuContainer) {
 			var menuContainerRect = this.menuContainer.getBoundingClientRect();
-			if (window.innerHeight < menuContainerRect.bottom + this.props.menuBuffer) {
-				window.scrollBy(0, menuContainerRect.bottom + this.props.menuBuffer - window.innerHeight);
+			const { scrollableParentId, menuBuffer } = this.props;
+			const container = scrollableParentId && document.getElementById(scrollableParentId);
+
+			if (container && container.clientHeight < menuContainerRect.bottom + menuBuffer) {
+				container.scrollTop += menuContainerRect.bottom + menuBuffer - container.clientHeight;
+			} else if (window.innerHeight < menuContainerRect.bottom + menuBuffer) {
+				window.scrollBy(0, menuContainerRect.bottom + menuBuffer - window.innerHeight);
 			}
 		}
 		if (prevProps.disabled !== this.props.disabled) {


### PR DESCRIPTION
Fixes issue when options menu is hidden due to parent is not scrolled.
Related issue #1267.

Couldn't write tests for that one, so coverage is going to drop a bit. If I render a parent div and a Select, then getting measurements like scrollTop or height of DOM element returns just undefined. May be test framework doesn't provide such data for some reason. Anyway if you have any ideas how to test that code, I will add unit tests for that.
