### PR TITLE
Async> cache async response regardless of req order

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -96,14 +96,14 @@ export default class Async extends Component {
 		}
 
 		const callback = (error, data) => {
+			const options = data && data.options || [];
+
+			if (cache) {
+				cache[inputValue] = options;
+			}
+
 			if (callback === this._callback) {
 				this._callback = null;
-
-				const options = data && data.options || [];
-
-				if (cache) {
-					cache[inputValue] = options;
-				}
 
 				this.setState({
 					isLoading: false,

--- a/src/Async.js
+++ b/src/Async.js
@@ -88,6 +88,8 @@ export default class Async extends Component {
 			cache &&
 			Object.prototype.hasOwnProperty.call(cache, inputValue)
 		) {
+			this._callback = null;
+
 			this.setState({
 				options: cache[inputValue]
 			});

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -146,6 +146,34 @@ describe('Async', () => {
 			return expect(asyncNode.textContent, 'to contain', 'Loading');
 		});
 
+		// TODO: I'm not sure what the best way to test this is, because this test returns positive even
+		// before the change. However, manual testing by throttling the network with Chrome devtools shows
+		// that this fixes the issue.
+		it.skip('caches the result of all option fetches', () => {
+			const optionResponse = createOptionsResponse(['foo']);
+			function loadOptions (input, resolve) {
+				setTimeout(function() {
+					resolve(null, optionResponse);
+				}, 10 - input.length);
+				// resolve(null, optionResponse);
+			}
+			createControl({
+				loadOptions,
+			});
+			const instance = asyncInstance;
+			typeSearchText('t');
+			typeSearchText('te');
+			typeSearchText('tes');
+
+			// TODO: How to test this?
+			setTimeout(function() {
+				console.log(instance._cache);
+				expect(instance._cache.t, 'to equal', optionResponse.options);
+				expect(instance._cache.te, 'to equal', optionResponse.options);
+				expect(instance._cache.tes, 'to equal', optionResponse.options);
+			}, 30);
+		});
+
 		describe('with callbacks', () => {
 			it('should display the loaded options', () => {
 				function loadOptions (input, resolve) {


### PR DESCRIPTION
Addresses #2009.

There is a WIP test -- I can't figure out how to simulate the exact
scenario that this patch fixes in the test. The current test returns
positive even without my change. Suggestions would be appreciated --
thanks!