### PR TITLE
Clear Async options after making a selection

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -145,7 +145,7 @@ export default class Async extends Component {
 		const props = {
 			noResultsText: isLoading ? loadingPlaceholder : searchPromptText,
 			placeholder: isLoading ? loadingPlaceholder : placeholder,
-			options: isLoading ? [] : options,
+			options: (isLoading && loadingPlaceholder) ? [] : options,
 			ref: (ref) => (this.select = ref),
 			onChange: (newValues) => {
 				if (this.props.value && (newValues.length > this.props.value.length)) {

--- a/src/Async.js
+++ b/src/Async.js
@@ -148,7 +148,7 @@ export default class Async extends Component {
 			options: isLoading ? [] : options,
 			ref: (ref) => (this.select = ref),
 			onChange: (newValues) => {
-				if (newValues.length > this.props.value.length) {
+				if (this.props.value && (newValues.length > this.props.value.length)) {
 					this.clearOptions();
 				}
 				this.props.onChange(newValues);

--- a/src/Async.js
+++ b/src/Async.js
@@ -8,7 +8,7 @@ const propTypes = {
 	children: React.PropTypes.func.isRequired,       // Child function responsible for creating the inner Select component; (props: Object): PropTypes.element
 	ignoreAccents: React.PropTypes.bool,             // strip diacritics when filtering; defaults to true
 	ignoreCase: React.PropTypes.bool,                // perform case-insensitive filtering; defaults to true
-	loadingPlaceholder: React.PropTypes.oneOfType([  // replaces the placeholder while options are loading 
+	loadingPlaceholder: React.PropTypes.oneOfType([  // replaces the placeholder while options are loading
 		React.PropTypes.string,
 		React.PropTypes.node
 	]),
@@ -64,6 +64,10 @@ export default class Async extends Component {
 				});
 			}
 		});
+	}
+
+	clearOptions() {
+		this.setState({options: []});
 	}
 
 	loadOptions (inputValue) {
@@ -142,7 +146,13 @@ export default class Async extends Component {
 			noResultsText: isLoading ? loadingPlaceholder : searchPromptText,
 			placeholder: isLoading ? loadingPlaceholder : placeholder,
 			options: isLoading ? [] : options,
-			ref: (ref) => (this.select = ref)
+			ref: (ref) => (this.select = ref),
+			onChange: (newValues) => {
+				if (newValues.length > this.props.value.length) {
+					this.clearOptions();
+				}
+				this.props.onChange(newValues);
+			}
 		};
 
 		return children({


### PR DESCRIPTION
I'm working on an upgrade from an old version of `react-select`.

My code uses `Async`, and there's a regression in the latest master: after you select a suggestion from a `<Async multi={true}/>`, the autocomplete options hang around.

This change clears the options list after selecting a new item (but not when removing an item).