### PR TITLE
Support Webpack 2, Webpack 3, rollup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Select control built with and for ReactJS",
   "main": "lib/index.js",
   "jsnext:main": "dist/react-select.es.js",
+  "module": "dist/react-select.es.js",
   "style": "dist/react-select.min.css",
   "author": "Jed Watson",
   "license": "MIT",


### PR DESCRIPTION
Current LTS versions of Webpack and Node honor the standardized `module` field in the `package.json`.  As I am using webpack 3 and was confused when it wasn't resolving your awesome optimized dist builds, I decided to PR the fix for y'all (and leave the old `jsnext:main` as there are plenty of systems that still use it)