### PR TITLE
Disable forced focus after remove via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ function onInputKeyDown(event) {
 	autosize  | bool | true  | If enabled, the input will expand as the length of its value increases
 	backspaceRemoves 	|	bool	|	true	|	whether pressing backspace removes the last item when there is no input value
 	backspaceToRemoveMessage	|	string	|	'Press backspace to remove {last label}'	|	prompt shown in input when at least one option in a multiselect is shown, set to '' to clear
+	blurOnRemove 	|	bool	|	true	|	whether the control should lose focus after removing a value
 	cache	|	bool	|	true	|	enables the options cache for `asyncOptions` (default: `true`)
 	className 	|	string	|	undefined	|	className for the outer element
 	clearable 	|	bool	|	true		|	should it be possible to reset value

--- a/src/Select.js
+++ b/src/Select.js
@@ -53,6 +53,7 @@ const Select = React.createClass({
 		autosize: React.PropTypes.bool,             // whether to enable autosizing or not
 		backspaceRemoves: React.PropTypes.bool,     // whether backspace removes an item if there is no text input
 		backspaceToRemoveMessage: React.PropTypes.string,  // Message to use for screenreaders to press backspace to remove the current item - {label} is replaced with the item label
+		blurOnRemove: React.PropTypes.bool,         // whether the control should lose focus after removing a value
 		className: React.PropTypes.string,          // className for the outer element
 		clearAllText: stringOrNode,                 // title for the "clear" control when multi: true
 		clearValueText: stringOrNode,               // title for the "clear" control
@@ -642,7 +643,11 @@ const Select = React.createClass({
 	removeValue (value) {
 		var valueArray = this.getValueArray(this.props.value);
 		this.setValue(valueArray.filter(i => i !== value));
-		this.focus();
+		if(this.props.blurOnRemove) {
+			this.blurInput();
+		}else {
+			this.focus();
+		}
 	},
 
 	clearValue (event) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1826,6 +1826,30 @@ describe('Select', () => {
                 </span>);
 		});
 
+		it('focuses the control after removing a value', () => {
+
+			setValueProp(['four','three']);
+			onChange.reset();  // Ignore previous onChange calls
+			pressDelete();
+			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
+			expect(instance.focus, 'was called');
+			expect(instance.blurInput, 'was not called');
+		});
+
+		it('blurs the control after removing a value when blurOnRemove=true', () => {
+
+			// Enable blurOnRemove
+			wrapper.setPropsForChild({
+				blurOnRemove: true,
+				value: ['four', 'three']
+			});
+			onChange.reset();  // Ignore previous onChange calls
+			pressDelete();
+			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
+			expect(instance.focus, 'was not called');
+			expect(instance.blurInput, 'was called');
+		});
+
 		it('removes an item when clicking on the X', () => {
 
 			setValueProp(['four', 'three', 'two']);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -56,7 +56,7 @@ class PropsWrapper extends React.Component {
 }
 
 describe('Select', () => {
-	var options, onChange, onInputChange, onBlur, onFocus;
+	var options, onChange, onInputChange;
 	var instance, wrapper;
 	var searchInputNode;
 
@@ -139,15 +139,11 @@ describe('Select', () => {
 
 		onChange = sinon.spy();
 		onInputChange = sinon.spy();
-		onBlur = sinon.spy();
-		onFocus = sinon.spy();
 		// Render an instance of the component
 		instance = TestUtils.renderIntoDocument(
 			<Select
 				onChange={onChange}
 				onInputChange={onInputChange}
-				onBlur={onBlur}
-				onFocus={onFocus}
 				{...props}
 				/>
 		);
@@ -1836,8 +1832,6 @@ describe('Select', () => {
 			onChange.reset();  // Ignore previous onChange calls
 			pressDelete();
 			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
-			expect(onFocus, 'was called');
-			expect(onBlur, 'was not called');
 		});
 
 		it('blurs the control after removing a value when blurOnRemove=true', () => {
@@ -1850,8 +1844,6 @@ describe('Select', () => {
 			onChange.reset();  // Ignore previous onChange calls
 			pressDelete();
 			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
-			expect(onFocus, 'was not called');
-			expect(onBlur, 'was called');
 		});
 
 		it('removes an item when clicking on the X', () => {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -56,7 +56,7 @@ class PropsWrapper extends React.Component {
 }
 
 describe('Select', () => {
-	var options, onChange, onInputChange;
+	var options, onChange, onInputChange, onBlur, onFocus;
 	var instance, wrapper;
 	var searchInputNode;
 
@@ -139,11 +139,15 @@ describe('Select', () => {
 
 		onChange = sinon.spy();
 		onInputChange = sinon.spy();
+		onBlur = sinon.spy();
+		onFocus = sinon.spy();
 		// Render an instance of the component
 		instance = TestUtils.renderIntoDocument(
 			<Select
 				onChange={onChange}
 				onInputChange={onInputChange}
+				onBlur={onBlur}
+				onFocus={onFocus}
 				{...props}
 				/>
 		);
@@ -1832,8 +1836,8 @@ describe('Select', () => {
 			onChange.reset();  // Ignore previous onChange calls
 			pressDelete();
 			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
-			expect(instance.focus, 'was called');
-			expect(instance.blurInput, 'was not called');
+			expect(onFocus, 'was called');
+			expect(onBlur, 'was not called');
 		});
 
 		it('blurs the control after removing a value when blurOnRemove=true', () => {
@@ -1846,8 +1850,8 @@ describe('Select', () => {
 			onChange.reset();  // Ignore previous onChange calls
 			pressDelete();
 			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
-			expect(instance.focus, 'was not called');
-			expect(instance.blurInput, 'was called');
+			expect(onFocus, 'was not called');
+			expect(onBlur, 'was called');
 		});
 
 		it('removes an item when clicking on the X', () => {


### PR DESCRIPTION
The PR refers to issue [1348](https://github.com/JedWatson/react-select/issues/1348).

It adds an optional prop which allows to replace the forced focus after removing a value with a forced blur. This resolves issues with falsely persistent isFocused-states that may occur when wrapping a react-select. It was tested manually as automated focus tests would not work.