### PR TITLE
Add keyboard accessibility to multiselect

### DIFF
--- a/src/Value.js
+++ b/src/Value.js
@@ -8,6 +8,7 @@ class Value extends React.Component {
 		super(props);
 
 		this.handleMouseDown = this.handleMouseDown.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onRemove = this.onRemove.bind(this);
 		this.handleTouchEndRemove = this.handleTouchEndRemove.bind(this);
 		this.handleTouchMove = this.handleTouchMove.bind(this);
@@ -25,6 +26,14 @@ class Value extends React.Component {
 		}
 		if (this.props.value.href) {
 			event.stopPropagation();
+		}
+	}
+
+	onKeyDown (event) {
+		if (event.keyCode === 13 || event.keyCode === 32) {
+			event.preventDefault();
+			event.stopPropagation();
+			this.onRemove(event);
 		}
 	}
 
@@ -57,8 +66,10 @@ class Value extends React.Component {
 		if (this.props.disabled || !this.props.onRemove) return;
 		return (
 			<span className="Select-value-icon"
+				tabIndex="0"
 				aria-hidden="true"
 				onMouseDown={this.onRemove}
+				onKeyDown={this.onKeyDown}
 				onTouchEnd={this.handleTouchEndRemove}
 				onTouchStart={this.handleTouchStart}
 				onTouchMove={this.handleTouchMove}>


### PR DESCRIPTION
I came across this issue while working on accessibility items throughout our app. The "x" icon on each of the multiselect pill values are currently not accessibly via keyboard. Pressing backspace to delete the value is a viable workaround, but is not obvious for a user who cannot see the screen and relies on a screen reader.