### PR TITLE
removing getInputValue function

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -701,10 +701,6 @@ class Select extends React.Component {
 		return this._focusedOption;
 	}
 
-	getInputValue () {
-		return this.state.inputValue;
-	}
-
 	selectFocusedOption () {
 		if (this._focusedOption) {
 			return this.selectValue(this._focusedOption);


### PR DESCRIPTION
Was doing some cleanup and testing work to try to bump up the coverage and ran across this unused `getInputValue` function - don't see it called anywhere, react-select seems to compile and tests run perfectly without it - looks like it was part of the initial work for `allowCreate` (https://github.com/JedWatson/react-select/commit/7fe723f1195d4dd5012ffb7f5c6b4b383daf5172) , but it seems unused now.