### PR TITLE
Allow to set default input value through props

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -65,6 +65,7 @@ const Select = React.createClass({
 		filterOptions: React.PropTypes.any,         // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
 		ignoreAccents: React.PropTypes.bool,        // whether to strip diacritics when filtering
 		ignoreCase: React.PropTypes.bool,           // whether to perform case-insensitive filtering
+		initialInputValue: React.PropTypes.string,  // initial input value
 		inputProps: React.PropTypes.object,         // custom attributes for the Input
 		inputRenderer: React.PropTypes.func,        // returns a custom input component
 		instanceId: React.PropTypes.string,         // set the components instanceId
@@ -133,6 +134,7 @@ const Select = React.createClass({
 			filterOptions: defaultFilterOptions,
 			ignoreAccents: true,
 			ignoreCase: true,
+			initialInputValue: '',
 			inputProps: {},
 			isLoading: false,
 			joinValues: false,
@@ -161,7 +163,7 @@ const Select = React.createClass({
 
 	getInitialState () {
 		return {
-			inputValue: '',
+			inputValue: this.props.initialInputValue,
 			isFocused: false,
 			isOpen: false,
 			isPseudoFocused: false,
@@ -850,7 +852,7 @@ const Select = React.createClass({
 			onFocus: this.handleInputFocus,
 			ref: ref => this.input = ref,
 			required: this.state.required,
-			value: this.state.inputValue
+			value: this.props.inputProps.value || this.state.inputValue
 		});
 
 		if (this.props.inputRenderer) {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2557,6 +2557,20 @@ describe('Select', () => {
 			});
 		});
 
+
+		describe('initialInputValue', () => {
+
+			beforeEach(() => {
+				instance = createControl({
+					initialInputValue: 'hello'
+				});
+			});
+
+			it('sets the value as the initial value of input field', () => {
+				expect(ReactDOM.findDOMNode(instance).querySelector('input').value, 'to equal', 'hello');
+			});
+		});
+
 		describe('inputProps', () => {
 
 


### PR DESCRIPTION
In `Select.*` components. they has configuration that named `inputProps` . 

We can set extra attributes to `input` element inside of `Select.*` components.

But atm, we cannot set `value` of `input` element because of `Object.assign` overrides the second argument value with third argument value. [ref](https://github.com/JedWatson/react-select/blob/ef3a4687bc67684809c3a2648143a1c325ee987e/src/Select.js#L838-L854)

I would like to set the default value of input like the case that the mount component will change with the state value like 

```js
const AsyncComponent = this.state.isCreatable
      ? Select.AsyncCreatable
      : Select.Async
```

In this case, we cannot hold the input value that I type before the component change.


This PR will fix the problem above. 