### PR TITLE
simplify stringifyValue

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -18,18 +18,7 @@ import defaultClearRenderer from './utils/defaultClearRenderer';
 import Option from './Option';
 import Value from './Value';
 
-function stringifyValue (value) {
-	const valueType = typeof value;
-	if (valueType === 'string') {
-		return value;
-	} else if (valueType === 'object') {
-		return JSON.stringify(value);
-	} else if (valueType === 'number' || valueType === 'boolean') {
-		return String(value);
-	} else {
-		return '';
-	}
-}
+const stringifyValue = (value) => typeof value === 'string' ? value : value !== null && JSON.stringify(value) || '';
 
 const stringOrNode = PropTypes.oneOfType([
 	PropTypes.string,


### PR DESCRIPTION
JSON.stringify will handle type casting (to string) properly for num, bool, objects, and arrays. This shortens the logic for handling the various cases. You could wrap this in a try/catch to prevent cyclical issues blowing things up but I don't think that's necessary.