### PR TITLE
add the ability to display multiselect options externally

### DIFF
--- a/examples/src/components/GithubUsers.js
+++ b/examples/src/components/GithubUsers.js
@@ -15,9 +15,11 @@ const GithubUsers = createClass({
 			backspaceRemoves: true,
 			multi: true,
 			creatable: false,
+			externalOptions: false,
 		};
 	},
 	onChange (value) {
+		console.log('You\'ve selected:', value);
 		this.setState({
 			value: value,
 		});
@@ -53,6 +55,11 @@ const GithubUsers = createClass({
 			backspaceRemoves: !this.state.backspaceRemoves
 		});
 	},
+	toggleExternal () {
+		this.setState({
+			externalOptions: !this.state.externalOptions
+		});
+	},
 	toggleCreatable () {
 		this.setState({
 			creatable: !this.state.creatable
@@ -66,7 +73,17 @@ const GithubUsers = createClass({
 		return (
 			<div className="section">
 				<h3 className="section-heading">{this.props.label} <a href="https://github.com/JedWatson/react-select/tree/master/examples/src/components/GithubUsers.js">(Source)</a></h3>
-				<AsyncComponent multi={this.state.multi} value={this.state.value} onChange={this.onChange} onValueClick={this.gotoUser} valueKey="id" labelKey="login" loadOptions={this.getUsers} backspaceRemoves={this.state.backspaceRemoves} />
+				<AsyncComponent
+					externalOptions={this.state.externalOptions}
+					multi={this.state.multi}
+					value={this.state.value}
+					onChange={this.onChange}
+					onValueClick={this.gotoUser}
+					valueKey="id"
+					labelKey="login"
+					loadOptions={this.getUsers}
+					backspaceRemoves={this.state.backspaceRemoves}
+				/>
 				<div className="checkbox-list">
 					<label className="checkbox">
 						<input type="radio" className="checkbox-control" checked={this.state.multi} onChange={this.switchToMulti}/>
@@ -81,6 +98,10 @@ const GithubUsers = createClass({
 					<label className="checkbox">
 					   <input type="checkbox" className="checkbox-control" checked={this.state.creatable} onChange={this.toggleCreatable} />
 					   <span className="checkbox-label">Creatable?</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" checked={this.state.externalOptions} onChange={this.toggleExternal}/>
+						<span className="checkbox-label">External Options</span>
 					</label>
 					<label className="checkbox">
 					   <input type="checkbox" className="checkbox-control" checked={this.state.backspaceRemoves} onChange={this.toggleBackspaceRemoves} />

--- a/examples/src/components/Multiselect.js
+++ b/examples/src/components/Multiselect.js
@@ -27,6 +27,7 @@ var MultiSelectField = createClass({
 			disabled: false,
 			crazy: false,
 			stayOpen: false,
+			externalOptions: false,
 			value: [],
 			rtl: false,
 		};
@@ -46,7 +47,7 @@ var MultiSelectField = createClass({
 	},
 
 	render () {
-		const { crazy, disabled, stayOpen, value } = this.state;
+		const { crazy, disabled, externalOptions, stayOpen, value } = this.state;
 		const options = crazy ? WHY_WOULD_YOU : FLAVOURS;
 		return (
 			<div className="section">
@@ -55,6 +56,7 @@ var MultiSelectField = createClass({
 					closeOnSelect={!stayOpen}
 					disabled={disabled}
 					multi
+					externalOptions={externalOptions}
 					onChange={this.handleSelectChange}
 					options={options}
 					placeholder="Select your favourite(s)"
@@ -75,7 +77,7 @@ var MultiSelectField = createClass({
 					</label>
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" name="crazy" checked={crazy} onChange={this.toggleCheckbox} />
-						<span className="checkbox-label">I don't like Chocolate (disabled the option)</span>
+						<span className="checkbox-label">I don&apos;t like Chocolate (disabled the option)</span>
 					</label>
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" name="stayOpen" checked={stayOpen} onChange={this.toggleCheckbox}/>
@@ -84,6 +86,10 @@ var MultiSelectField = createClass({
 					<label className="checkbox">
 						<input type="checkbox" className="checkbox-control" name="rtl" checked={this.state.rtl} onChange={this.toggleCheckbox} />
 						<span className="checkbox-label">rtl</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" name="externalOptions" checked={externalOptions} onChange={this.toggleCheckbox}/>
+						<span className="checkbox-label">Show selected options outside of the select box.</span>
 					</label>
 				</div>
 			</div>

--- a/src/Select.js
+++ b/src/Select.js
@@ -807,13 +807,9 @@ class Select extends React.Component {
 		);
 	}
 
-	renderValue (valueArray, isOpen) {
+	renderValueArray (valueArray, isOpen) {
 		let renderLabel = this.props.valueRenderer || this.getOptionLabel;
 		let ValueComponent = this.props.valueComponent;
-		if (!valueArray.length) {
-			const showPlaceholder = shouldShowPlaceholder(this.state, this.props, isOpen);
-			return showPlaceholder ? <div className="Select-placeholder">{this.props.placeholder}</div> : null;
-		}
 		let onClick = this.props.onValueClick ? this.handleValueClick : null;
 		if (this.props.multi) {
 			return valueArray.map((value, i) => {
@@ -848,6 +844,14 @@ class Select extends React.Component {
 				</ValueComponent>
 			);
 		}
+	}
+
+	renderValue (valueArray, isOpen) {
+		if ((this.props.externalOptions && this.props.multi) || !valueArray.length) {
+			const showPlaceholder = shouldShowPlaceholder(this.state, this.props, isOpen);
+			return showPlaceholder ? <div className="Select-placeholder">{this.props.placeholder}</div> : null;
+		}
+		return this.renderValueArray(valueArray, isOpen);
 	}
 
 	renderInput (valueArray, focusedOptionIndex) {
@@ -1160,29 +1164,41 @@ class Select extends React.Component {
 		}
 
 		return (
-			<div ref={ref => this.wrapper = ref}
-				 className={className}
-				 style={this.props.wrapperStyle}>
-				{this.renderHiddenField(valueArray)}
-				<div ref={ref => this.control = ref}
-					className="Select-control"
-					onKeyDown={this.handleKeyDown}
-					onMouseDown={this.handleMouseDown}
-					onTouchEnd={this.handleTouchEnd}
-					onTouchMove={this.handleTouchMove}
-					onTouchStart={this.handleTouchStart}
-					style={this.props.style}
-				>
-					<span className="Select-multi-value-wrapper" id={`${this._instancePrefix}-value`}>
-						{this.renderValue(valueArray, isOpen)}
-						{this.renderInput(valueArray, focusedOptionIndex)}
-					</span>
-					{removeMessage}
-					{this.renderLoading()}
-					{this.renderClear()}
-					{this.renderArrow()}
+			<div
+				ref={ref => this.wrapper = ref}
+				className={className}
+				style={this.props.wrapperStyle}>
+				<div
+					className={className}
+					style={this.props.wrapperStyle}>
+					{this.renderHiddenField(valueArray)}
+					<div ref={ref => this.control = ref}
+						className="Select-control"
+						onKeyDown={this.handleKeyDown}
+						onMouseDown={this.handleMouseDown}
+						onTouchEnd={this.handleTouchEnd}
+						onTouchMove={this.handleTouchMove}
+						onTouchStart={this.handleTouchStart}
+						style={this.props.style}
+					>
+						<span className="Select-multi-value-wrapper" id={this._instancePrefix + '-value'}>
+							{this.renderValue(valueArray, isOpen)}
+							{this.renderInput(valueArray, focusedOptionIndex)}
+						</span>
+						{removeMessage}
+						{this.renderLoading()}
+						{this.renderClear()}
+						{this.renderArrow()}
+					</div>
+					{isOpen ? this.renderOuter(options, valueArray, focusedOption) : null}
 				</div>
-				{isOpen ? this.renderOuter(options, valueArray, focusedOption) : null}
+				{this.props.multi && this.props.externalOptions && !!valueArray.length &&
+					<div
+						style={this.props.externalOptionStyle}
+						className="Select-multi-value-wrapper-external">
+						{ this.renderValueArray(valueArray, isOpen) }
+					</div>
+				}
 			</div>
 		);
 	}
@@ -1209,6 +1225,8 @@ Select.propTypes = {
 	delimiter: PropTypes.string,          // delimiter to use to join multiple values for the hidden field value
 	disabled: PropTypes.bool,             // whether the Select is disabled or not
 	escapeClearsValue: PropTypes.bool,    // whether escape clears the value when the menu is closed
+	externalOptionStyle: PropTypes.object,// optional style to apply to external option wrapper
+	externalOptions: PropTypes.bool,      // whether multiselect options appear outside the select controller
 	filterOption: PropTypes.func,         // method to filter a single option (option, filterString)
 	filterOptions: PropTypes.any,         // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
 	id: PropTypes.string, 				        // html id to set on the input element for accessibility or tests
@@ -1281,6 +1299,7 @@ Select.defaultProps = {
 	delimiter: ',',
 	disabled: false,
 	escapeClearsValue: true,
+	externalOptions: false,
 	filterOptions: defaultFilterOptions,
 	ignoreAccents: true,
 	ignoreCase: true,

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -1132,6 +1132,89 @@ describe('Select', () => {
 				]);
 			});
 		});
+		describe('with externalOptions=true multi=true', () => {
+
+			beforeEach(() => {
+				options = [
+					{ value: 'one', label: 'One' },
+					{ value: 'two', label: 'Two' },
+					{ value: 'three', label: 'Three' },
+					{ value: 'four', label: 'Four' }
+				];
+
+				wrapper = createControlWithWrapper({
+					value: ['one', 'three'],
+					options: options,
+					externalOptions: true,
+					multi: true,
+					searchable: true
+				});
+			});
+			it('selects the initial value, but sticks it in the external wrapper', () => {
+				expect(instance, 'to contain',
+						<span className="Select-multi-value-wrapper">
+					</span>);
+				expect(instance, 'to contain',
+						<div className="Select-multi-value-wrapper-external">
+                        <div><span className="Select-value-label">One</span></div>
+                        <div><span className="Select-value-label">Three</span></div>
+					</div>);
+			});
+			it('removes the last selected option with backspace', () => {
+
+				setValueProp(['four','three']);
+				onChange.reset();  // Ignore previous onChange calls
+				pressBackspace();
+				expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
+			});
+			it('removes the last selected option with delete', () => {
+				setValueProp(['two', 'four']);
+				onChange.reset();  // Ignore previous onChange calls
+				pressDelete();
+				expect(onChange, 'was called with', [{ label: 'Two', value: 'two' }]);
+			});
+			it('selects a single option on enter', () => {
+				setValueProp([]);
+				onChange.reset();  // Ignore previous onChange calls
+				typeSearchText('fo');
+				pressEnterToAccept();
+				expect(onChange, 'was called with', [{ label: 'Four', value: 'four' }]);
+			});
+			it('displays selected options', () => {
+				setValueProp(['four', 'three']);
+				expect(instance, 'to contain',
+					<div className="Select-multi-value-wrapper-external">
+                        <div><span className="Select-value-label">Four</span></div>
+                        <div><span className="Select-value-label">Three</span></div>
+					</div>);
+			});
+		});
+		describe('with externalOptions=true multi=false', () => {
+			beforeEach(() => {
+				options = [
+					{ value: 'one', label: 'One' },
+					{ value: 'two', label: 'Two' },
+					{ value: 'three', label: 'Three' },
+					{ value: 'four', label: 'Four' }
+				];
+
+				wrapper = createControlWithWrapper({
+					value: 'one',
+					options: options,
+					externalOptions: true,
+					multi: false,
+					searchable: true
+				});
+			});
+			it('selects the initial value, but ignores external wrapper', () => {
+				expect(instance, 'not to contain',
+						<span className="Select-multi-value-wrapper-external">
+					</span>);
+				expect(ReactDOM.findDOMNode(instance), 'queried for first', DISPLAYED_SELECTION_SELECTOR,
+					'to have text', 'One');
+			});
+
+		});
 
 		describe('searching', () => {
 


### PR DESCRIPTION
Thanks so much for this fantastic library - we're using it quite extensively in some internal components at the company i work for. One request we've received repeatedly as we've been working with multiselect dropdowns is the ability to optionally show large list of options externally, similar to this jquery plugin: http://www.jqueryscript.net/demo/Simple-Mobile-Friendly-jQuery-Tags-Input-Plugin-Taxonomy/

I've attached a screenshot of the option below.

<img width="607" alt="screen shot 2017-10-24 at 5 49 02 pm" src="https://user-images.githubusercontent.com/4459634/31971922-a88d5a3a-b8e3-11e7-844b-1ba718a8838d.png">
