### PR TITLE
special handing for backspace if inputValue contains one character

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -479,6 +479,8 @@ const Select = React.createClass({
 				if (!this.state.inputValue && this.props.backspaceRemoves) {
 					event.preventDefault();
 					this.popValue();
+				} else if (this.props.backspaceRemoves && this.state.inputValue.length === 1) {
+					this.popValue();
 				}
 			return;
 			case 9: // tab

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1782,6 +1782,14 @@ describe('Select', () => {
 			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
 		});
 
+		it('removes the last selected option with backspace when search text is set', () => {
+			typeSearchText('a');
+			setValueProp(['four','three']);
+			onChange.reset();  // Ignore previous onChange calls
+			pressBackspace();
+			expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
+		});
+
 		it('does not remove the last selected option with backspace when backspaceRemoves=false', () => {
 
 			// Disable backspace


### PR DESCRIPTION
if a value is selected, a new value is entered and removed with backspace, the old value appeared again and another backspace trigger was needed to remove the selected value.