### PR TITLE
Fix/numeric multi select

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -469,10 +469,6 @@ class Select extends React.Component {
 		if (props.multi) {
 			if (typeof value === 'string') {
 				value = value.split(props.delimiter);
-				// convert string array to numbers array if made of numbers only
-				if (!value.some(isNaN)) {
-					value = value.map(Number);
-				}				
 			}
 			if (!Array.isArray(value)) {
 				if (value === null || value === undefined) return [];
@@ -495,7 +491,7 @@ class Select extends React.Component {
 		let { options, valueKey } = props;
 		if (!options) return;
 		for (var i = 0; i < options.length; i++) {
-			if (options[i][valueKey] === value) return options[i];
+			if (String(options[i][valueKey]) === String(value)) return options[i];
 		}
 	}
 
@@ -787,7 +783,7 @@ class Select extends React.Component {
 				[this._instancePrefix + '-list']: isOpen,
 			});
 			return (
-				
+
 				<div
 					{...divProps}
 					role="combobox"

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -742,6 +742,17 @@ describe('Select', () => {
                         <div><span className="Select-value-label">Four</span></div>
 					</span>);
 			});
+			it('supports updating the values as a string', () => {
+				wrapper.setPropsForChild({
+					value: '3,4',
+				});
+
+				expect(instance, 'to contain',
+					<span className="Select-multi-value-wrapper">
+												<div><span className="Select-value-label">Three</span></div>
+												<div><span className="Select-value-label">Four</span></div>
+					</span>);
+			});
 
 			it('supports updating the value to a single value', () => {
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -718,8 +718,8 @@ describe('Select', () => {
 
 				expect(instance, 'to contain',
 					<span className="Select-multi-value-wrapper">
-                        <div><span className="Select-value-label">Two</span></div>
-                        <div><span className="Select-value-label">One</span></div>
+						<div><span className="Select-value-label">Two</span></div>
+						<div><span className="Select-value-label">One</span></div>
 					</span>);
 			});
 
@@ -738,8 +738,8 @@ describe('Select', () => {
 
 				expect(instance, 'to contain',
 					<span className="Select-multi-value-wrapper">
-                        <div><span className="Select-value-label">Three</span></div>
-                        <div><span className="Select-value-label">Four</span></div>
+						<div><span className="Select-value-label">Three</span></div>
+						<div><span className="Select-value-label">Four</span></div>
 					</span>);
 			});
 			it('supports updating the values as a string', () => {
@@ -749,8 +749,8 @@ describe('Select', () => {
 
 				expect(instance, 'to contain',
 					<span className="Select-multi-value-wrapper">
-												<div><span className="Select-value-label">Three</span></div>
-												<div><span className="Select-value-label">Four</span></div>
+						<div><span className="Select-value-label">Three</span></div>
+						<div><span className="Select-value-label">Four</span></div>
 					</span>);
 			});
 
@@ -775,7 +775,7 @@ describe('Select', () => {
 
 				expect(instance, 'to contain',
 					<span className="Select-multi-value-wrapper">
-                        <div><span className="Select-value-label">Zero</span></div>
+						<div><span className="Select-value-label">Zero</span></div>
 					</span>);
 			});
 


### PR DESCRIPTION
Added string coercion to condition in expandvalue()
Fixes the bug referenced in #1600 and in #1476 