### PR TITLE
tabindex parent bug fix for edge

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -962,7 +962,7 @@ class Select extends React.Component {
 
 		return (
 			<div ref={ref => this.menuContainer = ref} className="Select-menu-outer" style={this.props.menuContainerStyle}>
-				<div ref={ref => this.menu = ref} role="listbox" className="Select-menu" id={this._instancePrefix + '-list'}
+				<div ref={ref => this.menu = ref} role="listbox" tabIndex={-1} className="Select-menu" id={this._instancePrefix + '-list'}
 						 style={this.props.menuStyle}
 						 onScroll={this.handleMenuScroll}
 						 onMouseDown={this.handleMouseDownOnMenu}>


### PR DESCRIPTION
There is a bug in Edge where if a parent of the select has a tabindex, you are unable to use the scrollbar within the select. 

Within [handleInputBlur](https://github.com/JedWatson/react-select/blob/master/src/Select.js#L329), document.activeElement becomes the parent with tabindex, and fails the if(). 

To reproduce:

Add tabIndex={-1} to .section on [this line](https://github.com/JedWatson/react-select/blob/master/examples/src/components/States.js#L54) of the examples. Open the example in Edge and observe the inability to scroll using the scrollbar. 

--------------------------

This pull request adds tabindex={-1} to .Select-menu to prevent the parent from stealing the activeElement, and allows you to scroll. 

