### PR TITLE
Add aria-labels to Options

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -82,6 +82,7 @@ class Option extends React.Component {
 			<div className={className}
 				style={option.style}
 				role="option"
+				aria-label={option.label}
 				onMouseDown={this.handleMouseDown}
 				onMouseEnter={this.handleMouseEnter}
 				onMouseMove={this.handleMouseMove}


### PR DESCRIPTION
Note: This is my first time contributing to open source, so please let me know if there is anything you would like me to modify/change with this PR. Thanks!

I was working on accessibility/screen reader related fixes and a bug came up when testing with JAWS 18 and IE11 (on Win7). When navigating through the options, JAWS will only read "Link" for each option, but will not narrate the option label correctly to the user. For someone using a screen reader, this is a problem because they will have no idea what the options actually are. I added an aria-label to Options which will allow JAWS to correctly read the option.