### PR TITLE
fixed exception when clearing an Async field that is not set to multi

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -186,7 +186,7 @@ export default class Async extends Component {
 			options: (isLoading && loadingPlaceholder) ? [] : options,
 			ref: (ref) => (this.select = ref),
 			onChange: (newValues) => {
-				if (this.props.value && (newValues.length > this.props.value.length)) {
+				if (this.props.multi && this.props.value && (newValues.length > this.props.value.length)) {
 					this.clearOptions();
 				}
 				this.props.onChange(newValues);


### PR DESCRIPTION
In a7782b34abdc9d2beb8c604ee605fb1e81db8bd2, the following bug was introduced:
When clicking the "clear" Button of an Async Component and its `multi` property is not present or is set to `false`, it throws an exception, because the code expects an array as new value.

I've created a temporary fix for this, that you can pull if you want.
It might make sense to ask @DanielHeath if this is the proper way to fix this, though.