### PR TITLE
prevent reset of inputValue when hit 'down' key, after close menu

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -722,7 +722,8 @@ const Select = createClass({
 		if (!this.state.isOpen) {
 			this.setState({
 				isOpen: true,
-				inputValue: '',
+				// prevent reset of inputValue when hit 'down' key, after close menu
+				// inputValue: '',
 				focusedOption: this._focusedOption || (options.length ? options[dir === 'next' ? 0 : options.length - 1].option : null)
 			});
 			return;


### PR DESCRIPTION
When I switch to another browser tab and come back. Or just closed the option menu.

And hit keyboard 'down' key. It will clear inputValue and I need to type again to search