### PR TITLE
Add alwaysOpen prop support

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -7,6 +7,7 @@ import Select from 'react-select';
 import Creatable from './components/Creatable';
 import Contributors from './components/Contributors';
 import GithubUsers from './components/GithubUsers';
+import CustomActivation from './components/CustomActivation';
 import CustomComponents from './components/CustomComponents';
 import CustomRender from './components/CustomRender';
 import Multiselect from './components/Multiselect';
@@ -16,20 +17,21 @@ import Virtualized from './components/Virtualized';
 import States from './components/States';
 
 ReactDOM.render(
-	<div>
-		<States label="States" searchable />
-		<Multiselect label="Multiselect" />
-		<Virtualized label="Virtualized" />
-		<Contributors label="Contributors (Async)" />
-		<GithubUsers label="Github users (Async with fetch.js)" />
-		<NumericSelect label="Numeric Values" />
-		<BooleanSelect label="Boolean Values" />
-		<CustomRender label="Custom Render Methods"/>
-		<CustomComponents label="Custom Placeholder, Option, Value, and Arrow Components" />
-		<Creatable
-			hint="Enter a value that's NOT in the list, then hit return"
-			label="Custom tag creation"
-		/>
-	</div>,
-	document.getElementById('example')
+  <div>
+    <States label="States" searchable />
+    <Multiselect label="Multiselect" />
+    <Virtualized label="Virtualized" />
+    <Contributors label="Contributors (Async)" />
+    <GithubUsers label="Github users (Async with fetch.js)" />
+    <NumericSelect label="Numeric Values" />
+    <BooleanSelect label="Boolean Values" />
+    <CustomActivation label="Custom Activation" />
+    <CustomRender label="Custom Render Methods"/>
+    <CustomComponents label="Custom Placeholder, Option, Value, and Arrow Components" />
+    <Creatable
+      hint="Enter a value that's NOT in the list, then hit return"
+      label="Custom tag creation"
+    />
+  </div>,
+  document.getElementById('example')
 );

--- a/examples/src/components/CustomActivation.js
+++ b/examples/src/components/CustomActivation.js
@@ -42,7 +42,7 @@ export default class CustomActivation extends React.PureComponent {
             placeholder="Select your favourite(s)"
             option={FLAVOURS}
             onChange={this.handleSelectChange}
-            isOpen={this.state.isOpen}
+            alwaysOpen={this.state.isOpen}
           />
         </div>
       </div>

--- a/examples/src/components/CustomActivation.js
+++ b/examples/src/components/CustomActivation.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import Select from 'react-select';
+
+const FLAVOURS = [
+  { label: 'Chocolate', value: 'chocolate' },
+  { label: 'Vanilla', value: 'vanilla' },
+  { label: 'Strawberry', value: 'strawberry' },
+  { label: 'Caramel', value: 'caramel' },
+  { label: 'Cookies and Cream', value: 'cookiescream' },
+  { label: 'Peppermint', value: 'peppermint' },
+];
+
+export default class CustomActivation extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: null,
+    };
+  }
+
+  handlesMouseLeave() {
+    this.setState({ isOpen: false });
+  }
+
+  handleClose() {
+    this.setState({ isOpen: true });
+  }
+
+  handleSelectChange(options) {
+    this.setState({ value: options });
+  }
+
+  render() {
+    return (
+      <div className="section">
+        <h3 className="section-heading">{ this.props.label }</h3>
+        <div onMouseLeave={this.handlesMouseLeave}>
+          <Select
+            multi
+            value={this.state.value}
+            placeholder="Select your favourite(s)"
+            option={FLAVOURS}
+            onChange={this.handleSelectChange}
+            isOpen={this.state.isOpen}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/Select.js
+++ b/src/Select.js
@@ -38,7 +38,7 @@ const stringOrNode = PropTypes.oneOfType([
 
 let instanceId = 1;
 
-class Select extends React.Component {
+class Select extends React.PureComponent {
 
 	constructor(props) {
 		super(props);
@@ -69,7 +69,7 @@ class Select extends React.Component {
 		this.state = {
 			inputValue: '',
 			isFocused: false,
-			isOpen: props.isOpen,
+			isOpen: false,
 			isPseudoFocused: false,
 			required: false,
 		};
@@ -95,13 +95,11 @@ class Select extends React.Component {
 	componentWillReceiveProps (nextProps) {
 		const valueArray = this.getValueArray(nextProps.value, nextProps);
 
-		if (nextProps.required) {
-			this.setState({
-				required: this.handleRequired(valueArray[0], nextProps.multi),
-			});
-		}
-
-    this.setState({ isOpen: nextProps.isOpen });
+    if (nextProps.required) {
+      this.setState({
+        required: this.handleRequired(valueArray[0], nextProps.multi)
+      });
+    }
 	}
 
 	componentWillUpdate (nextProps, nextState) {
@@ -977,7 +975,7 @@ class Select extends React.Component {
 	render () {
 		let valueArray = this.getValueArray(this.props.value);
 		let options = this._visibleOptions = this.filterOptions(this.props.multi ? this.getValueArray(this.props.value) : null);
-		let isOpen = this.state.isOpen;
+		let isOpen = this.props.alwaysOpen || this.state.isOpen;
 		if (this.props.multi && !options.length && valueArray.length && !this.state.inputValue) isOpen = false;
 		const focusedOptionIndex = this.getFocusableOptionIndex(valueArray[0]);
 
@@ -1045,6 +1043,7 @@ class Select extends React.Component {
 
 Select.propTypes = {
     addLabelText: PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
+    alwaysOpen: PropTypes.bool,           // whether the Select is open via props
     'aria-describedby': PropTypes.string, // HTML ID(s) of element(s) that should be used to describe this input (for assistive tech)
     'aria-label': PropTypes.string,       // Aria label (for assistive tech)
     'aria-labelledby': PropTypes.string,  // HTML ID of an element that should be used as the label (for assistive tech)
@@ -1071,7 +1070,6 @@ Select.propTypes = {
     inputRenderer: PropTypes.func,        // returns a custom input component
     instanceId: PropTypes.string,         // set the components instanceId
     isLoading: PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
-    isOpen: PropTypes.bool,               // whether the Select is open via props
     joinValues: PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
     labelKey: PropTypes.string,           // path of the label value in option objects
     matchPos: PropTypes.string,           // (any|start) match the start or entire string when filtering
@@ -1118,6 +1116,7 @@ Select.propTypes = {
 };
 
 Select.defaultProps = {
+    alwaysOpen: false,
     addLabelText: 'Add "{label}"?',
     arrowRenderer: defaultArrowRenderer,
     autosize: true,
@@ -1136,7 +1135,6 @@ Select.defaultProps = {
     ignoreCase: true,
     inputProps: {},
     isLoading: false,
-    isOpen: false,
     joinValues: false,
     labelKey: 'label',
     matchPos: 'any',

--- a/src/Select.js
+++ b/src/Select.js
@@ -100,6 +100,8 @@ class Select extends React.Component {
 				required: this.handleRequired(valueArray[0], nextProps.multi),
 			});
 		}
+
+    this.setState({ isOpen: nextProps.isOpen });
 	}
 
 	componentWillUpdate (nextProps, nextState) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -69,7 +69,7 @@ class Select extends React.Component {
 		this.state = {
 			inputValue: '',
 			isFocused: false,
-			isOpen: false,
+			isOpen: props.isOpen,
 			isPseudoFocused: false,
 			required: false,
 		};
@@ -1069,6 +1069,7 @@ Select.propTypes = {
     inputRenderer: PropTypes.func,        // returns a custom input component
     instanceId: PropTypes.string,         // set the components instanceId
     isLoading: PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
+    isOpen: PropTypes.bool,               // whether the Select is open via props
     joinValues: PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
     labelKey: PropTypes.string,           // path of the label value in option objects
     matchPos: PropTypes.string,           // (any|start) match the start or entire string when filtering
@@ -1133,6 +1134,7 @@ Select.defaultProps = {
     ignoreCase: true,
     inputProps: {},
     isLoading: false,
+    isOpen: false,
     joinValues: false,
     labelKey: 'label',
     matchPos: 'any',

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3929,4 +3929,12 @@ describe('Select', () => {
 			expect(input, 'to equal', document.activeElement);
 		});
 	});
+
+  describe('isOpen', () => {
+    it('renders the select options if isOpen is true', () => {
+      instance = createControl({ options: defaultOptions, isOpen: true });
+      const selector = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option');
+      expect(selector, 'to have length', 4);
+    });
+  });
 });

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3930,9 +3930,9 @@ describe('Select', () => {
 		});
 	});
 
-  describe('isOpen', () => {
-    it('renders the select options if isOpen is true', () => {
-      instance = createControl({ options: defaultOptions, isOpen: true });
+  describe('alwaysOpen', () => {
+    it('renders the select options if alwaysOpen is true', () => {
+      instance = createControl({ options: defaultOptions, alwaysOpen: true });
       const selector = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-menu .Select-option');
       expect(selector, 'to have length', 4);
     });


### PR DESCRIPTION
Rather than juggle a prop tied to the state provide support for `alwaysOpen`.

```es6
const options = [
  { label: "Vanilla", value: "vanilla" },
  { label: "Chocolate", value: "chocolate" },
  { label: "Strawberry", value: "strawberry" },
];

export default () => (
  <Select options={options} alwaysOpen />
);
```

Rel #817 