### PR TITLE
Adding a test case for unhandled promise rejections from loadOptions

### DIFF
--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -192,6 +192,25 @@ describe('Async', () => {
 				typeSearchText('bar');
 				expect(asyncNode.querySelectorAll('[role=option]').length, 'to equal', 0);
 			});
+
+			it('should not swallow rejected promises', done => {
+				const handler = sinon.spy();
+
+				process.on('unhandledRejection', handler);
+
+			  Promise.reject(new Error('rejection'));
+
+				createControl({
+					loadOptions: () => Promise.reject(new Error('rejection')),
+					autoload: true,
+				});
+
+				setTimeout(() => {
+					expect(handler, 'was called times', 2);
+
+					done();
+				}, 500);
+			});
 		});
 
 		describe('with promises', () => {


### PR DESCRIPTION
I don't see anything in the docs about rejected promises, and I know it's common for promises to get swallowed, but it's definitely bad behavior to silently fail and not trigger a global handler. I've written a test case for it - let me know if you want me to make an issue or anything.