### PR TITLE
remove create-react-class dependency from main sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "https://github.com/JedWatson/react-select.git"
   },
   "dependencies": {
-    "create-react-class": "^15.5.2",
     "classnames": "^2.2.4",
     "react-input-autosize": "^1.1.3",
     "prop-types": "^15.5.8"
@@ -21,6 +20,7 @@
     "babel-eslint": "^4.1.3",
     "chai": "^3.5.0",
     "coveralls": "^2.11.12",
+    "create-react-class": "^15.5.2",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.15.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Follow-up for #1734, #1820, #1821, #1822, #1823, #1824 