### PR TITLE
Fix clearable padding style

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -118,6 +118,10 @@
 	white-space: nowrap;
 }
 
+.has-value.is-clearable.Select--single > .Select-control .Select-value {
+	padding-right: (@select-clear-width + @select-arrow-width * 5);
+}
+
 .has-value.Select--single > .Select-control .Select-value,
 .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value {
 	.Select-value-label {

--- a/scss/control.scss
+++ b/scss/control.scss
@@ -106,6 +106,10 @@
 	white-space: nowrap;
 }
 
+.has-value.is-clearable.Select--single > .Select-control .Select-value {
+	padding-right: ($select-clear-width + $select-arrow-width * 5);
+}
+
 .has-value.Select--single > .Select-control .Select-value,
 .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value {
 	.Select-value-label {


### PR DESCRIPTION
Adjust padding-right because prevent text from overlapping `×` button.

### Before
####  (English / Japanese)
![before](https://user-images.githubusercontent.com/656742/28050276-b806bf00-6637-11e7-9428-1c2717ec1553.png)

### After

![after](https://user-images.githubusercontent.com/656742/28050322-01bfee1e-6638-11e7-921e-bf1b589863cc.png)