### PR TITLE
Focusing options using the arrow key calls a handler function prop

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -80,6 +80,7 @@ const Select = React.createClass({
 		multi: React.PropTypes.bool,                // multi-value input
 		name: React.PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
 		noResultsText: stringOrNode,                // placeholder displayed when there are no matching search results
+		onArrowKeyFocus: React.PropTypes.func,      // function to be executed when an option is focused from arrow key movement
 		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
 		onBlurResetsInput: React.PropTypes.bool,    // whether input is cleared on blur
 		onChange: React.PropTypes.func,             // onChange handler: function (newValue) {}
@@ -753,9 +754,16 @@ const Select = React.createClass({
 			focusedIndex = 0;
 		}
 
+		var focusedObject = options[focusedIndex];
+		var focusedOption = focusedObject.option;
+
+		if (this.props.onArrowKeyFocus) {
+			this.props.onArrowKeyFocus(focusedOption);
+		}
+
 		this.setState({
-			focusedIndex: options[focusedIndex].index,
-			focusedOption: options[focusedIndex].option
+			focusedIndex: focusedObject.index,
+			focusedOption: focusedOption,
 		});
 	},
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -345,6 +345,36 @@ describe('Select', () => {
 
 		});
 
+		describe('with the onArrowKeyFocus prop present', () => {
+			var onArrowKeyFocus;
+
+			beforeEach(() => {
+				options = [
+					{ value: 'one', label: 'One' },
+					{ value: 'two', label: 'Two' },
+					{ value: 'three', label: 'Three' }
+				];
+
+				onArrowKeyFocus = sinon.spy();
+
+				instance = createControl({
+					name: 'form-field-name',
+					value: 'one',
+					onArrowKeyFocus: onArrowKeyFocus,
+					options: options,
+					simpleValue: true,
+				});
+			});
+
+			it('calls onArrowKeyFocus with the new option', () => {
+				clickArrowToOpen();
+				pressDown();
+				expect(onArrowKeyFocus, 'was called with', options[1]);
+				pressDown();
+				expect(onArrowKeyFocus, 'was called with', options[2]);
+			});
+		});
+
 		it('should display the options menu when tapped', function() {
 			TestUtils.Simulate.touchStart(getSelectControl(instance));
 			TestUtils.Simulate.touchEnd(getSelectControl(instance));


### PR DESCRIPTION
This PR allows passing a function prop called `onArrowKeyFocus` which is called when a new option is focused using the up and down arrow keys.

closes #1413