### PR TITLE
fixed: async doesn't change value when onInputChange returns a value

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -138,7 +138,17 @@ export default class Async extends Component {
 
 	onInputChange (inputValue) {
 		const { ignoreAccents, ignoreCase, onInputChange } = this.props;
-		let transformedInputValue = inputValue;
+		let newInputValue = inputValue;
+
+		if (onInputChange) {
+			const value = onInputChange(newInputValue);
+			// Note: != used deliberately here to catch undefined and null
+			if (value != null && typeof value !== 'object') {
+				newInputValue = '' + value;
+			}
+		}
+
+		let transformedInputValue = newInputValue;
 
 		if (ignoreAccents) {
 			transformedInputValue = stripDiacritics(transformedInputValue);
@@ -148,15 +158,11 @@ export default class Async extends Component {
 			transformedInputValue = transformedInputValue.toLowerCase();
 		}
 
-		if (onInputChange) {
-			onInputChange(transformedInputValue);
-		}
-
-		this.setState({ inputValue });
+		this.setState({ inputValue: newInputValue });
 		this.loadOptions(transformedInputValue);
 
-		// Return the original input value to avoid modifying the user's view of the input while typing.
-		return inputValue;
+		// Return new input value, but without applying toLowerCase() to avoid modifying the user's view case of the input while typing.
+		return newInputValue;
 	}
 
 	noResultsText() {

--- a/test/Async-test.js
+++ b/test/Async-test.js
@@ -145,7 +145,7 @@ describe('Async', () => {
 			typeSearchText('te');
 			return expect(asyncNode.textContent, 'to contain', 'Loading');
 		});
-		
+
 		it('caches the result of all option fetches', (cb) => {
 			const res = {
 				t: createOptionsResponse(['t']),
@@ -474,6 +474,15 @@ describe('Async', () => {
 			});
 			typeSearchText('a');
 			return expect(onInputChange, 'was called times', 1);
+		});
+
+		it('should change the value when onInputChange returns a value', () => {
+			const onInputChange = sinon.stub().returns('2');
+			const instance = createControl({
+				onInputChange,
+			});
+			typeSearchText('1');
+			return expect(filterInputNode.value, 'to equal', '2');
 		});
 	});
 


### PR DESCRIPTION
This PR fixes #1597, fixes #1941, fixes #2069 

Function passed through `onInputChange` prop will be called with initial input value (`stripDiacritics` will not be applied in case `ignoreAccents` and `toLowerCase` will not be applied in case `ignoreCase`).
