### PR TITLE
Fix small bug in Creatable

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -161,7 +161,8 @@ const Creatable = React.createClass({
 
 		return menuRenderer({
 			...params,
-			onSelect: this.onOptionSelect
+			onSelect: this.onOptionSelect,
+			selectValue: this.onOptionSelect
 		});
 	},
 


### PR DESCRIPTION
`Select` component passes its `menuRenderer` duplicate values for `onSelect` and `selectValue` (not sure why). `Creatable` only overrides the `onSelect` parameter (whoops, this is totally my fault). This caused a bug downstream in react-virtualized-select (see bvaughn/react-virtualized-select/issues/33).

That bug has been fixed but in order to prevent further confusion, this PR overrides both properties to keep them in sync.