### PR TITLE
Creatable: when `promptTextCreator` returns only the label, changes don't fire on first Enter key press

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -89,7 +89,7 @@ class CreatableSelect extends React.Component {
 	}) {
 		const { isOptionUnique } = this.props;
 
-		options = options || this.select.filterOptions();
+		options = options || this.props.options;
 
 		return isOptionUnique({
 			labelKey: this.labelKey,


### PR DESCRIPTION
#### This PR solves this issue: https://github.com/JedWatson/react-select/issues/2125

#### Bug can be seen here: https://plnkr.co/edit/lC6lJuAYaTItCSJxTjnD?p=preview

#### Reason
It was caused because when creating a new choice, there is a check to see if the option is unique (even though there is a check for that to even display the new option creator). This check was checking the value against a list of filtered options. This filter was the passed down filter prop and was basically checking the option against itself with the addition of the prompt text. Therefore, by accident if there was a prompt text it was passing, but when using `(label) => label`, it was failing.

#### Solution
It has been fixed to check against the list of options available.