### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can also use the standalone build by including `react-select.js` and `react-
 
 ## Usage
 
-React-Select generates a hidden text field containing the selected value, so you can submit it as part of a standard form. You can also listen for changes with the `onChange` event property.
+React-Select generates a hidden text field containing the selected value, so you can submit it as part of a standard form. You must also listen for changes with the `onChange` event property.
 
 Options should be provided as an `Array` of `Object`s, each with a `value` and `label` property for rendering and searching. You can use a `disabled` property to indicate whether the option is disabled or not.
 


### PR DESCRIPTION
Now the component throws an exception if `onChange` is not a function.
So, it forces developer to specify it explicitly.