### PR TITLE
Fix onMenuScrollToBottom does not work in chrome 58.0

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -447,7 +447,7 @@ class Select extends React.Component {
 	handleMenuScroll (event) {
 		if (!this.props.onMenuScrollToBottom) return;
 		let { target } = event;
-		if (target.scrollHeight > target.offsetHeight && !(target.scrollHeight - target.offsetHeight - target.scrollTop)) {
+		if (target.scrollHeight > target.offsetHeight && (target.scrollHeight - target.offsetHeight - target.scrollTop) <= 0) {
 			this.props.onMenuScrollToBottom();
 		}
 	}


### PR DESCRIPTION
Determining whether the user had scrolled to the bottom of the menu used an integer to boolean coercian. Replacing the coercian with an integer comparison instead fixes the problem.