### PR TITLE
Fix focus on next Element on tab press

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -482,7 +482,7 @@ const Select = React.createClass({
 				}
 			return;
 			case 9: // tab
-				if (event.shiftKey || !this.state.isOpen || !this.props.tabSelectsValue) {
+				if (event.shiftKey || !this.state.isOpen || !this.props.tabSelectsValue || this.state.inputValue.length==0) {
 					return;
 				}
 				this.selectFocusedOption();


### PR DESCRIPTION
When I chose multiple values and I wanted to focus on the next element by pressing `tab` it didn't work so I had to press `esc` first and only afterwards `tab`.
Most clients encounter with this problem so I fix it by adding one more cond in keyDown handler.