### PR TITLE
fix error on empty options

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -637,7 +637,7 @@ const Select = React.createClass({
 		if (!valueArray.length) return;
 		if (valueArray[valueArray.length-1].clearableValue === false) return;
 		if (this.props.multi) this.setValue(valueArray.slice(0, valueArray.length - 1));
-		setValue(undefined);
+		this.setValue(undefined);
 	},
 
 	removeValue (value) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -701,21 +701,23 @@ const Select = React.createClass({
 	},
 
 	focusAdjacentOption (dir) {
-		var options = this._visibleOptions
+		const options = this._visibleOptions
 			.map((option, index) => ({ option, index }))
 			.filter(option => !option.option.disabled);
 		this._scrollToFocusedOptionOnUpdate = true;
+		const focusedOption = this._focusedOption ||
+			(options.length && options[dir === 'next' ? 0 : options.length - 1].option);
 		if (!this.state.isOpen) {
 			this.setState({
 				isOpen: true,
 				inputValue: '',
-				focusedOption: this._focusedOption || options[dir === 'next' ? 0 : options.length - 1].option
+				focusedOption
 			});
 			return;
 		}
 		if (!options.length) return;
-		var focusedIndex = -1;
-		for (var i = 0; i < options.length; i++) {
+		let focusedIndex = -1;
+		for (let i = 0; i < options.length; i++) {
 			if (this._focusedOption === options[i].option) {
 				focusedIndex = i;
 				break;
@@ -734,14 +736,14 @@ const Select = React.createClass({
 		} else if (dir === 'end') {
 			focusedIndex = options.length - 1;
 		} else if (dir === 'page_up') {
-			var potentialIndex = focusedIndex - this.props.pageSize;
+			const potentialIndex = focusedIndex - this.props.pageSize;
 			if ( potentialIndex < 0 ) {
 				focusedIndex = 0;
 			} else {
 				focusedIndex = potentialIndex;
 			}
 		} else if (dir === 'page_down') {
-			var potentialIndex = focusedIndex + this.props.pageSize;
+			const potentialIndex = focusedIndex + this.props.pageSize;
 			if ( potentialIndex > options.length - 1 ) {
 				focusedIndex = options.length - 1;
 			} else {

--- a/src/Select.js
+++ b/src/Select.js
@@ -636,7 +636,8 @@ const Select = React.createClass({
 		var valueArray = this.getValueArray(this.props.value);
 		if (!valueArray.length) return;
 		if (valueArray[valueArray.length-1].clearableValue === false) return;
-		this.setValue(valueArray.slice(0, valueArray.length - 1));
+		if (this.props.multi) this.setValue(valueArray.slice(0, valueArray.length - 1));
+		setValue(undefined);
 	},
 
 	removeValue (value) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -535,6 +535,19 @@ describe('Select', () => {
 
 		});
 
+		it('should open the options on arrow down and show no results text if options are closed and empty', () => {
+			var emptyInstance = createControl({
+				options: [],
+				noResultsText: 'No results unit test'
+			});
+			var selectControl = getSelectControl(emptyInstance);
+
+			TestUtils.Simulate.keyDown(selectControl, { keyCode: 38, key: 'ArrowDown' });
+			expect(emptyInstance.state.isOpen, 'to be true');
+			expect(ReactDOM.findDOMNode(emptyInstance).querySelector('.Select-menu'),
+			'to have text', 'No results unit test');
+		});
+
 		it('should open the options on arrow down with the top option focused, when the options are closed', () => {
 
 			var selectControl = getSelectControl(instance);


### PR DESCRIPTION
i think it's feasible to assume one may want to start out with an empty options list. at the very least, i don't think it should throw an error if in that scenario.