### PR TITLE
[fix] Make getFocusableOptionIndex use valueKey

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1023,7 +1023,7 @@ const Select = createClass({
 		if (focusedOption && !focusedOption.disabled) {
 			let focusedOptionIndex = -1;
 			options.some((option, index) => {
-				const isOptionEqual = option.value === focusedOption.value;
+				const isOptionEqual = option[this.props.valueKey] === focusedOption[this.props.valueKey];
 				if (isOptionEqual) {
 					focusedOptionIndex = index;
 				}


### PR DESCRIPTION
Currently the `getFocusableOptionIndex` method assumes that the value for a particular option is stored under the `value` key, rather than using the `valueKey` prop like elsewhere. This causes the up/down arrows and option hovering to not work