### PR TITLE
onOpen: run after dom has rendered

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -99,14 +99,6 @@ class Select extends React.Component {
 		}
 	}
 
-	componentWillUpdate (nextProps, nextState) {
-		if (nextState.isOpen !== this.state.isOpen) {
-			this.toggleTouchOutsideEvent(nextState.isOpen);
-			const handler = nextState.isOpen ? nextProps.onOpen : nextProps.onClose;
-			handler && handler();
-		}
-	}
-
 	componentDidUpdate (prevProps, prevState) {
 		// focus to the selected option
 		if (this.menu && this.focused && this.state.isOpen && !this.hasScrolledToOption) {
@@ -139,6 +131,11 @@ class Select extends React.Component {
 		if (prevProps.disabled !== this.props.disabled) {
 			this.setState({ isFocused: false }); // eslint-disable-line react/no-did-update-set-state
 			this.closeMenu();
+		}
+		if (prevState.isOpen !== this.state.isOpen) {
+			this.toggleTouchOutsideEvent(this.state.isOpen);
+			const handler = this.state.isOpen ? this.props.onOpen : this.props.onClose;
+			handler && handler();
 		}
 	}
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3060,7 +3060,7 @@ describe('Select', () => {
 			});
 
 			it('is called when the options are displayed', () => {
-				TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(instance).querySelector('.Select-control'), { button: 0 });
+				clickArrowToOpen();
 				expect(eventHandler, 'was called once');
 			});
 		});
@@ -3081,10 +3081,9 @@ describe('Select', () => {
 
 			it('is called after the options are hidden', () => {
 				const domNode = ReactDOM.findDOMNode(instance);
-				TestUtils.Simulate.mouseDown(domNode.querySelector('.Select-control'));
+				clickArrowToOpen();
 				eventHandler.reset();
-
-				TestUtils.Simulate.keyDown(domNode.querySelector('input'), { keyCode: 27, key: 'Escape' });
+				pressEscape();
 				expect(eventHandler, 'was called once');
 			});
 		});

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3063,6 +3063,17 @@ describe('Select', () => {
 				clickArrowToOpen();
 				expect(eventHandler, 'was called once');
 			});
+
+			it('is called after dom has rendered', (done) => {
+				instance = createControl({
+					onOpen: () => {
+						expect(instance.menu, 'not to equal', undefined);
+						done();
+					}
+				});
+
+				clickArrowToOpen();
+			});
 		});
 
 		describe('onClose', () => {


### PR DESCRIPTION
This PR changes the onOpen event handler to be called after the dom has rendered and refs have been initialized.

This is useful since one of the uses of `onOpen` is to change the menu css dynamically as it opens. Currently this requires an `setInterval` hack which can result in flickering.

Any and all feedback is welcome! :)