### PR TITLE
`openAfterFocus` change was accidentally reverted in the rc4 release.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -257,7 +257,7 @@ class Select extends React.Component {
 			});
 		} else {
 			// otherwise, focus the input and open the menu
-			this._openAfterFocus = true;
+			this._openAfterFocus = this.props.openAfterFocus;
 			this.focus();
 		}
 	}


### PR DESCRIPTION
Reverting back due to it was merged in to fix #1580.