### PR TITLE
Always pass valueArray to menuRenderer

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1121,7 +1121,7 @@ const Select = createClass({
 					{this.renderClear()}
 					{this.renderArrow()}
 				</div>
-				{isOpen ? this.renderOuter(options, !this.props.multi ? valueArray : null, focusedOption) : null}
+				{isOpen ? this.renderOuter(options, valueArray, focusedOption) : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
My application's designers wish to display a visual indicator for selected items instead of hiding them from the dropdown list when using a multi selector. Always passing the `valueArray` to the menu renderer seemed to be the best and least-impact way to do so.

The default behavior of the select box appears to be unaffected by this change, since the actual hiding of options happens in the default `filterOptions` function.