### PR TITLE
Add menuScroll prop to allow customizing menu scroll behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ function onInputKeyDown(event) {
 	matchProp 	|	string	|	'any'		|	(any, label, value) which option property to filter on
 	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
 	menuRenderer | func | undefined | Renders a custom menu with options; accepts the following named parameters: `menuRenderer({ focusedOption, focusOption, options, selectValue, valueArray })`
+	menuScroller | func | undefined | function for customizing menu scroll behaviour: `menuScroller({ menuNode })`
 	multi 		|	bool	|	undefined	|	multi-value input
 	name 		|	string	|	undefined	|	field name, for hidden `<input />` tag
 	noResultsText 	|	string	|	'No results found'	|	placeholder displayed when there are no matching search results or a falsy value to hide it

--- a/src/Select.js
+++ b/src/Select.js
@@ -76,6 +76,7 @@ const Select = React.createClass({
 		menuBuffer: React.PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
 		menuContainerStyle: React.PropTypes.object, // optional style to apply to the menu container
 		menuRenderer: React.PropTypes.func,         // renders a custom menu with options
+		menuScroller: React.PropTypes.func,         // scrolls menu: function (menuNode) {}
 		menuStyle: React.PropTypes.object,          // optional style to apply to the menu
 		multi: React.PropTypes.bool,                // multi-value input
 		name: React.PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
@@ -207,9 +208,9 @@ const Select = React.createClass({
 	componentDidUpdate (prevProps, prevState) {
 		// focus to the selected option
 		if (this.menu && this.focused && this.state.isOpen && !this.hasScrolledToOption) {
-			let focusedOptionNode = ReactDOM.findDOMNode(this.focused);
 			let menuNode = ReactDOM.findDOMNode(this.menu);
-			menuNode.scrollTop = focusedOptionNode.offsetTop;
+			const menuScroller = this.props.menuScroller ? this.props.menuScroller : this.menuScroller;
+			menuScroller(menuNode);
 			this.hasScrolledToOption = true;
 		} else if (!this.state.isOpen) {
 			this.hasScrolledToOption = false;
@@ -771,6 +772,11 @@ const Select = React.createClass({
 		if (this._focusedOption) {
 			return this.selectValue(this._focusedOption);
 		}
+	},
+
+	menuScroller(menuNode) {
+		let focusedOptionNode = ReactDOM.findDOMNode(this.focused);
+		menuNode.scrollTop = focusedOptionNode.offsetTop;
 	},
 
 	renderLoading () {


### PR DESCRIPTION
Allow customizing scroll behaviour of menu node by letting users specify a `menuScroller` handler with  a `menuNode` parameter.  

Current default is scrolling to top of last focused (selected) option. This perfectly fits for single select case and 99% of the time customizations won't be needed. Still, I think scrolling behaviour should  be overridable and it will especially come in handy when `multi` is `true`