### PR TITLE
fix arrow flip

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -81,7 +81,7 @@
 	border-color: darken(@select-input-border-color, 10%) @select-input-border-color lighten(@select-input-border-color, 5%);
 
 	// flip the arrow so its pointing up when the menu is open
-	> .Select-arrow {
+	.Select-arrow {
 		border-color: transparent transparent @select-arrow-color;
 		border-width: 0 @select-arrow-width @select-arrow-width;
 	}


### PR DESCRIPTION
This PR fixes the select control arrow flipping.

The `.Select-arrow` component is not a direct descendant of `.Select-control` so the existing CSS for arrow flipping was not being used.