### PR TITLE
Set `_callback` to null when AsyncSelect unmounts.

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -66,6 +66,10 @@ export default class Async extends Component {
 			this.loadOptions('');
 		}
 	}
+	
+	componentWillUnmount () {
+		this._callback = null;
+	}
 
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.options !== this.props.options) {


### PR DESCRIPTION
If the AsyncComponent unmounts while the app is fetching the options, the `loadOptions` callback will try to update the component when it eventually resolves.  This will cause React to print a warning message about updating unmounted components.  This pull request sets the `this._callback` field to null when the component unmounts, which tells the component to ignore the results of the callback.