### PR TITLE
Muti Select: Prevent selected option with long text from line breaking

### DIFF
--- a/less/multi.less
+++ b/less/multi.less
@@ -28,7 +28,7 @@
 		border: 1px solid @select-item-border-color-fb;  /* Fallback color for IE 8 */
 		border: 1px solid @select-item-border-color;
 		color: @select-item-color;
-		display: inline-block;
+		display: table;
 		font-size: @select-item-font-size;
 		line-height: 1.4;
 		margin-left: @select-item-gutter;
@@ -39,7 +39,7 @@
 	// common
 	.Select-value-icon,
 	.Select-value-label {
-		display: inline-block;
+		display: table-cell;
 		vertical-align: middle;
 	}
 


### PR DESCRIPTION
Options with long names cause a line break in multiselect between the icon and the text.  Tried searching for a related issue, but didn't see one.

Before:
![image](https://user-images.githubusercontent.com/11380129/31842653-fa28e1ae-b5a3-11e7-8995-1494ffd7ef16.png)

After: 
![image](https://user-images.githubusercontent.com/11380129/31842660-ffba913a-b5a3-11e7-8345-6a5f29452b02.png)
