### PR TITLE
Fix onInputChange lost

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -31,6 +31,9 @@ const Creatable = React.createClass({
     // ({ label: string, labelKey: string, valueKey: string }): Object
 		newOptionCreator: React.PropTypes.func,
 
+		// input change handler: function (inputValue) {}
+		onInputChange: React.PropTypes.func,
+
 		// input keyDown handler: function (event) {}
 		onInputKeyDown: React.PropTypes.func,
 
@@ -155,6 +158,12 @@ const Creatable = React.createClass({
 	},
 
 	onInputChange (input) {
+		const { onInputChange } = this.props;
+
+		if (onInputChange) {
+			onInputChange(input);
+		}
+
 		// This value may be needed in between Select mounts (when this.select is null)
 		this.inputValue = input;
 	},


### PR DESCRIPTION
This is to preserve the functionality of `onInputChange` when using `Creatable`.
