### PR TITLE
Migrate to prop-types and create-react-class packages

### DIFF
--- a/examples/src/components/BooleanSelect.js
+++ b/examples/src/components/BooleanSelect.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
-var ValuesAsBooleansField = React.createClass({
+var ValuesAsBooleansField = createClass({
 	displayName: 'ValuesAsBooleansField',
 	propTypes: {
-		label: React.PropTypes.string
+		label: PropTypes.string
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/Contributors.js
+++ b/examples/src/components/Contributors.js
@@ -1,14 +1,16 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
 const CONTRIBUTORS = require('../data/contributors');
 const MAX_CONTRIBUTORS = 6;
 const ASYNC_DELAY = 500;
 
-const Contributors = React.createClass({
+const Contributors = createClass({
 	displayName: 'Contributors',
 	propTypes: {
-		label: React.PropTypes.string,
+		label: PropTypes.string,
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/Creatable.js
+++ b/examples/src/components/Creatable.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
-var CreatableDemo = React.createClass({
+var CreatableDemo = createClass({
 	displayName: 'CreatableDemo',
 	propTypes: {
-		hint: React.PropTypes.string,
-		label: React.PropTypes.string
+		hint: PropTypes.string,
+		label: PropTypes.string
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/CustomComponents.js
+++ b/examples/src/components/CustomComponents.js
@@ -1,20 +1,22 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 import Gravatar from 'react-gravatar';
 
 const USERS = require('../data/users');
 const GRAVATAR_SIZE = 15;
 
-const GravatarOption = React.createClass({
+const GravatarOption = createClass({
 	propTypes: {
-		children: React.PropTypes.node,
-		className: React.PropTypes.string,
-		isDisabled: React.PropTypes.bool,
-		isFocused: React.PropTypes.bool,
-		isSelected: React.PropTypes.bool,
-		onFocus: React.PropTypes.func,
-		onSelect: React.PropTypes.func,
-		option: React.PropTypes.object.isRequired,
+		children: PropTypes.node,
+		className: PropTypes.string,
+		isDisabled: PropTypes.bool,
+		isFocused: PropTypes.bool,
+		isSelected: PropTypes.bool,
+		onFocus: PropTypes.func,
+		onSelect: PropTypes.func,
+		option: PropTypes.object.isRequired,
 	},
 	handleMouseDown (event) {
 		event.preventDefault();
@@ -50,11 +52,11 @@ const GravatarOption = React.createClass({
 	}
 });
 
-const GravatarValue = React.createClass({
+const GravatarValue = createClass({
 	propTypes: {
-		children: React.PropTypes.node,
-		placeholder: React.PropTypes.string,
-		value: React.PropTypes.object
+		children: PropTypes.node,
+		placeholder: PropTypes.string,
+		value: PropTypes.object
 	},
 	render () {
 		var gravatarStyle = {
@@ -76,10 +78,10 @@ const GravatarValue = React.createClass({
 	}
 });
 
-const UsersField = React.createClass({
+const UsersField = createClass({
 	propTypes: {
-		hint: React.PropTypes.string,
-		label: React.PropTypes.string,
+		hint: PropTypes.string,
+		label: PropTypes.string,
 	},
 	getInitialState () {
 		return {};

--- a/examples/src/components/CustomRender.js
+++ b/examples/src/components/CustomRender.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 import Highlighter from 'react-highlight-words';
 
-var DisabledUpsellOptions = React.createClass({
+var DisabledUpsellOptions = createClass({
 	displayName: 'DisabledUpsellOptions',
 	propTypes: {
-		label: React.PropTypes.string,
+		label: PropTypes.string,
 	},
 	getInitialState () {
 		return {};

--- a/examples/src/components/GithubUsers.js
+++ b/examples/src/components/GithubUsers.js
@@ -1,12 +1,14 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 import fetch from 'isomorphic-fetch';
 
 
-const GithubUsers = React.createClass({
+const GithubUsers = createClass({
 	displayName: 'GithubUsers',
 	propTypes: {
-		label: React.PropTypes.string,
+		label: PropTypes.string,
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/Multiselect.js
+++ b/examples/src/components/Multiselect.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
 const FLAVOURS = [
@@ -14,10 +16,10 @@ const WHY_WOULD_YOU = [
 	{ label: 'Chocolate (are you crazy?)', value: 'chocolate', disabled: true },
 ].concat(FLAVOURS.slice(1));
 
-var MultiSelectField = React.createClass({
+var MultiSelectField = createClass({
 	displayName: 'MultiSelectField',
 	propTypes: {
-		label: React.PropTypes.string,
+		label: PropTypes.string,
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/NumericSelect.js
+++ b/examples/src/components/NumericSelect.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
-var ValuesAsNumbersField = React.createClass({
+var ValuesAsNumbersField = createClass({
 	displayName: 'ValuesAsNumbersField',
 	propTypes: {
-		label: React.PropTypes.string
+		label: PropTypes.string
 	},
 	getInitialState () {
 		return {

--- a/examples/src/components/States.js
+++ b/examples/src/components/States.js
@@ -1,13 +1,15 @@
 import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Select from 'react-select';
 
 const STATES = require('../data/states');
 
-var StatesField = React.createClass({
+var StatesField = createClass({
 	displayName: 'StatesField',
 	propTypes: {
-		label: React.PropTypes.string,
-		searchable: React.PropTypes.bool,
+		label: PropTypes.string,
+		searchable: PropTypes.bool,
 	},
 	getDefaultProps () {
 		return {

--- a/examples/src/components/Virtualized.js
+++ b/examples/src/components/Virtualized.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import createClass from 'create-react-class';
 import VirtualizedSelect from 'react-virtualized-select';
 
 const DATA = require('../data/cities');
 
-var CitiesField = React.createClass({
+var CitiesField = createClass({
 	displayName: 'CitiesField',
 	getInitialState () {
 		return {};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,9 @@ var taskConfig = {
 			'classnames',
 			'react-input-autosize',
 			'react',
-			'react-dom'
+			'react-dom',
+			'create-react-class',
+			'prop-types'
 		],
 		less: {
 			path: 'less',

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "url": "https://github.com/JedWatson/react-select.git"
   },
   "dependencies": {
+    "create-react-class": "15.5.1",
     "classnames": "^2.2.4",
-    "react-input-autosize": "^1.1.0"
+    "react-input-autosize": "^1.1.0",
+    "prop-types": "15.5.6"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "create-react-class": "15.5.1",
     "classnames": "^2.2.4",
-    "react-input-autosize": "^1.1.0",
-    "prop-types": "15.5.6"
+    "react-input-autosize": "^1.1.3",
+    "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/JedWatson/react-select.git"
   },
   "dependencies": {
-    "create-react-class": "15.5.1",
+    "create-react-class": "^15.5.2",
     "classnames": "^2.2.4",
     "react-input-autosize": "^1.1.3",
-    "prop-types": "^15.5.6"
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/Async.js
+++ b/src/Async.js
@@ -1,35 +1,36 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Select from './Select';
 import stripDiacritics from './utils/stripDiacritics';
 
 const propTypes = {
-	autoload: React.PropTypes.bool.isRequired,       // automatically call the `loadOptions` prop on-mount; defaults to true
-	cache: React.PropTypes.any,                      // object to use to cache results; set to null/false to disable caching
-	children: React.PropTypes.func.isRequired,       // Child function responsible for creating the inner Select component; (props: Object): PropTypes.element
-	ignoreAccents: React.PropTypes.bool,             // strip diacritics when filtering; defaults to true
-	ignoreCase: React.PropTypes.bool,                // perform case-insensitive filtering; defaults to true
-	loadingPlaceholder: React.PropTypes.oneOfType([  // replaces the placeholder while options are loading
-		React.PropTypes.string,
-		React.PropTypes.node
+	autoload: PropTypes.bool.isRequired,       // automatically call the `loadOptions` prop on-mount; defaults to true
+	cache: PropTypes.any,                      // object to use to cache results; set to null/false to disable caching
+	children: PropTypes.func.isRequired,       // Child function responsible for creating the inner Select component; (props: Object): PropTypes.element
+	ignoreAccents: PropTypes.bool,             // strip diacritics when filtering; defaults to true
+	ignoreCase: PropTypes.bool,                // perform case-insensitive filtering; defaults to true
+	loadingPlaceholder: PropTypes.oneOfType([  // replaces the placeholder while options are loading
+		PropTypes.string,
+		PropTypes.node
 	]),
-	loadOptions: React.PropTypes.func.isRequired,    // callback to load options asynchronously; (inputValue: string, callback: Function): ?Promise
-	multi: React.PropTypes.bool,                     // multi-value input
+	loadOptions: PropTypes.func.isRequired,    // callback to load options asynchronously; (inputValue: string, callback: Function): ?Promise
+	multi: PropTypes.bool,                     // multi-value input
 	options: PropTypes.array.isRequired,             // array of options
-	placeholder: React.PropTypes.oneOfType([         // field placeholder, displayed when there's no value (shared with Select)
-		React.PropTypes.string,
-		React.PropTypes.node
+	placeholder: PropTypes.oneOfType([         // field placeholder, displayed when there's no value (shared with Select)
+		PropTypes.string,
+		PropTypes.node
 	]),
-	noResultsText: React.PropTypes.oneOfType([       // field noResultsText, displayed when no options come back from the server
-		React.PropTypes.string,
-		React.PropTypes.node
+	noResultsText: PropTypes.oneOfType([       // field noResultsText, displayed when no options come back from the server
+		PropTypes.string,
+		PropTypes.node
 	]),
-	onChange: React.PropTypes.func,                  // onChange handler: function (newValue) {}
-	searchPromptText: React.PropTypes.oneOfType([    // label to prompt for search input
-		React.PropTypes.string,
-		React.PropTypes.node
+	onChange: PropTypes.func,                  // onChange handler: function (newValue) {}
+	searchPromptText: PropTypes.oneOfType([    // label to prompt for search input
+		PropTypes.string,
+		PropTypes.node
 	]),
-	onInputChange: React.PropTypes.func,             // optional for keeping track of what is being typed
-	value: React.PropTypes.any,                      // initial field value
+	onInputChange: PropTypes.func,             // optional for keeping track of what is being typed
+	value: PropTypes.any,                      // initial field value
 };
 
 const defaultCache = {};
@@ -214,4 +215,4 @@ function defaultChildren (props) {
 	return (
 		<Select {...props} />
 	);
-};
+}

--- a/src/AsyncCreatable.js
+++ b/src/AsyncCreatable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createClass from 'create-react-class';
 import Select from './Select';
 
 function reduce(obj, props = {}){
@@ -10,7 +11,7 @@ function reduce(obj, props = {}){
   }, props);
 }
 
-const AsyncCreatable = React.createClass({
+const AsyncCreatable = createClass({
 	displayName: 'AsyncCreatableSelect',
 
 	focus () {

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Select from './Select';
 import defaultFilterOptions from './utils/defaultFilterOptions';
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
@@ -10,45 +11,45 @@ const Creatable = React.createClass({
 		// Child function responsible for creating the inner Select component
 		// This component can be used to compose HOCs (eg Creatable and Async)
 		// (props: Object): PropTypes.element
-		children: React.PropTypes.func,
+		children: PropTypes.func,
 
 		// See Select.propTypes.filterOptions
-		filterOptions: React.PropTypes.any,
+		filterOptions: PropTypes.any,
 
 		// Searches for any matching option within the set of options.
 		// This function prevents duplicate options from being created.
 		// ({ option: Object, options: Array, labelKey: string, valueKey: string }): boolean
-		isOptionUnique: React.PropTypes.func,
+		isOptionUnique: PropTypes.func,
 
 	    // Determines if the current input text represents a valid option.
 	    // ({ label: string }): boolean
-	    isValidNewOption: React.PropTypes.func,
+	    isValidNewOption: PropTypes.func,
 
 		// See Select.propTypes.menuRenderer
-		menuRenderer: React.PropTypes.any,
+		menuRenderer: PropTypes.any,
 
 	    // Factory to create new option.
 	    // ({ label: string, labelKey: string, valueKey: string }): Object
-		newOptionCreator: React.PropTypes.func,
+		newOptionCreator: PropTypes.func,
 
 		// input change handler: function (inputValue) {}
-		onInputChange: React.PropTypes.func,
+		onInputChange: PropTypes.func,
 
 		// input keyDown handler: function (event) {}
-		onInputKeyDown: React.PropTypes.func,
+		onInputKeyDown: PropTypes.func,
 
 		// new option click handler: function (option) {}
-		onNewOptionClick: React.PropTypes.func,
+		onNewOptionClick: PropTypes.func,
 
 		// See Select.propTypes.options
-		options: React.PropTypes.array,
+		options: PropTypes.array,
 
 	    // Creates prompt/placeholder option text.
 	    // (filterText: string): string
-		promptTextCreator: React.PropTypes.func,
+		promptTextCreator: PropTypes.func,
 
 		// Decides if a keyDown event (eg its `keyCode`) should result in the creation of a new option.
-		shouldKeyDownEventCreateNewOption: React.PropTypes.func,
+		shouldKeyDownEventCreateNewOption: PropTypes.func,
 	},
 
 	// Default prop methods

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Select from './Select';
 import defaultFilterOptions from './utils/defaultFilterOptions';
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
 
-const Creatable = React.createClass({
+const Creatable = createClass({
 	displayName: 'CreatableSelect',
 
 	propTypes: {

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,19 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const Option = React.createClass({
 	propTypes: {
-		children: React.PropTypes.node,
-		className: React.PropTypes.string,             // className (based on mouse position)
-		instancePrefix: React.PropTypes.string.isRequired,  // unique prefix for the ids (used for aria)
-		isDisabled: React.PropTypes.bool,              // the option is disabled
-		isFocused: React.PropTypes.bool,               // the option is focused
-		isSelected: React.PropTypes.bool,              // the option is selected
-		onFocus: React.PropTypes.func,                 // method to handle mouseEnter on option element
-		onSelect: React.PropTypes.func,                // method to handle click on option element
-		onUnfocus: React.PropTypes.func,               // method to handle mouseLeave on option element
-		option: React.PropTypes.object.isRequired,     // object that is base for that option
-		optionIndex: React.PropTypes.number,           // index of the option, used to generate unique ids for aria
+		children: PropTypes.node,
+		className: PropTypes.string,             // className (based on mouse position)
+		instancePrefix: PropTypes.string.isRequired,  // unique prefix for the ids (used for aria)
+		isDisabled: PropTypes.bool,              // the option is disabled
+		isFocused: PropTypes.bool,               // the option is focused
+		isSelected: PropTypes.bool,              // the option is selected
+		onFocus: PropTypes.func,                 // method to handle mouseEnter on option element
+		onSelect: PropTypes.func,                // method to handle click on option element
+		onUnfocus: PropTypes.func,               // method to handle mouseLeave on option element
+		option: PropTypes.object.isRequired,     // object that is base for that option
+		optionIndex: PropTypes.number,           // index of the option, used to generate unique ids for aria
 	},
 	blockEvent (event) {
 		event.preventDefault();

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Option = React.createClass({
+const Option = createClass({
 	propTypes: {
 		children: PropTypes.node,
 		className: PropTypes.string,             // className (based on mouse position)

--- a/src/Select.js
+++ b/src/Select.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import AutosizeInput from 'react-input-autosize';
 import classNames from 'classnames';
@@ -33,9 +34,9 @@ function stringifyValue (value) {
 	}
 }
 
-const stringOrNode = React.PropTypes.oneOfType([
-	React.PropTypes.string,
-	React.PropTypes.node
+const stringOrNode = PropTypes.oneOfType([
+	PropTypes.string,
+	PropTypes.node
 ]);
 
 let instanceId = 1;
@@ -45,76 +46,76 @@ const Select = React.createClass({
 	displayName: 'Select',
 
 	propTypes: {
-		addLabelText: React.PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
-		'aria-describedby': React.PropTypes.string,	// HTML ID(s) of element(s) that should be used to describe this input (for assistive tech)
-		'aria-label': React.PropTypes.string,       // Aria label (for assistive tech)
-		'aria-labelledby': React.PropTypes.string,	// HTML ID of an element that should be used as the label (for assistive tech)
-		arrowRenderer: React.PropTypes.func,				// Create drop-down caret element
-		autoBlur: React.PropTypes.bool,             // automatically blur the component when an option is selected
-		autofocus: React.PropTypes.bool,            // autofocus the component on mount
-		autosize: React.PropTypes.bool,             // whether to enable autosizing or not
-		backspaceRemoves: React.PropTypes.bool,     // whether backspace removes an item if there is no text input
-		backspaceToRemoveMessage: React.PropTypes.string,  // Message to use for screenreaders to press backspace to remove the current item - {label} is replaced with the item label
-		className: React.PropTypes.string,          // className for the outer element
+		addLabelText: PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
+		'aria-describedby': PropTypes.string,	// HTML ID(s) of element(s) that should be used to describe this input (for assistive tech)
+		'aria-label': PropTypes.string,       // Aria label (for assistive tech)
+		'aria-labelledby': PropTypes.string,	// HTML ID of an element that should be used as the label (for assistive tech)
+		arrowRenderer: PropTypes.func,				// Create drop-down caret element
+		autoBlur: PropTypes.bool,             // automatically blur the component when an option is selected
+		autofocus: PropTypes.bool,            // autofocus the component on mount
+		autosize: PropTypes.bool,             // whether to enable autosizing or not
+		backspaceRemoves: PropTypes.bool,     // whether backspace removes an item if there is no text input
+		backspaceToRemoveMessage: PropTypes.string,  // Message to use for screenreaders to press backspace to remove the current item - {label} is replaced with the item label
+		className: PropTypes.string,          // className for the outer element
 		clearAllText: stringOrNode,                 // title for the "clear" control when multi: true
-		clearRenderer: React.PropTypes.func,        // create clearable x element
+		clearRenderer: PropTypes.func,        // create clearable x element
 		clearValueText: stringOrNode,               // title for the "clear" control
-		clearable: React.PropTypes.bool,            // should it be possible to reset value
-		deleteRemoves: React.PropTypes.bool,        // whether backspace removes an item if there is no text input
-		delimiter: React.PropTypes.string,          // delimiter to use to join multiple values for the hidden field value
-		disabled: React.PropTypes.bool,             // whether the Select is disabled or not
-		escapeClearsValue: React.PropTypes.bool,    // whether escape clears the value when the menu is closed
-		filterOption: React.PropTypes.func,         // method to filter a single option (option, filterString)
-		filterOptions: React.PropTypes.any,         // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
-		ignoreAccents: React.PropTypes.bool,        // whether to strip diacritics when filtering
-		ignoreCase: React.PropTypes.bool,           // whether to perform case-insensitive filtering
-		inputProps: React.PropTypes.object,         // custom attributes for the Input
-		inputRenderer: React.PropTypes.func,        // returns a custom input component
-		instanceId: React.PropTypes.string,         // set the components instanceId
-		isLoading: React.PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
-		joinValues: React.PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
-		labelKey: React.PropTypes.string,           // path of the label value in option objects
-		matchPos: React.PropTypes.string,           // (any|start) match the start or entire string when filtering
-		matchProp: React.PropTypes.string,          // (any|label|value) which option property to filter on
-		menuBuffer: React.PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
-		menuContainerStyle: React.PropTypes.object, // optional style to apply to the menu container
-		menuRenderer: React.PropTypes.func,         // renders a custom menu with options
-		menuStyle: React.PropTypes.object,          // optional style to apply to the menu
-		multi: React.PropTypes.bool,                // multi-value input
-		name: React.PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
+		clearable: PropTypes.bool,            // should it be possible to reset value
+		deleteRemoves: PropTypes.bool,        // whether backspace removes an item if there is no text input
+		delimiter: PropTypes.string,          // delimiter to use to join multiple values for the hidden field value
+		disabled: PropTypes.bool,             // whether the Select is disabled or not
+		escapeClearsValue: PropTypes.bool,    // whether escape clears the value when the menu is closed
+		filterOption: PropTypes.func,         // method to filter a single option (option, filterString)
+		filterOptions: PropTypes.any,         // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
+		ignoreAccents: PropTypes.bool,        // whether to strip diacritics when filtering
+		ignoreCase: PropTypes.bool,           // whether to perform case-insensitive filtering
+		inputProps: PropTypes.object,         // custom attributes for the Input
+		inputRenderer: PropTypes.func,        // returns a custom input component
+		instanceId: PropTypes.string,         // set the components instanceId
+		isLoading: PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
+		joinValues: PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
+		labelKey: PropTypes.string,           // path of the label value in option objects
+		matchPos: PropTypes.string,           // (any|start) match the start or entire string when filtering
+		matchProp: PropTypes.string,          // (any|label|value) which option property to filter on
+		menuBuffer: PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
+		menuContainerStyle: PropTypes.object, // optional style to apply to the menu container
+		menuRenderer: PropTypes.func,         // renders a custom menu with options
+		menuStyle: PropTypes.object,          // optional style to apply to the menu
+		multi: PropTypes.bool,                // multi-value input
+		name: PropTypes.string,               // generates a hidden <input /> tag with this field name for html forms
 		noResultsText: stringOrNode,                // placeholder displayed when there are no matching search results
-		onBlur: React.PropTypes.func,               // onBlur handler: function (event) {}
-		onBlurResetsInput: React.PropTypes.bool,    // whether input is cleared on blur
-		onChange: React.PropTypes.func,             // onChange handler: function (newValue) {}
-		onClose: React.PropTypes.func,              // fires when the menu is closed
-		onCloseResetsInput: React.PropTypes.bool,		// whether input is cleared when menu is closed through the arrow
-		onFocus: React.PropTypes.func,              // onFocus handler: function (event) {}
-		onInputChange: React.PropTypes.func,        // onInputChange handler: function (inputValue) {}
-		onInputKeyDown: React.PropTypes.func,       // input keyDown handler: function (event) {}
-		onMenuScrollToBottom: React.PropTypes.func, // fires when the menu is scrolled to the bottom; can be used to paginate options
-		onOpen: React.PropTypes.func,               // fires when the menu is opened
-		onValueClick: React.PropTypes.func,         // onClick handler for value labels: function (value, event) {}
-		openAfterFocus: React.PropTypes.bool,       // boolean to enable opening dropdown when focused
-		openOnFocus: React.PropTypes.bool,          // always open options menu on focus
-		optionClassName: React.PropTypes.string,    // additional class(es) to apply to the <Option /> elements
-		optionComponent: React.PropTypes.func,      // option component to render in dropdown
-		optionRenderer: React.PropTypes.func,       // optionRenderer: function (option) {}
-		options: React.PropTypes.array,             // array of options
-		pageSize: React.PropTypes.number,           // number of entries to page when using page up/down keys
+		onBlur: PropTypes.func,               // onBlur handler: function (event) {}
+		onBlurResetsInput: PropTypes.bool,    // whether input is cleared on blur
+		onChange: PropTypes.func,             // onChange handler: function (newValue) {}
+		onClose: PropTypes.func,              // fires when the menu is closed
+		onCloseResetsInput: PropTypes.bool,		// whether input is cleared when menu is closed through the arrow
+		onFocus: PropTypes.func,              // onFocus handler: function (event) {}
+		onInputChange: PropTypes.func,        // onInputChange handler: function (inputValue) {}
+		onInputKeyDown: PropTypes.func,       // input keyDown handler: function (event) {}
+		onMenuScrollToBottom: PropTypes.func, // fires when the menu is scrolled to the bottom; can be used to paginate options
+		onOpen: PropTypes.func,               // fires when the menu is opened
+		onValueClick: PropTypes.func,         // onClick handler for value labels: function (value, event) {}
+		openAfterFocus: PropTypes.bool,       // boolean to enable opening dropdown when focused
+		openOnFocus: PropTypes.bool,          // always open options menu on focus
+		optionClassName: PropTypes.string,    // additional class(es) to apply to the <Option /> elements
+		optionComponent: PropTypes.func,      // option component to render in dropdown
+		optionRenderer: PropTypes.func,       // optionRenderer: function (option) {}
+		options: PropTypes.array,             // array of options
+		pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 		placeholder: stringOrNode,                  // field placeholder, displayed when there's no value
-		required: React.PropTypes.bool,             // applies HTML5 required attribute when needed
-		resetValue: React.PropTypes.any,            // value to use when you clear the control
-		scrollMenuIntoView: React.PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
-		searchable: React.PropTypes.bool,           // whether to enable searching feature or not
-		simpleValue: React.PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
-		style: React.PropTypes.object,              // optional style to apply to the control
-		tabIndex: React.PropTypes.string,           // optional tab index of the control
-		tabSelectsValue: React.PropTypes.bool,      // whether to treat tabbing out while focused to be value selection
-		value: React.PropTypes.any,                 // initial field value
-		valueComponent: React.PropTypes.func,       // value component to render
-		valueKey: React.PropTypes.string,           // path of the label value in option objects
-		valueRenderer: React.PropTypes.func,        // valueRenderer: function (option) {}
-		wrapperStyle: React.PropTypes.object,       // optional style to apply to the component wrapper
+		required: PropTypes.bool,             // applies HTML5 required attribute when needed
+		resetValue: PropTypes.any,            // value to use when you clear the control
+		scrollMenuIntoView: PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
+		searchable: PropTypes.bool,           // whether to enable searching feature or not
+		simpleValue: PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
+		style: PropTypes.object,              // optional style to apply to the control
+		tabIndex: PropTypes.string,           // optional tab index of the control
+		tabSelectsValue: PropTypes.bool,      // whether to treat tabbing out while focused to be value selection
+		value: PropTypes.any,                 // initial field value
+		valueComponent: PropTypes.func,       // value component to render
+		valueKey: PropTypes.string,           // path of the label value in option objects
+		valueRenderer: PropTypes.func,        // valueRenderer: function (option) {}
+		wrapperStyle: PropTypes.object,       // optional style to apply to the component wrapper
 	},
 
 	statics: { Async, AsyncCreatable, Creatable },

--- a/src/Select.js
+++ b/src/Select.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import AutosizeInput from 'react-input-autosize';
@@ -41,7 +42,7 @@ const stringOrNode = PropTypes.oneOfType([
 
 let instanceId = 1;
 
-const Select = React.createClass({
+const Select = createClass({
 
 	displayName: 'Select',
 

--- a/src/Value.js
+++ b/src/Value.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const Value = React.createClass({
@@ -6,12 +7,12 @@ const Value = React.createClass({
 	displayName: 'Value',
 
 	propTypes: {
-		children: React.PropTypes.node,
-		disabled: React.PropTypes.bool,               // disabled prop passed to ReactSelect
-		id: React.PropTypes.string,                   // Unique id for the value - used for aria
-		onClick: React.PropTypes.func,                // method to handle click on value label
-		onRemove: React.PropTypes.func,               // method to handle removal of the value
-		value: React.PropTypes.object.isRequired,     // the option object for this value
+		children: PropTypes.node,
+		disabled: PropTypes.bool,               // disabled prop passed to ReactSelect
+		id: PropTypes.string,                   // Unique id for the value - used for aria
+		onClick: PropTypes.func,                // method to handle click on value label
+		onRemove: PropTypes.func,               // method to handle removal of the value
+		value: PropTypes.object.isRequired,     // the option object for this value
 	},
 
 	handleMouseDown (event) {

--- a/src/Value.js
+++ b/src/Value.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import createClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const Value = React.createClass({
+const Value = createClass({
 
 	displayName: 'Value',
 


### PR DESCRIPTION
In React 15.5 they are starting the process to migrate away from having `PropTypes` and `createClass` under the main `React` object. This PR updates all of the related files needed to use the new packages.

I ran all of the unit tests and also tested the examples app after the changes. Both had no errors/issues.