### PR TITLE
[FIX] #1316 enable opening if autosize=false and click on input

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -318,7 +318,7 @@ const Select = createClass({
 			return;
 		}
 
-		if (event.target.tagName === 'INPUT' && this.props.autosize) {
+		if (event.target.tagName === 'INPUT') {
 			return;
 		}
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -1120,8 +1120,8 @@ const Select = createClass({
 					onTouchMove={this.handleTouchMove}
 				>
 					<span className="Select-multi-value-wrapper" id={this._instancePrefix + '-value'}>
-						{this.renderValue(valueArray, isOpen)}
 						{this.renderInput(valueArray, focusedOptionIndex)}
+						{this.renderValue(valueArray, isOpen)}
 					</span>
 					{removeMessage}
 					{this.renderLoading()}

--- a/src/Select.js
+++ b/src/Select.js
@@ -318,7 +318,7 @@ const Select = createClass({
 			return;
 		}
 
-		if (event.target.tagName === 'INPUT') {
+		if (event.target.tagName === 'INPUT' && this.props.autosize) {
 			return;
 		}
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -575,6 +575,21 @@ describe('Select', () => {
 				required: undefined
 			});
 		});
+
+		it('should open the options again when clicked after selection has been made and still focused', () => {
+			// Click to show options
+			const node = ReactDOM.findDOMNode(instance);
+			const selectControl = getSelectControl(instance);
+			TestUtils.Simulate.mouseDown(selectControl, { button: 0 });
+			// Should be open
+			expect(node, 'queried for', '.Select-option', 'to have length', 3);
+			// Select first option
+			TestUtils.Simulate.mouseDown(node.querySelector('.Select-option'), { button: 0 });
+			// Click again to show options
+			TestUtils.Simulate.mouseDown(selectControl, { button: 0 });
+			// Should be open again
+			expect(node, 'queried for', '.Select-option', 'to have length', 3);
+		});
 	});
 
 	describe('with a return from onInputChange', () => {
@@ -3914,6 +3929,32 @@ describe('Select', () => {
 			expect(input, 'not to equal', document.activeElement);
 			instance.focus();
 			expect(input, 'to equal', document.activeElement);
+		});
+	});
+
+	describe('with autosize=false, searchable=true', () => {
+		beforeEach(() => {
+			instance = createControl({
+				autosize: false,
+				options: [{ value: 1, label: '1' }, { value: 2, label: '2' }],
+				value: 1,
+			});
+		});
+
+		it('should open the options again when clicked after selection has been made and still focused', () => {
+			// Click to show options
+			const node = ReactDOM.findDOMNode(instance);
+			TestUtils.Simulate.mouseDown(getSelectControl(instance), { button: 0 });
+			// Should open menu
+			expect(node, 'queried for', '.Select-option', 'to have length', 2);
+			// Select first option
+			TestUtils.Simulate.mouseDown(node.querySelector('.Select-option'), { button: 0 });
+			// Should close menu (and keep focus)
+			expect(node, 'queried for', '.Select-option', 'to have length', 0);
+			// Click again to show options
+			TestUtils.Simulate.mouseDown(getSelectControl(instance), { button: 0 });
+			// Should open menu again
+			expect(node, 'queried for', '.Select-option', 'to have length', 2);
 		});
 	});
 });

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -575,21 +575,6 @@ describe('Select', () => {
 				required: undefined
 			});
 		});
-
-		it('should open the options again when clicked after selection has been made and still focused', () => {
-			// Click to show options
-			const node = ReactDOM.findDOMNode(instance);
-			const selectControl = getSelectControl(instance);
-			TestUtils.Simulate.mouseDown(selectControl, { button: 0 });
-			// Should be open
-			expect(node, 'queried for', '.Select-option', 'to have length', 3);
-			// Select first option
-			TestUtils.Simulate.mouseDown(node.querySelector('.Select-option'), { button: 0 });
-			// Click again to show options
-			TestUtils.Simulate.mouseDown(selectControl, { button: 0 });
-			// Should be open again
-			expect(node, 'queried for', '.Select-option', 'to have length', 3);
-		});
 	});
 
 	describe('with a return from onInputChange', () => {
@@ -3929,32 +3914,6 @@ describe('Select', () => {
 			expect(input, 'not to equal', document.activeElement);
 			instance.focus();
 			expect(input, 'to equal', document.activeElement);
-		});
-	});
-
-	describe('with autosize=false, searchable=true', () => {
-		beforeEach(() => {
-			instance = createControl({
-				autosize: false,
-				options: [{ value: 1, label: '1' }, { value: 2, label: '2' }],
-				value: 1,
-			});
-		});
-
-		it('should open the options again when clicked after selection has been made and still focused', () => {
-			// Click to show options
-			const node = ReactDOM.findDOMNode(instance);
-			TestUtils.Simulate.mouseDown(getSelectControl(instance), { button: 0 });
-			// Should open menu
-			expect(node, 'queried for', '.Select-option', 'to have length', 2);
-			// Select first option
-			TestUtils.Simulate.mouseDown(node.querySelector('.Select-option'), { button: 0 });
-			// Should close menu (and keep focus)
-			expect(node, 'queried for', '.Select-option', 'to have length', 0);
-			// Click again to show options
-			TestUtils.Simulate.mouseDown(getSelectControl(instance), { button: 0 });
-			// Should open menu again
-			expect(node, 'queried for', '.Select-option', 'to have length', 2);
 		});
 	});
 });


### PR DESCRIPTION
This is a proposed fix for issue #1316 
The menu should open when a user clicks on the input after a selection has been made and the input is still in focus.
Aborting handleMouseDown when clicked on the input element only when `autosize=false` will fix the issue.
Downside is that it's not possible to change the location of the cursor by clicking when entering a search string.
