### PR TITLE
Update onChange callback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ var options = [
 	{ value: 'two', label: 'Two' }
 ];
 
-function logChange(val) {
-	console.log("Selected: " + val);
+function logChange(option) {
+	console.log("Selected: " + option.value);
 }
 
 <Select


### PR DESCRIPTION
Currently, in this example the onChange callback param name of `val` implies that it it's type will be a string of `'one'` or `'two'`.  This is not the case, updated to reflect this fact.