### PR TITLE
fix typo in handleKeyDown method

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -428,7 +428,7 @@ class Select extends React.Component {
 				}
 				this.focusStartOption();
 			break;
-			case 46: // backspace
+			case 46: // delete
 				if (!this.state.inputValue && this.props.deleteRemoves) {
 					event.preventDefault();
 					this.popValue();


### PR DESCRIPTION
- fix typo in handleKeyDown method switch statement. 'backspace' (keyCode: 8) case is already defined, and keyCode: 46 should actually be the 'delete' key instead of backspace