### PR TITLE
Always allow accents and case in the input

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -136,15 +136,7 @@ export default class Async extends Component {
 	}
 
 	_onInputChange (inputValue) {
-		const { ignoreAccents, ignoreCase, onInputChange } = this.props;
-
-		if (ignoreAccents) {
-			inputValue = stripDiacritics(inputValue);
-		}
-
-		if (ignoreCase) {
-			inputValue = inputValue.toLowerCase();
-		}
+		const { onInputChange } = this.props;
 
 		if (onInputChange) {
 			onInputChange(inputValue);


### PR DESCRIPTION
It would be nice to always allow accents and case in the Input regardless of if `ignoreAccents` or `ignoreCase` are true, especially when using create mode (since you may want to create a value that has accents or is case-sensitive).

I think they can safely be removed from here for filtering purposes since they are still applied to the input value in `defaultFilterOptions.js`

As discussed in https://github.com/JedWatson/react-select/pull/1329 and https://github.com/JedWatson/react-select/issues/1352.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jedwatson/react-select/1789)
<!-- Reviewable:end -->
