### PR TITLE
do not show clear button if value is an empty string

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -812,7 +812,7 @@ class Select extends React.Component {
 	}
 
 	renderClear () {
-		if (!this.props.clearable || this.props.value === undefined || this.props.value === null || this.props.multi && !this.props.value.length || this.props.disabled || this.props.isLoading) return;
+		if (!this.props.clearable || this.props.value === undefined || this.props.value === null || this.props.value === '' || this.props.multi && !this.props.value.length || this.props.disabled || this.props.isLoading) return;
 		const clear = this.props.clearRenderer();
 
 		return (


### PR DESCRIPTION
The clear button should not display if value is an empty string

Fixes https://github.com/JedWatson/react-select/issues/2073