### PR TITLE
Set isLoading to false if cache hit

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -91,6 +91,7 @@ export default class Async extends Component {
 			this._callback = null;
 
 			this.setState({
+				isLoading: false,
 				options: cache[inputValue]
 			});
 


### PR DESCRIPTION
From @youtogod in the comments of #2012:

> Add this would be better : `this.setState({ isLoading: false, options: cache[inputValue] });`. Otherwise when hitting the cache during a promise, the loading icon will remain and the menu won't appear.