### PR TITLE
Prevent UglifyJs from choking on defaultArrowRenderer.js

### DIFF
--- a/src/utils/defaultArrowRenderer.js
+++ b/src/utils/defaultArrowRenderer.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function arrowRenderer ({ onMouseDown }) {
+export default function arrowRenderer (props) {
 	return (
 		<span
 			className="Select-arrow"
-			onMouseDown={onMouseDown}
+			onMouseDown={props.onMouseDown}
 		/>
 	);
 };


### PR DESCRIPTION
UglifyJs chokes on defaultArrowRenderer.js as destructuring is not es5. This fixes that. The alternative is to change the main entry point of this module from "lib/index.js" to "dist/react-select.js".