### PR TITLE
Support event default prevention for shouldKeyDownEventCreateNewOption

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -186,7 +186,7 @@ const Creatable = createClass({
 		if (
 			focusedOption &&
 			focusedOption === this._createPlaceholderOption &&
-			shouldKeyDownEventCreateNewOption({ keyCode: event.keyCode })
+			shouldKeyDownEventCreateNewOption(event)
 		) {
 			this.createNewOption();
 
@@ -278,8 +278,8 @@ function promptTextCreator (label) {
 	return `Create option "${label}"`;
 }
 
-function shouldKeyDownEventCreateNewOption ({ keyCode }) {
-	switch (keyCode) {
+function shouldKeyDownEventCreateNewOption (event) {
+	switch (event.keyCode) {
 		case 9:   // TAB
 		case 13:  // ENTER
 		case 188: // COMMA

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -146,6 +146,19 @@ describe('Creatable', () => {
 		expect(selectedOption, 'to be', options[0]);
 	});
 
+	it('should not create a new option when the event is default prevented within shouldKeyDownEventCreateNewOption', () => {
+		let selectedOption;
+		const options = [];
+		createControl({
+			onChange: (option) => selectedOption = option,
+			options,
+			shouldKeyDownEventCreateNewOption: (event) => event.preventDefault()
+		});
+		typeSearchText('foo');
+		TestUtils.Simulate.keyDown(filterInputNode, { keyCode: 13 });
+		expect(options, 'to have length', 0);
+	});
+
 	it('should not create a new option if the placeholder option is not selected but should select the focused option', () => {
 		const options = [{ label: 'One', value: 1 }];
 		createControl({


### PR DESCRIPTION
The `Create` component supports a `shouldKeyDownEventCreateNewOption` prop, which is a useful place for us to determine if we should create an option or not based on certain criteria. More specifically, we have a use case to prevent the creation of an option that doesn't pass certain criteria. Therefore, we were hoping that we could simply call `event.preventDefault()` within this callback when determining that the ENTER key was pressed and the criteria hasn't been met.

Unfortunately, `shouldKeyDownEventCreateNewOption` does not get passed the entire event object for some reason. Rather, it receives a stripped-down version of the event, containing only the `keyCode` attribute. This PR restores the parameter to be the full event object so that we can call `preventDefault` in our override function and thwart the option creation if need be.

Perhaps this event stripping is done for a reason, but it wasn't apparent to us. Thank you!