### PR TITLE
New option for property matchPos: preferStart

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 
 import defaultArrowRenderer from './utils/defaultArrowRenderer';
 import defaultFilterOptions from './utils/defaultFilterOptions';
-import preferableFilterOptions from './utils/preferableFilterOptions'
+import preferableFilterOptions from './utils/preferableFilterOptions';
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
 import defaultClearRenderer from './utils/defaultClearRenderer';
 
@@ -881,9 +881,19 @@ class Select extends React.Component {
 		var options = this.props.options || [];
 		if (this.props.filterOptions || this.props.preferableFilterOptions) {
 			// Maintain backwards compatibility with boolean attribute
-			const filterOptions = this.props.preferStartMatch ?
-				(typeof this.props.preferableFilterOptions === 'function' ? this.props.preferableFilterOptions : preferableFilterOptions)
-				: (typeof this.props.filterOptions === 'function' ? this.props.filterOptions : defaultFilterOptions);
+			let filterOptions;
+			switch(this.props.matchPos) {
+				case 'preferStart':
+					filterOptions = (typeof this.props.preferableFilterOptions === 'function')
+						? this.props.preferableFilterOptions
+						: preferableFilterOptions;
+					break;
+				case 'start':
+				default:
+					filterOptions = (typeof this.props.filterOptions === 'function')
+						? this.props.filterOptions
+						: defaultFilterOptions;
+			}
 
 			return filterOptions(
 				options,
@@ -896,7 +906,6 @@ class Select extends React.Component {
 					labelKey: this.props.labelKey,
 					matchPos: this.props.matchPos,
 					matchProp: this.props.matchProp,
-					preferStartMatch: this.props.preferStartMatch,
 					valueKey: this.props.valueKey,
 					trimFilter: this.props.trimFilter
 				}
@@ -1112,7 +1121,7 @@ Select.propTypes = {
 	isLoading: PropTypes.bool,            // whether the Select is loading externally or not (such as options being loaded)
 	joinValues: PropTypes.bool,           // joins multiple values into a single form field with the delimiter (legacy mode)
 	labelKey: PropTypes.string,           // path of the label value in option objects
-	matchPos: PropTypes.string,           // (any|start) match the start or entire string when filtering
+	matchPos: PropTypes.string,           // (any|start|preferStart) match the start, match entire string or firstly match the start, then the entire string when filtering
 	matchProp: PropTypes.string,          // (any|label|value) which option property to filter on
 	menuBuffer: PropTypes.number,         // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
 	menuContainerStyle: PropTypes.object, // optional style to apply to the menu container
@@ -1141,7 +1150,6 @@ Select.propTypes = {
 	options: PropTypes.array,             // array of options
 	pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 	placeholder: stringOrNode,            // field placeholder, displayed when there's no value
-	preferStartMatch: PropTypes.bool,     // boolean to enable selecting firstly the option(s) which start(s) with text input
 	preferableFilterOptions: PropTypes.any,  // boolean to enable filtering or function to filter the options array ([options], filterString, [values]) when preferStartMatch property is true
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
 	required: PropTypes.bool,             // applies HTML5 required attribute when needed
@@ -1195,7 +1203,6 @@ Select.defaultProps = {
 	optionComponent: Option,
 	pageSize: 5,
 	placeholder: 'Select...',
-	preferStartMatch: false,
 	preferableFilterOptions: preferableFilterOptions,
 	removeSelected: true,
 	required: false,

--- a/src/Select.js
+++ b/src/Select.js
@@ -895,7 +895,7 @@ class Select extends React.Component {
 					labelKey: this.props.labelKey,
 					matchPos: this.props.matchPos,
 					matchProp: this.props.matchProp,
-					preferEarlyMatch: this.props.preferEarlyMatch,
+					preferStartMatch: this.props.preferStartMatch,
 					valueKey: this.props.valueKey,
 					trimFilter: this.props.trimFilter
 				}
@@ -1140,7 +1140,7 @@ Select.propTypes = {
 	options: PropTypes.array,             // array of options
 	pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 	placeholder: stringOrNode,            // field placeholder, displayed when there's no value
-	preferEarlyMatch: PropTypes.bool,     // boolean to enable selecting firstly the option(s) which start(s) with text input
+	preferStartMatch: PropTypes.bool,     // boolean to enable selecting firstly the option(s) which start(s) with text input
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
 	required: PropTypes.bool,             // applies HTML5 required attribute when needed
 	resetValue: PropTypes.any,            // value to use when you clear the control
@@ -1193,7 +1193,7 @@ Select.defaultProps = {
 	optionComponent: Option,
 	pageSize: 5,
 	placeholder: 'Select...',
-	preferEarlyMatch: false,
+	preferStartMatch: false,
 	removeSelected: true,
 	required: false,
 	rtl: false,

--- a/src/Select.js
+++ b/src/Select.js
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 
 import defaultArrowRenderer from './utils/defaultArrowRenderer';
 import defaultFilterOptions from './utils/defaultFilterOptions';
+import preferableFilterOptions from './utils/preferableFilterOptions'
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
 import defaultClearRenderer from './utils/defaultClearRenderer';
 
@@ -878,11 +879,11 @@ class Select extends React.Component {
 	filterOptions (excludeOptions) {
 		var filterValue = this.state.inputValue;
 		var options = this.props.options || [];
-		if (this.props.filterOptions) {
+		if (this.props.filterOptions || this.props.preferableFilterOptions) {
 			// Maintain backwards compatibility with boolean attribute
-			const filterOptions = typeof this.props.filterOptions === 'function'
-				? this.props.filterOptions
-				: defaultFilterOptions;
+			const filterOptions = this.props.preferStartMatch ?
+				(typeof this.props.preferableFilterOptions === 'function' ? this.props.preferableFilterOptions : preferableFilterOptions)
+				: (typeof this.props.filterOptions === 'function' ? this.props.filterOptions : defaultFilterOptions);
 
 			return filterOptions(
 				options,
@@ -1141,6 +1142,7 @@ Select.propTypes = {
 	pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 	placeholder: stringOrNode,            // field placeholder, displayed when there's no value
 	preferStartMatch: PropTypes.bool,     // boolean to enable selecting firstly the option(s) which start(s) with text input
+	preferableFilterOptions: PropTypes.any,  // boolean to enable filtering or function to filter the options array ([options], filterString, [values]) when preferStartMatch property is true
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
 	required: PropTypes.bool,             // applies HTML5 required attribute when needed
 	resetValue: PropTypes.any,            // value to use when you clear the control
@@ -1194,6 +1196,7 @@ Select.defaultProps = {
 	pageSize: 5,
 	placeholder: 'Select...',
 	preferStartMatch: false,
+	preferableFilterOptions: preferableFilterOptions,
 	removeSelected: true,
 	required: false,
 	rtl: false,

--- a/src/Select.js
+++ b/src/Select.js
@@ -895,6 +895,7 @@ class Select extends React.Component {
 					labelKey: this.props.labelKey,
 					matchPos: this.props.matchPos,
 					matchProp: this.props.matchProp,
+					preferEarlyMatch: this.props.preferEarlyMatch,
 					valueKey: this.props.valueKey,
 					trimFilter: this.props.trimFilter
 				}
@@ -1139,6 +1140,7 @@ Select.propTypes = {
 	options: PropTypes.array,             // array of options
 	pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 	placeholder: stringOrNode,            // field placeholder, displayed when there's no value
+	preferEarlyMatch: PropTypes.bool,     // boolean to enable selecting firstly the option(s) which start(s) with text input
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
 	required: PropTypes.bool,             // applies HTML5 required attribute when needed
 	resetValue: PropTypes.any,            // value to use when you clear the control
@@ -1191,6 +1193,7 @@ Select.defaultProps = {
 	optionComponent: Option,
 	pageSize: 5,
 	placeholder: 'Select...',
+	preferEarlyMatch: false,
 	removeSelected: true,
 	required: false,
 	rtl: false,

--- a/src/utils/defaultFilterOptions.js
+++ b/src/utils/defaultFilterOptions.js
@@ -1,7 +1,42 @@
 import stripDiacritics from './stripDiacritics';
 import trim from './trim';
 
+function renderOptions(option, filterValue, excludeOptions, props, earlyMatchRequired) {
+	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
+	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
+	if (!filterValue) return true;
+	var valueTest = String(option[props.valueKey]);
+	var labelTest = String(option[props.labelKey]);
+	if (props.ignoreAccents) {
+		if (props.matchProp !== 'label') valueTest = stripDiacritics(valueTest);
+		if (props.matchProp !== 'value') labelTest = stripDiacritics(labelTest);
+	}
+	if (props.ignoreCase) {
+		if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
+		if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
+	}
+	if(earlyMatchRequired) {
+		return props.matchPos === 'start' ? (
+			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+		) : (
+			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) == 0) ||
+			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) == 0)
+		);
+	} else {
+		return props.matchPos === 'start' ? (
+			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+		) : (
+			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
+			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
+		);
+	}
+}
+
 function filterOptions (options, filterValue, excludeOptions, props) {
+	var _this = this;
+	
 	if (props.ignoreAccents) {
 		filterValue = stripDiacritics(filterValue);
 	}
@@ -15,31 +50,16 @@ function filterOptions (options, filterValue, excludeOptions, props) {
 	}
 
 	if (excludeOptions) excludeOptions = excludeOptions.map(i => i[props.valueKey]);
-
-	return options.filter(option => {
-		if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
-		if (props.filterOption) return props.filterOption.call(this, option, filterValue);
-		if (!filterValue) return true;
-		var valueTest = String(option[props.valueKey]);
-		var labelTest = String(option[props.labelKey]);
-
-		if (props.ignoreAccents) {
-			if (props.matchProp !== 'label') valueTest = stripDiacritics(valueTest);
-			if (props.matchProp !== 'value') labelTest = stripDiacritics(labelTest);
-		}
-
-		if (props.ignoreCase) {
-			if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
-			if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
-		}
-		return props.matchPos === 'start' ? (
-			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
-			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
-		) : (
-			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
-			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
-		);
+	var optionsStartWithFilterValue = options.filter(function (option) {
+		return renderOptions(option, filterValue, excludeOptions, props, true)
 	});
+	var optionsContainFilterValue = options.filter(function (option) {
+		return renderOptions(option, filterValue, excludeOptions, props);
+	});
+	return props.preferEarlyMatch ?
+		optionsStartWithFilterValue.concat(optionsContainFilterValue)
+		:
+		optionsContainFilterValue;
 }
 
 export default filterOptions;

--- a/src/utils/defaultFilterOptions.js
+++ b/src/utils/defaultFilterOptions.js
@@ -1,32 +1,7 @@
 import stripDiacritics from './stripDiacritics';
 import trim from './trim';
 
-function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired, excludeStartMatch) {
-	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
-	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
-	if (!filterValue) return true;
-	var valueTest = String(option[props.valueKey]);
-	var labelTest = String(option[props.labelKey]);
-	if (props.ignoreAccents) {
-		if (props.matchProp !== 'label') valueTest = stripDiacritics(valueTest);
-		if (props.matchProp !== 'value') labelTest = stripDiacritics(labelTest);
-	}
-	if (props.ignoreCase) {
-		if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
-		if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
-	}
-	return (props.matchPos === 'start' || startMatchRequired) ? (
-		(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
-		(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
-	) : (
-		(props.matchProp !== 'label' && (excludeStartMatch ? valueTest.indexOf(filterValue) > 0 : valueTest.indexOf(filterValue) >= 0)) ||
-		(props.matchProp !== 'value' && (excludeStartMatch ? labelTest.indexOf(filterValue) > 0 : labelTest.indexOf(filterValue) >= 0))
-	);
-}
-
 function filterOptions (options, filterValue, excludeOptions, props) {
-	var _this = this;
-	
 	if (props.ignoreAccents) {
 		filterValue = stripDiacritics(filterValue);
 	}
@@ -40,16 +15,31 @@ function filterOptions (options, filterValue, excludeOptions, props) {
 	}
 
 	if (excludeOptions) excludeOptions = excludeOptions.map(i => i[props.valueKey]);
-	var optionsStartWithFilterValue = options.filter(function (option) {
-		return getFilteredOptions(option, filterValue, excludeOptions, props, true);
+
+	return options.filter(option => {
+		if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
+		if (props.filterOption) return props.filterOption.call(this, option, filterValue);
+		if (!filterValue) return true;
+		var valueTest = String(option[props.valueKey]);
+		var labelTest = String(option[props.labelKey]);
+
+		if (props.ignoreAccents) {
+			if (props.matchProp !== 'label') valueTest = stripDiacritics(valueTest);
+			if (props.matchProp !== 'value') labelTest = stripDiacritics(labelTest);
+		}
+
+		if (props.ignoreCase) {
+			if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
+			if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
+		}
+		return props.matchPos === 'start' ? (
+			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+		) : (
+			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
+			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
+		);
 	});
-	var optionsContainFilterValue = options.filter(function (option) {
-		return getFilteredOptions(option, filterValue, excludeOptions, props, null, props.preferStartMatch);
-	});
-	return props.preferStartMatch ?
-		optionsStartWithFilterValue.concat(optionsContainFilterValue)
-		:
-		optionsContainFilterValue;
 }
 
 export default filterOptions;

--- a/src/utils/defaultFilterOptions.js
+++ b/src/utils/defaultFilterOptions.js
@@ -47,7 +47,7 @@ function filterOptions (options, filterValue, excludeOptions, props) {
 		return getFilteredOptions(option, filterValue, excludeOptions, props);
 	});
 	return props.preferStartMatch ?
-		optionsStartWithFilterValue.concat(optionsContainFilterValue);
+		optionsStartWithFilterValue.concat(optionsContainFilterValue)
 		:
 		optionsContainFilterValue;
 }

--- a/src/utils/defaultFilterOptions.js
+++ b/src/utils/defaultFilterOptions.js
@@ -1,7 +1,7 @@
 import stripDiacritics from './stripDiacritics';
 import trim from './trim';
 
-function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired) {
+function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired, excludeStartMatch) {
 	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
 	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
 	if (!filterValue) return true;
@@ -19,8 +19,8 @@ function getFilteredOptions(option, filterValue, excludeOptions, props, startMat
 		(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
 		(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
 	) : (
-		(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
-		(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
+		(props.matchProp !== 'label' && (excludeStartMatch ? valueTest.indexOf(filterValue) > 0 : valueTest.indexOf(filterValue) >= 0)) ||
+		(props.matchProp !== 'value' && (excludeStartMatch ? labelTest.indexOf(filterValue) > 0 : labelTest.indexOf(filterValue) >= 0))
 	);
 }
 
@@ -44,7 +44,7 @@ function filterOptions (options, filterValue, excludeOptions, props) {
 		return getFilteredOptions(option, filterValue, excludeOptions, props, true);
 	});
 	var optionsContainFilterValue = options.filter(function (option) {
-		return getFilteredOptions(option, filterValue, excludeOptions, props);
+		return getFilteredOptions(option, filterValue, excludeOptions, props, null, props.preferStartMatch);
 	});
 	return props.preferStartMatch ?
 		optionsStartWithFilterValue.concat(optionsContainFilterValue)

--- a/src/utils/defaultFilterOptions.js
+++ b/src/utils/defaultFilterOptions.js
@@ -1,7 +1,7 @@
 import stripDiacritics from './stripDiacritics';
 import trim from './trim';
 
-function renderOptions(option, filterValue, excludeOptions, props, earlyMatchRequired) {
+function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired) {
 	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
 	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
 	if (!filterValue) return true;
@@ -15,23 +15,13 @@ function renderOptions(option, filterValue, excludeOptions, props, earlyMatchReq
 		if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
 		if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
 	}
-	if(earlyMatchRequired) {
-		return props.matchPos === 'start' ? (
-			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
-			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
-		) : (
-			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) == 0) ||
-			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) == 0)
-		);
-	} else {
-		return props.matchPos === 'start' ? (
-			(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
-			(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
-		) : (
-			(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
-			(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
-		);
-	}
+	return (props.matchPos === 'start' || startMatchRequired) ? (
+		(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+		(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+	) : (
+		(props.matchProp !== 'label' && valueTest.indexOf(filterValue) >= 0) ||
+		(props.matchProp !== 'value' && labelTest.indexOf(filterValue) >= 0)
+	);
 }
 
 function filterOptions (options, filterValue, excludeOptions, props) {
@@ -51,13 +41,13 @@ function filterOptions (options, filterValue, excludeOptions, props) {
 
 	if (excludeOptions) excludeOptions = excludeOptions.map(i => i[props.valueKey]);
 	var optionsStartWithFilterValue = options.filter(function (option) {
-		return renderOptions(option, filterValue, excludeOptions, props, true)
+		return getFilteredOptions(option, filterValue, excludeOptions, props, true);
 	});
 	var optionsContainFilterValue = options.filter(function (option) {
-		return renderOptions(option, filterValue, excludeOptions, props);
+		return getFilteredOptions(option, filterValue, excludeOptions, props);
 	});
-	return props.preferEarlyMatch ?
-		optionsStartWithFilterValue.concat(optionsContainFilterValue)
+	return props.preferStartMatch ?
+		optionsStartWithFilterValue.concat(optionsContainFilterValue);
 		:
 		optionsContainFilterValue;
 }

--- a/src/utils/preferableFilterOptions.js
+++ b/src/utils/preferableFilterOptions.js
@@ -1,7 +1,7 @@
 import stripDiacritics from './stripDiacritics';
 import trim from './trim';
 
-function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired, excludeStartMatch) {
+function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired) {
 	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
 	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
 	if (!filterValue) return true;
@@ -15,12 +15,12 @@ function getFilteredOptions(option, filterValue, excludeOptions, props, startMat
 		if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
 		if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
 	}
-	return (props.matchPos === 'start' || startMatchRequired) ? (
+	return startMatchRequired ? (
 		(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
 		(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
 	) : (
-		(props.matchProp !== 'label' && (excludeStartMatch ? valueTest.indexOf(filterValue) > 0 : valueTest.indexOf(filterValue) >= 0)) ||
-		(props.matchProp !== 'value' && (excludeStartMatch ? labelTest.indexOf(filterValue) > 0 : labelTest.indexOf(filterValue) >= 0))
+		(props.matchProp !== 'label' && valueTest.indexOf(filterValue) > 0) ||
+		(props.matchProp !== 'value' && labelTest.indexOf(filterValue) > 0)
 	);
 }
 
@@ -44,12 +44,9 @@ function preferableFilterOptions (options, filterValue, excludeOptions, props) {
 		return getFilteredOptions(option, filterValue, excludeOptions, props, true);
 	});
 	var optionsContainFilterValue = options.filter(function (option) {
-		return getFilteredOptions(option, filterValue, excludeOptions, props, null, props.preferStartMatch);
+		return getFilteredOptions(option, filterValue, excludeOptions, props);
 	});
-	return props.preferStartMatch ?
-		optionsStartWithFilterValue.concat(optionsContainFilterValue)
-		:
-		optionsContainFilterValue;
+	return optionsStartWithFilterValue.concat(optionsContainFilterValue);
 }
 
 export default preferableFilterOptions;

--- a/src/utils/preferableFilterOptions.js
+++ b/src/utils/preferableFilterOptions.js
@@ -1,0 +1,55 @@
+import stripDiacritics from './stripDiacritics';
+import trim from './trim';
+
+function getFilteredOptions(option, filterValue, excludeOptions, props, startMatchRequired, excludeStartMatch) {
+	if (excludeOptions && excludeOptions.indexOf(option[props.valueKey]) > -1) return false;
+	if (props.filterOption) return props.filterOption.call(this, option, filterValue);
+	if (!filterValue) return true;
+	var valueTest = String(option[props.valueKey]);
+	var labelTest = String(option[props.labelKey]);
+	if (props.ignoreAccents) {
+		if (props.matchProp !== 'label') valueTest = stripDiacritics(valueTest);
+		if (props.matchProp !== 'value') labelTest = stripDiacritics(labelTest);
+	}
+	if (props.ignoreCase) {
+		if (props.matchProp !== 'label') valueTest = valueTest.toLowerCase();
+		if (props.matchProp !== 'value') labelTest = labelTest.toLowerCase();
+	}
+	return (props.matchPos === 'start' || startMatchRequired) ? (
+		(props.matchProp !== 'label' && valueTest.substr(0, filterValue.length) === filterValue) ||
+		(props.matchProp !== 'value' && labelTest.substr(0, filterValue.length) === filterValue)
+	) : (
+		(props.matchProp !== 'label' && (excludeStartMatch ? valueTest.indexOf(filterValue) > 0 : valueTest.indexOf(filterValue) >= 0)) ||
+		(props.matchProp !== 'value' && (excludeStartMatch ? labelTest.indexOf(filterValue) > 0 : labelTest.indexOf(filterValue) >= 0))
+	);
+}
+
+function preferableFilterOptions (options, filterValue, excludeOptions, props) {
+	var _this = this;
+	
+	if (props.ignoreAccents) {
+		filterValue = stripDiacritics(filterValue);
+	}
+
+	if (props.ignoreCase) {
+		filterValue = filterValue.toLowerCase();
+	}
+
+	if (props.trimFilter) {
+		filterValue = trim(filterValue);
+	}
+
+	if (excludeOptions) excludeOptions = excludeOptions.map(i => i[props.valueKey]);
+	var optionsStartWithFilterValue = options.filter(function (option) {
+		return getFilteredOptions(option, filterValue, excludeOptions, props, true);
+	});
+	var optionsContainFilterValue = options.filter(function (option) {
+		return getFilteredOptions(option, filterValue, excludeOptions, props, null, props.preferStartMatch);
+	});
+	return props.preferStartMatch ?
+		optionsStartWithFilterValue.concat(optionsContainFilterValue)
+		:
+		optionsContainFilterValue;
+}
+
+export default preferableFilterOptions;

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -927,11 +927,11 @@ describe('Select', () => {
 				});
 			});
 
-			describe('with preferStartMatch=true and matchProp=value', () => {
+			describe('with matchPos=preferStart and matchProp=value', () => {
 
 				beforeEach(() => {
 					instance = createControl({
-						preferStartMatch: true,
+						matchPos: 'preferStart',
 						matchProp: 'value',
 						options: [
 							{ value: 'abc', label: 'AaBbCc' },
@@ -962,11 +962,11 @@ describe('Select', () => {
 				});
 			});
 
-			describe('with preferStartMatch=true and matchProp=label', () => {
+			describe('with matchPos=preferStart and matchProp=label', () => {
 
 				beforeEach(() => {
 					instance = createControl({
-						preferStartMatch: true,
+						matchPos: 'preferStart',
 						matchProp: 'label',
 						options: [
 							{ value: 'abc', label: 'ABC' },

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -926,6 +926,76 @@ describe('Select', () => {
 						'.Select-option');
 				});
 			});
+
+			describe('with preferStartMatch=true and matchProp=value', () => {
+
+				beforeEach(() => {
+					instance = createControl({
+						preferStartMatch: true,
+						matchProp: 'value',
+						options: [
+							{ value: 'abc', label: 'AaBbCc' },
+							{ value: 'bcd', label: 'BbCcDd' },
+							{ value: 'efg', label: 'EeFfGg' },
+							{ value: 'cdb', label: 'CcDdBb' }
+						]
+					});
+				});
+
+				it('finds text firstly at the start of the value, then anywhere in value', () => {
+
+					typeSearchText('cd');
+					expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-option',
+						'to satisfy', [
+							expect.it('to have text', 'CcDdBb'),
+							expect.it('to have text', 'BbCcDd')
+						]);
+				});
+
+				it('does not match text at end', () => {
+
+					typeSearchText('cg');
+					expect(ReactDOM.findDOMNode(instance), 'to contain elements matching',
+						'.Select-noresults');
+					expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching',
+						'.Select-option');
+				});
+			});
+
+			describe('with preferStartMatch=true and matchProp=label', () => {
+
+				beforeEach(() => {
+					instance = createControl({
+						preferStartMatch: true,
+						matchProp: 'label',
+						options: [
+							{ value: 'abc', label: 'ABC' },
+							{ value: 'bcd', label: 'BCD' },
+							{ value: 'efg', label: 'EFG' },
+							{ value: 'cdb', label: 'CDB' }
+						]
+					});
+				});
+
+				it('finds text firstly at the start of the label, then anywhere in label', () => {
+
+					typeSearchText('cd');
+					expect(ReactDOM.findDOMNode(instance), 'queried for', '.Select-option',
+						'to satisfy', [
+							expect.it('to have text', 'CDB'),
+							expect.it('to have text', 'BCD')
+						]);
+				});
+
+				it('does not match text at end', () => {
+
+					typeSearchText('cg');
+					expect(ReactDOM.findDOMNode(instance), 'to contain elements matching',
+						'.Select-noresults');
+					expect(ReactDOM.findDOMNode(instance), 'to contain no elements matching',
+						'.Select-option');
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
New option for property `matchPos` to prioritize options that match a given filter input at the **beginning** of the value/label. Options that start with the filter input will be listed first, other matches follow. This offers more flexibility than just setting` matchPos = "start"`.

Also added to tests with `matchPos="preferStart"` and both, `matchProp` set to either `"value"` or `"label"`.