### PR TITLE
Added ‘maxSelectedOptions’ option for multiple select

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ You can manipulate the input using the onInputChange and returning a new value.
 function cleanInput(inputValue) {
 	  // Strip all non-number characters from the input
     return inputValue.replace(/[^0-9]/g, "");
-}   
+}
 
 <Select
     name="form-field-name"
@@ -365,6 +365,8 @@ function onInputKeyDown(event) {
 	loadOptions	|	func	|	undefined	|	function that returns a promise or calls a callback with the options: `function(input, [callback])`
 	matchPos 	|	string	|	'any'		|	(any, start) match the start or entire string when filtering
 	matchProp 	|	string	|	'any'		|	(any, label, value) which option property to filter on
+	maxSelectedOptions 	| number 	| 	undefined 	| maximum number of selected options for select multiple
+	maxSelectedOptionsText 	| string 	| 'You can only select {optionsCount} items' 	| placeholder displayed when max number of selected options reached
 	menuBuffer	|	number	|	0		|	buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
 	menuRenderer | func | undefined | Renders a custom menu with options; accepts the following named parameters: `menuRenderer({ focusedOption, focusOption, options, selectValue, valueArray })`
 	multi 		|	bool	|	undefined	|	multi-value input

--- a/examples/src/components/Multiselect.js
+++ b/examples/src/components/Multiselect.js
@@ -25,6 +25,8 @@ var MultiSelectField = React.createClass({
 			crazy: false,
 			options: FLAVOURS,
 			value: [],
+			maxSelectedOptionsEnabled: false,
+			maxSelectedOptions: 2
 		};
 	},
 	handleSelectChange (value) {
@@ -41,11 +43,16 @@ var MultiSelectField = React.createClass({
 			options: crazy ? WHY_WOULD_YOU : FLAVOURS,
 		});
 	},
+	toggleMaxSelectedOptions (e) {
+		this.setState({
+			maxSelectedOptionsEnabled: e.target.checked
+		});
+	},
 	render () {
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label}</h3>
-				<Select multi simpleValue disabled={this.state.disabled} value={this.state.value} placeholder="Select your favourite(s)" options={this.state.options} onChange={this.handleSelectChange} />
+				<Select multi simpleValue disabled={this.state.disabled} maxSelectedOptions={this.state.maxSelectedOptionsEnabled ? this.state.maxSelectedOptions : undefined} value={this.state.value} placeholder="Select your favourite(s)" options={this.state.options} onChange={this.handleSelectChange} />
 
 				<div className="checkbox-list">
 					<label className="checkbox">
@@ -55,6 +62,10 @@ var MultiSelectField = React.createClass({
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" checked={this.state.crazy} onChange={this.toggleChocolate} />
 						<span className="checkbox-label">I don't like Chocolate (disabled the option)</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" checked={this.state.maxSelectedOptionsEnabled} onChange={this.toggleMaxSelectedOptions} />
+						<span className="checkbox-label">Maximum selected options ({this.state.maxSelectedOptions} options)</span>
 					</label>
 				</div>
 			</div>

--- a/less/menu.less
+++ b/less/menu.less
@@ -68,8 +68,9 @@
 }
 
 
-// no results
+// no results and max options
 
+.Select-maxoptions,
 .Select-noresults {
 	box-sizing: border-box;
 	color: @select-noresults-color;

--- a/scss/menu.scss
+++ b/scss/menu.scss
@@ -66,8 +66,9 @@
 }
 
 
-// no results
+// no results and max options
 
+.Select-maxoptions,
 .Select-noresults {
 	box-sizing: border-box;
 	color: $select-noresults-color;

--- a/src/Select.js
+++ b/src/Select.js
@@ -73,6 +73,8 @@ const Select = React.createClass({
 		labelKey: React.PropTypes.string,           // path of the label value in option objects
 		matchPos: React.PropTypes.string,           // (any|start) match the start or entire string when filtering
 		matchProp: React.PropTypes.string,          // (any|label|value) which option property to filter on
+		maxSelectedOptions: React.PropTypes.number, // maximum number of selected options for select multiple
+		maxSelectedOptionsText: stringOrNode,       // placeholder displayed when max number of selected options reached - {optionsCount} is replaced with maxSelectedOptions value
 		menuBuffer: React.PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
 		menuContainerStyle: React.PropTypes.object, // optional style to apply to the menu container
 		menuRenderer: React.PropTypes.func,         // renders a custom menu with options
@@ -156,6 +158,7 @@ const Select = React.createClass({
 			tabSelectsValue: true,
 			valueComponent: Value,
 			valueKey: 'value',
+			maxSelectedOptionsText: 'You can only select {optionsCount} items',
 		};
 	},
 
@@ -952,7 +955,13 @@ const Select = React.createClass({
 	},
 
 	renderMenu (options, valueArray, focusedOption) {
-		if (options && options.length) {
+		if (this.props.multi && this.props.maxSelectedOptions && this.props.maxSelectedOptionsText && this.props.maxSelectedOptions <= this.getValueArray(this.props.value).length) {
+			return (
+				<div className="Select-maxoptions">
+					{this.props.maxSelectedOptionsText.replace('{optionsCount}', this.props.maxSelectedOptions)}
+				</div>
+			);
+		} else if (options && options.length) {
 			return this.props.menuRenderer({
 				focusedOption,
 				focusOption: this.focusOption,

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1894,6 +1894,60 @@ describe('Select', () => {
 			});
 		});
 
+		describe('with maxSelectedOption set', () => {
+
+			beforeEach(() => {
+
+				wrapper = createControlWithWrapper({
+					multi: true,
+					options: options,
+					value: 'one,two',
+					maxSelectedOptions: 2,
+					maxSelectedOptionsText: 'Testing {optionsCount}'
+				});
+			});
+
+			it('renders label element with text about maximum selected options with opened menu', () => {
+
+				clickArrowToOpen();
+
+				expect(ReactDOM.findDOMNode(instance),
+					'to contain elements matching', '.Select-maxoptions'
+				);
+			});
+
+			it('doesn\'t render label element with text about maximum selected options with closed menu', () => {
+
+				expect(ReactDOM.findDOMNode(instance),
+					'to contain no elements matching', '.Select-maxoptions'
+				);
+			});
+
+			it('renders list when maximum selected options is not exceeded', () => {
+
+				var node = ReactDOM.findDOMNode(instance);
+
+				setValueProp(['one']);
+				clickArrowToOpen();
+
+				expect(node,
+					'to contain no elements matching', '.Select-maxoptions'
+				);
+
+				expect(node, 'queried for', '.Select-option:nth-child(1)', 'to have items satisfying', 'to have text', 'Two');
+				expect(node, 'queried for', '.Select-option:nth-child(2)', 'to have items satisfying', 'to have text', 'Three');
+				expect(node, 'queried for', '.Select-option:nth-child(3)', 'to have items satisfying', 'to have text', 'Four');
+			});
+
+			it('renders label element with correct message about maximum selected options', () => {
+
+				clickArrowToOpen();
+
+				expect(ReactDOM.findDOMNode(instance), 'queried for first', '.Select-maxoptions',
+					'to have text', 'Testing 2');
+			});
+		});
+
 	});
 
 	describe('with multi=true and clearable=true', () => {


### PR DESCRIPTION
I want to resolve #1392 I added 'maxSelectedOptions' option which should be a number and a 'maxSelectedOptionsText' for help message. It works only for multi-selects.
When user reaches allowed number of selected options - a help message will be shown instead of options menu (with same styling as an 'No results' message).