### PR TITLE
[Creatable] Handle null children prop gracefully

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -205,11 +205,20 @@ const Creatable = React.createClass({
 
 	render () {
 		const {
-			children = defaultChildren,
 			newOptionCreator,
 			shouldKeyDownEventCreateNewOption,
 			...restProps
 		} = this.props;
+
+		let { children } = this.props;
+
+		// XXX: We can't use destructuring default values to set this, because if
+		// we're passed null for our 'children' prop, the default value will not be
+		// used as babel compiles destructuring default values to:
+		// value === undefined ? defaultValue : value
+		if (!children) {
+			children = defaultChildren;
+		}
 
 		const props = {
 			...restProps,


### PR DESCRIPTION
Previously ```Creatable``` used ES6 destructuring default values to set ```children``` to ```defaultChildren```. 

If a null ```children``` prop is passed, the null value will be used, rather than the default value, as Babel compiles destructuring defaults to ```value === undefined ? defaultValue : value```. This will result in an exception when ```children``` is invoked as a function a few lines later.

This patch simply amends Creatable's ```render()``` method to use ```defaultChildren``` if ```children``` is any kind of falsey value. 