### PR TITLE
Fix aria-owns attribute - Issue #1521

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -871,12 +871,17 @@ const Select = React.createClass({
 
 		if (this.props.disabled || !this.props.searchable) {
 			const { inputClassName, ...divProps } = this.props.inputProps;
+
+			const ariaOwns = classNames({
+				[this._instancePrefix + '-list']: isOpen,
+			});
+
 			return (
 				<div
 					{...divProps}
 					role="combobox"
 					aria-expanded={isOpen}
-					aria-owns={isOpen ? this._instancePrefix + '-list' : this._instancePrefix + '-value'}
+					aria-owns={ariaOwns}
 					aria-activedescendant={isOpen ? this._instancePrefix + '-option-' + focusedOptionIndex : this._instancePrefix + '-value'}
 					className={className}
 					tabIndex={this.props.tabIndex || 0}


### PR DESCRIPTION
(Addresses issue #1521)

It appears that Firefox is getting stuck in some kind of infinite loop due to incorrect use of `aria-owns` attribute. Here's the W3C spec on `aria-owns`:

https://www.w3.org/TR/wai-aria/states_and_properties#aria-owns

In `Select.js`, line 879, when `isOpen` is false, the component assigns `this._instancePrefix + '-value'` to `aria-owns`. That value corresponds to a DOM node which *is* a parent, and thus has a hierarchical relationship, breaking the W3C spec. 

If you visit the demo in Chrome (https://jedwatson.github.io/react-select/) and inspect the HTML, you'll see that in the situation when the component would be breaking Firefox, Chrome has intelligently removed the offending `aria-owns` value.

(This PR uses the same "classNames" approach to generating `aria-owns` already used on line 841.) 