### PR TITLE
strip proptypes in production build (fixes #1882)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,10 +13,16 @@ const globals = {
 	react: 'React',
 };
 const external = Object.keys(globals);
-const babelOptions = {
-	babelrc: false,
-	presets: [['es2015', { modules: false }], 'stage-0', 'react'],
-	plugins: ['external-helpers'],
+const babelOptions = (production) => {
+	let result = {
+		babelrc: false,
+		presets: [['es2015', { modules: false }], 'stage-0', 'react'],
+		plugins: ['external-helpers'],
+	};
+	if (production) {
+		result.plugins.push('transform-react-remove-prop-types');
+	};
+	return result;
 };
 
 export default [
@@ -27,7 +33,7 @@ export default [
 			format: 'es',
 		},
 		external: external,
-		plugins: [babel(babelOptions)],
+		plugins: [babel(babelOptions(false))],
 	},
 	{
 		input: 'src/index.umd.js',
@@ -38,7 +44,7 @@ export default [
 		},
 		globals: globals,
 		external: external,
-		plugins: [babel(babelOptions), resolve()],
+		plugins: [babel(babelOptions(false)), resolve()],
 	},
 	{
 		input: 'src/index.umd.js',
@@ -49,6 +55,6 @@ export default [
 		},
 		globals: globals,
 		external: external,
-		plugins: [babel(babelOptions), resolve(), uglify({}, minify)],
+		plugins: [babel(babelOptions(true)), resolve(), uglify({}, minify)],
 	},
 ];


### PR DESCRIPTION
File size changes:
```
react-select.es.js: 82822 -> 82970
react-select.js: 84232 -> 84380
react-select.min.js: 43966 -> 41700
```
See also #1876.