### PR TITLE
try to focus the next available option after a selection.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -630,6 +630,13 @@ const Select = React.createClass({
 	addValue (value) {
 		var valueArray = this.getValueArray(this.props.value);
 		this.setValue(valueArray.concat(value));
+		const visibleOptions = this._visibleOptions.filter(val => !val.disabled);
+		const index = visibleOptions.indexOf(value);
+		if (visibleOptions.length > index + 1) {
+			this.focusOption(visibleOptions[index + 1]);
+		} else if (index > 0) {
+			this.focusOption(visibleOptions[index - 1]);
+		}
 	},
 
 	popValue () {


### PR DESCRIPTION
When the menu is displayed into a "scrollable" div, we like to have the scroll following the focused element so that keyboard navigation shows the current element. 

The problem is that when selecting an option in a multi-option component, the current system focuses the first option of the list, forcing users to re-navigate to their last position.

This PR focuses the option immediately adjacent to the last selected one, to avoid scrolling issues.