### PR TITLE
Convert trim.js to es6

### DIFF
--- a/src/utils/trim.js
+++ b/src/utils/trim.js
@@ -1,3 +1,3 @@
-module.exports = function trim(str) {
+export default function trim(str) {
     return str.replace(/^\s+|\s+$/g, '');
-};
+}


### PR DESCRIPTION
Trying to build master (plus a couple commits for a custom fork) with the new rollup process (`npm run build`), I ran into the following failure:

```
[build.rollup] The script called "build.rollup" which runs "rollup --config" failed with exit code 1 https://github.com/kentcdodds/nps/blob/v5.7.1/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
[build.rollup] nps build.rollup exited with code 1
The script called "build" which runs "node node_modules/rimraf/bin.js dist && node node_modules/rimraf/bin.js lib && node node_modules/concurrently/src/main.js --kill-others-on-fail --prefix-colors "bgBlue.bold,bgMagenta.bold" --prefix "[{name}]" --names "build.css,build.cssmin" 'nps build.css' 'nps build.cssmin' && node node_modules/concurrently/src/main.js --kill-others-on-fail --prefix-colors "bgBlue.bold,bgMagenta.bold" --prefix "[{name}]" --names "build.rollup,build.babel" 'nps build.rollup' 'nps build.babel'" failed with exit code 1 https://github.com/kentcdodds/nps/blob/v5.7.1/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
```

Which made me run `rollup --config`, which gave me the following error:

```
src/index.js → dist/react-select.es.js...
[!] Error: 'default' is not exported by src/utils/trim.js
https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module
src/utils/defaultFilterOptions.js (2:7)
1: import stripDiacritics from './stripDiacritics';
2: import trim from './trim';
          ^
3: 
4: function filterOptions(options, filterValue, excludeOptions, props) {
```

I'm not sure if this is the only/best solution, but converting trim.js from ES5 `module.exports` syntax to ES6 `export default` syntax fixed the problem and allowed me to build it.