### PR TITLE
Remove option `addLabelText` from README and propTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,7 @@ function onInputKeyDown(event) {
 
 | Property | Type | Default | Description |
 |:---|:---|:---|:---|
-| addLabelText | string | 'Add "{label}"?' | text to display when `allowCreate` is true |
-  arrowRenderer | func | undefined | Renders a custom drop-down arrow to be shown in the right-hand side of the select: `arrowRenderer({ onMouseDown, isOpen })` |
+| arrowRenderer | func | undefined | Renders a custom drop-down arrow to be shown in the right-hand side of the select: `arrowRenderer({ onMouseDown, isOpen })` |
 | autoBlur | bool | false | Blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices |
 | autofocus | bool | undefined | autofocus the component on mount |
 | autoload | bool | true | whether to auto-load the default async options set |

--- a/src/Select.js
+++ b/src/Select.js
@@ -1050,7 +1050,6 @@ Select.propTypes = {
 	'aria-describedby': PropTypes.string, // HTML ID(s) of element(s) that should be used to describe this input (for assistive tech)
 	'aria-label': PropTypes.string,       // Aria label (for assistive tech)
 	'aria-labelledby': PropTypes.string,  // HTML ID of an element that should be used as the label (for assistive tech)
-	addLabelText: PropTypes.string,       // placeholder displayed when you want to add a label on a multi-value input
 	arrowRenderer: PropTypes.func,        // Create drop-down caret element
 	autoBlur: PropTypes.bool,             // automatically blur the component when an option is selected
 	autofocus: PropTypes.bool,            // deprecated; use autoFocus instead
@@ -1123,7 +1122,6 @@ Select.propTypes = {
 };
 
 Select.defaultProps = {
-	addLabelText: 'Add "{label}"?',
 	arrowRenderer: defaultArrowRenderer,
 	autosize: true,
 	backspaceRemoves: true,

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1605,8 +1605,7 @@ describe('Select', () => {
 				value: 'one',
 				options: options,
 				allowCreate: true,
-				searchable: true,
-				addLabelText: 'Add {label} to values?'
+				searchable: true
 			});
 		});
 


### PR DESCRIPTION
The option `addLabelText` is now replace by `promptTextCreator`in
`Creatable` and only existed in documentation and propTypes anymore.