### PR TITLE
Correct release candidate version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Select control built with and for [React](http://facebook.github.io/react/inde
 
 ## New version 1.0.0-rc
 
-I've nearly completed a major rewrite of this component (see issue [#568](https://github.com/JedWatson/react-select/issues/568) for details and progress). The new code has been merged into `master`, and `react-select@1.0.0-rc` has been published to npm and bower.
+I've nearly completed a major rewrite of this component (see issue [#568](https://github.com/JedWatson/react-select/issues/568) for details and progress). The new code has been merged into `master`, and `react-select@1.0.0-rc.10` has been published to npm and bower.
 
 1.0.0 has some breaking changes. The documentation is still being updated for the new API; notes on the changes can be found in [CHANGES.md](https://github.com/JedWatson/react-select/blob/master/CHANGES.md) and will be finalised into [HISTORY.md](https://github.com/JedWatson/react-select/blob/master/HISTORY.md) soon.
 


### PR DESCRIPTION
It seems that the version stated on the README cannot be found, but react-select@1.0.0-rc.10 is the latest version.


```sh
$ -> npm install react-select@1.0.0-rc --save
npm ERR! code ETARGET
npm ERR! notarget No matching version found for react-select@1.0.0-rc
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```