### PR TITLE
Fixed bug. No more comparing objects in getFocusableOptionIndex

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1009,7 +1009,14 @@ const Select = React.createClass({
 
 		let focusedOption = this.state.focusedOption || selectedOption;
 		if (focusedOption && !focusedOption.disabled) {
-			const focusedOptionIndex = options.findIndex(option => option.value === focusedOption.value);
+			let focusedOptionIndex = -1;
+			options.some((option, index) => {
+				const isOptionEqual = option.value === focusedOption.value;
+				if (isOptionEqual) {
+					focusedOptionIndex = index;
+				}
+				return isOptionEqual;
+			});
 			if (focusedOptionIndex !== -1) {
 				return focusedOptionIndex;
 			}

--- a/src/Select.js
+++ b/src/Select.js
@@ -1009,7 +1009,7 @@ const Select = React.createClass({
 
 		let focusedOption = this.state.focusedOption || selectedOption;
 		if (focusedOption && !focusedOption.disabled) {
-			const focusedOptionIndex = options.indexOf(focusedOption);
+			const focusedOptionIndex = options.findIndex(option => option.value === focusedOption.value);
 			if (focusedOptionIndex !== -1) {
 				return focusedOptionIndex;
 			}


### PR DESCRIPTION
When using with redux-form focusedOption can be not equal to any element of options array

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness