### PR TITLE
Clear Async options after making a selection

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -72,6 +72,10 @@ export default class Async extends Component {
 		});
 	}
 
+	clearOptions() {
+		this.setState({ options: [] });
+	}
+
 	loadOptions (inputValue) {
 		const { cache, loadOptions } = this.props;
 
@@ -174,7 +178,13 @@ export default class Async extends Component {
 			noResultsText: this.noResultsText(),
 			placeholder: isLoading ? loadingPlaceholder : placeholder,
 			options: (isLoading && loadingPlaceholder) ? [] : options,
-			ref: (ref) => (this.select = ref)
+			ref: (ref) => (this.select = ref),
+			onChange: (newValues) => {
+				if (this.props.value && (newValues.length > this.props.value.length)) {
+					this.clearOptions();
+				}
+				this.props.onChange(newValues);
+			}
 		};
 
 		return children({


### PR DESCRIPTION
Currently, when you make a selection from an async
dropdown, it keeps the list open but clears the input.

This looks inconsistent and doesn't match the common UX
for async search (looking up an item from a long list).