### PR TITLE
Add open on ENTER behavior

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -391,7 +391,10 @@ class Select extends React.Component {
 				this.selectFocusedOption();
 			return;
 			case 13: // enter
-				if (!this.state.isOpen) return;
+				if (!this.state.isOpen) {
+					this.focusNextOption();
+					return;	
+				}
 				event.stopPropagation();
 				this.selectFocusedOption();
 			break;


### PR DESCRIPTION
Note: This is my _second_ time contributing to open source so please let me know if there's anything I can fix/change/edit with this PR.

I was working on accessibility/screen reader related issues which requires a lot navigating via keyboard-only. I found that pressing ENTER on the combobox does not open the options, which I believe to be standard expected behavior with dropdowns and comboboxes.