### PR TITLE
Fix wrapping on Firefox in SCSS files

### DIFF
--- a/scss/control.scss
+++ b/scss/control.scss
@@ -217,6 +217,7 @@
 	margin: -1px;
 	clip: rect(0,0,0,0);
 	overflow: hidden;
+	float: left;
 }
 
 


### PR DESCRIPTION
This is the same fix as #1300, but applied to the SCSS files.