### PR TITLE
Adding new option to select the currently focused option on blur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bower_components
 
 # Editor artifacts
 .idea
+*.iml
 
 # Other
 .DS_Store

--- a/src/Select.js
+++ b/src/Select.js
@@ -82,6 +82,7 @@ const Select = React.createClass({
 		noResultsText: stringOrNode,                // placeholder displayed when there are no matching search results
 		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
 		onBlurResetsInput: React.PropTypes.bool,    // whether input is cleared on blur
+		onBlurSelectsFocusedOption: React.PropTypes.bool, // whether to select the currently focused option on blur
 		onChange: React.PropTypes.func,             // onChange handler: function (newValue) {}
 		onClose: React.PropTypes.func,              // fires when the menu is closed
 		onCloseResetsInput: React.PropTypes.bool,		// whether input is cleared when menu is closed through the arrow
@@ -144,6 +145,7 @@ const Select = React.createClass({
 			multi: false,
 			noResultsText: 'No results found',
 			onBlurResetsInput: true,
+			onBlurSelectsFocusedOption: false,
 			onCloseResetsInput: true,
 			openAfterFocus: false,
 			optionComponent: Option,
@@ -440,6 +442,10 @@ const Select = React.createClass({
 		if (this.props.onBlurResetsInput) {
 			onBlurredState.inputValue = '';
 		}
+		if (this.props.onBlurSelectsFocusedOption) {
+			this.selectFocusedOption();
+		}
+
 		this.setState(onBlurredState);
 	},
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2912,6 +2912,40 @@ describe('Select', () => {
 			});
 		});
 
+		describe('with onBlurSelectsFocusedOption=true', () => {
+			beforeEach(() => {
+				instance = createControl({
+					options: defaultOptions,
+					onBlurSelectsFocusedOption: true
+				});
+			});
+
+			it('should select focused option after calling onBlur', () => {
+				typeSearchText('One');
+
+				TestUtils.Simulate.blur(searchInputNode);
+
+				expect(onChange, 'was called');
+			});
+		});
+
+		describe('with onBlurSelectsFocusedOption=false', () => {
+			beforeEach(() => {
+				instance = createControl({
+					options: defaultOptions,
+					onBlurSelectsFocusedOption: false
+				});
+			});
+
+			it('should not select focused option after calling onBlur', () => {
+				typeSearchText('One');
+
+				TestUtils.Simulate.blur(searchInputNode);
+
+				expect(onChange, 'was not called');
+			});
+		});
+
 		describe('onFocus', () => {
 
 			var onFocus;


### PR DESCRIPTION
In the current application where I'm using react-select, I'm looking for a way to automatically select the current option when the user clicks out of the select box without hitting 'enter' or 'tab' with a multi-select and add the currently-focused option to the list of selected options. I'm currently using a wrapper element similar to the one in https://github.com/JedWatson/react-select/issues/186 to manually select the value. Moving this functionality into the select component will remove the need for this type of workaround and hopefully resolve at least part of the cause of issues  https://github.com/JedWatson/react-select/issues/186 and https://github.com/JedWatson/react-select/issues/489 