### PR TITLE
Fix "Module create-react-class not found" (fix #1697)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.4",
-    "react-input-autosize": "^1.1.0"
+    "react-input-autosize": "1.1.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
Fix for #1697 

There's a regression with the latest version of `react-input-autosize`.
Build is failing because of a dependency with the module `create-react-class`, [more info on the related issue](https://github.com/JedWatson/react-input-autosize/issues/84)