### PR TITLE
Add `keepInputCase` prop - Closes #1106

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -81,16 +81,16 @@ export default class Async extends Component {
 		this.setState({ options: [] });
 	}
 
-	loadOptions (inputValue) {
+	loadOptions (inputValue, normalizedInputValue=inputValue) {
 		const { loadOptions } = this.props;
 		const cache = this._cache;
 
 		if (
 			cache &&
-			cache.hasOwnProperty(inputValue)
+			cache.hasOwnProperty(normalizedInputValue)
 		) {
 			this.setState({
-				options: cache[inputValue]
+				options: cache[normalizedInputValue]
 			});
 
 			return;
@@ -103,7 +103,7 @@ export default class Async extends Component {
 				const options = data && data.options || [];
 
 				if (cache) {
-					cache[inputValue] = options;
+					cache[normalizedInputValue] = options;
 				}
 
 				this.setState({
@@ -116,7 +116,7 @@ export default class Async extends Component {
 		// Ignore all but the most recent request
 		this._callback = callback;
 
-		const promise = loadOptions(inputValue, callback);
+		const promise = loadOptions(normalizedInputValue, callback);
 		if (promise) {
 			promise.then(
 				(data) => callback(null, data),
@@ -138,20 +138,21 @@ export default class Async extends Component {
 
 	_onInputChange (inputValue) {
 		const { ignoreAccents, ignoreCase, onInputChange } = this.props;
+    var normalizedInputValue = inputValue;
 
 		if (ignoreAccents) {
-			inputValue = stripDiacritics(inputValue);
+			normalizedInputValue = stripDiacritics(normalizedInputValue);
 		}
 
 		if (ignoreCase) {
-			inputValue = inputValue.toLowerCase();
+			normalizedInputValue = normalizedInputValue.toLowerCase();
 		}
 
 		if (onInputChange) {
 			onInputChange(inputValue);
 		}
 
-		return this.loadOptions(inputValue);
+		return this.loadOptions(inputValue, normalizedInputValue);
 	}
 
 	inputValue() {

--- a/test/AsyncCreatable-test.js
+++ b/test/AsyncCreatable-test.js
@@ -42,6 +42,10 @@ describe('AsyncCreatable', () => {
 		}
 	};
 
+	function typeSearchText(text) {
+		TestUtils.Simulate.change(filterInputNode, { target: { value: text } });
+	};
+
 	it('should create an inner Select', () => {
 		createControl();
 		expect(creatableNode, 'to have attributes', {
@@ -59,4 +63,19 @@ describe('AsyncCreatable', () => {
 			class: ['foo']
 		});
 	});
+
+  it('does not case-fold or otherwise modify the input text', () => {
+    createControl({
+      ignoreCase: true,
+      loadOptions: (input, resolve) => {
+        resolve(null, { options: [] });
+      }
+    });
+
+    typeSearchText('F');
+    typeSearchText('FO');
+    typeSearchText('FOO');
+
+		expect(filterInputNode.value, 'to equal', 'FOO');
+  });
 });


### PR DESCRIPTION
Closes #1106 

Add `keepInputCase` prop that leaves the casing of what the user types in the input, but still allows the control to ignore the case when filtering the results.

For example, with `keepInputCase=true` and `ignoreCase=true`, we get the following:

![image](https://cloud.githubusercontent.com/assets/7032816/19745570/2bc21b0a-9ba0-11e6-9ad3-0b65964481f6.png)

but still get:

![image](https://cloud.githubusercontent.com/assets/7032816/19745560/24212972-9ba0-11e6-8b2c-58ca85dd024a.png)

The one caveat is it requires the async method to be case insensitive. But this way it doesn't change the input to be lowercased which, when using with a creatable, can prevent the user from typing it in correctly.
