### PR TITLE
Add inputValue to menuRenderer

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -968,6 +968,7 @@ const Select = createClass({
 			return this.props.menuRenderer({
 				focusedOption,
 				focusOption: this.focusOption,
+				inputValue: this.state.inputValue,
 				instancePrefix: this._instancePrefix,
 				labelKey: this.props.labelKey,
 				onFocus: this.focusOption,


### PR DESCRIPTION
We wish to override the `optionRenderer` to highlight each search result with the main inputs' query. This means that the option at some level will need access to the input's value. I originally attempted to append the input value to the data by overriding `filterOptions`, but that broke filtering and selection. This seemed to be the most reasonable way to do it, and does not affect default behavior.