### PR TITLE
Update tabIndex propType to string or number

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -37,6 +37,10 @@ const stringOrNode = React.PropTypes.oneOfType([
 	React.PropTypes.string,
 	React.PropTypes.node
 ]);
+const stringOrNumber = React.PropTypes.oneOfType([
+	React.PropTypes.string,
+	React.PropTypes.number
+]);
 
 let instanceId = 1;
 
@@ -107,7 +111,7 @@ const Select = React.createClass({
 		searchable: React.PropTypes.bool,           // whether to enable searching feature or not
 		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
 		style: React.PropTypes.object,              // optional style to apply to the control
-		tabIndex: React.PropTypes.string,           // optional tab index of the control
+		tabIndex: stringOrNumber,                   // optional tab index of the control
 		tabSelectsValue: React.PropTypes.bool,      // whether to treat tabbing out while focused to be value selection
 		value: React.PropTypes.any,                 // initial field value
 		valueComponent: React.PropTypes.func,       // value component to render


### PR DESCRIPTION
This PR fixes #1132. Integer properties can be set as either a `number` or a `string`, depending on the way you set the property value. When using [IDL](https://github.com/facebook/react/blob/e452e3374135c116ef687a8bb3a5d277e3cde8fb/src/renderers/dom/shared/DOMPropertyOperations.js#L146), `tabIndex` should be an integer, but when using [`element.setAttribute()`](https://github.com/facebook/react/blob/e452e3374135c116ef687a8bb3a5d277e3cde8fb/src/renderers/dom/shared/DOMPropertyOperations.js#L158), the value needs to always be a `string`. React converts values to string when setting the value through `setAttribute`, but I think it's better to keep both of the types for backwards compatibility purposes 😄 
More on content vs IDL attributes [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#Content_versus_IDL_attributes).