### PR TITLE
Adjust line-height so text doesn't get cut off in in Firefox

### DIFF
--- a/less/control.less
+++ b/less/control.less
@@ -200,7 +200,7 @@
 		margin: 0;
 		outline: none;
 		// padding: 0;
-		line-height: 14px;  /* For IE 8 compatibility */
+		line-height: 17px;  /* For IE 8 compatibility */
 		padding: ((@select-input-internal-height - 14) / 2 - 2) 0 ((@select-input-internal-height - 14) / 2 + 2);  /* For IE 8 compatibility */
 		-webkit-appearance: none;
 

--- a/scss/control.scss
+++ b/scss/control.scss
@@ -187,7 +187,7 @@
 		margin: 0;
 		outline: none;
 		// padding: 0;
-		line-height: 14px;  /* For IE 8 compatibility */
+		line-height: 17px;  /* For IE 8 compatibility */
 		padding: (($select-input-internal-height - 14) / 2 - 2) 0 (($select-input-internal-height - 14) / 2 + 2);  /* For IE 8 compatibility */
 		-webkit-appearance: none;
 


### PR DESCRIPTION
First PR here. This seems to fix text getting cut off in Firefox. #2094 
![line-height](https://user-images.githubusercontent.com/1160410/32139892-ce21fd64-bc03-11e7-98a2-fe8d916a099e.gif)
