### PR TITLE
Fix missing .focus() method in Creatable (#1437)

### DIFF
--- a/src/AsyncCreatable.js
+++ b/src/AsyncCreatable.js
@@ -13,6 +13,10 @@ function reduce(obj, props = {}){
 const AsyncCreatable = React.createClass({
 	displayName: 'AsyncCreatableSelect',
 
+	focus () {
+		this.select.focus();
+	},
+
 	render () {
 		return (
 			<Select.Async {...this.props}>
@@ -26,6 +30,7 @@ const AsyncCreatable = React.createClass({
 									return asyncProps.onInputChange(input);
 								}}
 								ref={(ref) => {
+									this.select = ref;
 									creatableProps.ref(ref);
 									asyncProps.ref(ref);
 								}}

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -203,6 +203,10 @@ const Creatable = React.createClass({
 		}
 	},
 
+	focus () {
+		this.select.focus();
+	},
+
 	render () {
 		const {
 			newOptionCreator,

--- a/test/AsyncCreatable-test.js
+++ b/test/AsyncCreatable-test.js
@@ -59,4 +59,17 @@ describe('AsyncCreatable', () => {
 			class: ['foo']
 		});
 	});
+
+	describe('.focus()', () => {
+		beforeEach(() => {
+			createControl({});
+			TestUtils.Simulate.blur(filterInputNode);
+		});
+
+		it('focuses the search input', () => {
+			expect(filterInputNode, 'not to equal', document.activeElement);
+			creatableInstance.focus();
+			expect(filterInputNode, 'to equal', document.activeElement);
+		});
+	});
 });

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -237,4 +237,17 @@ describe('Creatable', () => {
 		createControl({ onInputKeyDown: event => done() });
 		return creatableInstance.onInputKeyDown({ keyCode: 97 });
 	});
+
+	describe('.focus()', () => {
+		beforeEach(() => {
+			createControl({});
+			TestUtils.Simulate.blur(filterInputNode);
+		});
+
+		it('focuses the search input', () => {
+			expect(filterInputNode, 'not to equal', document.activeElement);
+			creatableInstance.focus();
+			expect(filterInputNode, 'to equal', document.activeElement);
+		});
+	});
 });


### PR DESCRIPTION
Fixes the #1437 by adding `.focus()` instance method to `Creatable`.