### PR TITLE
Export default util functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@ import Creatable from './Creatable';
 import Value from './Value';
 import Option from './Option';
 
+import defaultMenuRenderer from './utils/defaultMenuRenderer';
+import defaultArrowRenderer from './utils/defaultArrowRenderer';
+import defaultClearRenderer from './utils/defaultClearRenderer';
+import defaultFilterOptions from './utils/defaultFilterOptions';
+
 Select.Async = Async;
 Select.AsyncCreatable = AsyncCreatable;
 Select.Creatable = Creatable;
@@ -17,5 +22,9 @@ export {
 	AsyncCreatable,
 	Creatable,
 	Value,
-	Option
+	Option,
+	defaultMenuRenderer,
+	defaultArrowRenderer,
+	defaultClearRenderer,
+	defaultFilterOptions
 };


### PR DESCRIPTION
This is useful when trying to alter default behavior of react-select without necessarily re-inventing things already in use in react select.
In fact, we're currently using copy-pasted defaultOptionRenderer from react selects code.
Things would be way nicer if you could also import such functions from react-select package.