### PR TITLE
Tell git not to merge built files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+dist/* binary
+examples/dist/* binary
+lib/* binary


### PR DESCRIPTION
Currently when merging / rebasing, git tries to merge compiled assets (and practically always gets it wrong).

This change tells git not to even try to merge assets - instead, the developer should run 'npm run build' when a merge conflict occurs and then commit the results.