### PR TITLE
Fix scroll focus when using up arrow key

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -226,8 +226,10 @@ const Select = createClass({
 			var menuDOM = ReactDOM.findDOMNode(this.menu);
 			var focusedRect = focusedDOM.getBoundingClientRect();
 			var menuRect = menuDOM.getBoundingClientRect();
-			if (focusedRect.bottom > menuRect.bottom || focusedRect.top < menuRect.top) {
+			if (focusedRect.bottom > menuRect.bottom) {
 				menuDOM.scrollTop = (focusedDOM.offsetTop + focusedDOM.clientHeight - menuDOM.offsetHeight);
+			} else if (focusedRect.top < menuRect.top) {
+				menuDOM.scrollTop = focusedDOM.offsetTop;
 			}
 		}
 		if (this.props.scrollMenuIntoView && this.menuContainer) {


### PR DESCRIPTION
When using up arrow key to scroll up
![react-select-old](https://user-images.githubusercontent.com/1379711/27570279-17d0c41a-5b27-11e7-8b5b-66c431ecc811.gif)

What this pull request fixed
![react-select-new](https://user-images.githubusercontent.com/1379711/27570331-8b12c75c-5b27-11e7-9c8f-fe587673992b.gif)

Thanks!