### PR TITLE
onMenuScrollToBottom fires when the menu is scrolled to the bottom on resize window

### DIFF
--- a/less/menu.less
+++ b/less/menu.less
@@ -31,6 +31,7 @@
 .Select-menu {
 	max-height: (@select-menu-max-height - 2px);
 	overflow-y: auto;
+	border-bottom: 1px solid transparent;
 }
 
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -541,7 +541,9 @@ const Select = React.createClass({
 	handleMenuScroll (event) {
 		if (!this.props.onMenuScrollToBottom) return;
 		let { target } = event;
-		if (target.scrollHeight > target.offsetHeight && !(target.scrollHeight - target.offsetHeight - target.scrollTop)) {
+		const { bottom: endPoint } = this.menuListEndPoint.getBoundingClientRect();
+		const { bottom } = target.getBoundingClientRect();
+		if (target.scrollHeight > target.clientHeight && bottom >= endPoint) {
 			this.props.onMenuScrollToBottom();
 		}
 	},
@@ -1034,6 +1036,7 @@ const Select = React.createClass({
 						 onScroll={this.handleMenuScroll}
 						 onMouseDown={this.handleMouseDownOnMenu}>
 					{menu}
+					<div ref={ref => this.menuListEndPoint = ref}></div>
 				</div>
 			</div>
 		);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -242,6 +242,11 @@ describe('Select', () => {
 			expect(instance.menu, 'not to equal', undefined);
 		});
 
+		it('menuListEndPoint', () => {
+			clickArrowToOpen();
+			expect(instance.menuListEndPoint, 'not to equal', undefined);
+		});
+
 		it('wrapper', () => {
 			expect(instance.wrapper, 'not to equal', undefined);
 		});


### PR DESCRIPTION
Fixed issue #1516.
Due to rounding error in some browsers (Edge) and fractional values in others (Chrome) on window resize I decided to use an additional element to detect end of scrolling. I find the coordinates of the element and comparing the coordinates of the element and container options