### PR TITLE
Remove `jsnext:main` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-rc.7",
   "description": "A Select control built with and for ReactJS",
   "main": "lib/index.js",
-  "jsnext:main": "dist/react-select.es.js",
   "style": "dist/react-select.min.css",
   "author": "Jed Watson",
   "license": "MIT",


### PR DESCRIPTION
The file does not exist, this sneaked in in https://github.com/JedWatson/react-select/pull/1953/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R6