### PR TITLE
handleMouseDownOnArrow fix when openOnClick prop is set to false

### DIFF
--- a/examples/src/components/States.js
+++ b/examples/src/components/States.js
@@ -64,6 +64,7 @@ var StatesField = createClass({
 					value={this.state.selectValue}
 					onChange={this.updateValue}
 					rtl={this.state.rtl}
+					openOnClick={false}
 					searchable={this.state.searchable}
 				/>
 				<button style={{ marginTop: '15px' }} type="button" onClick={this.focusStateSelect}>Focus Select</button>

--- a/src/Select.js
+++ b/src/Select.js
@@ -267,13 +267,17 @@ class Select extends React.Component {
 		}
 		// If the menu isn't open, let the event bubble to the main handleMouseDown
 		if (!this.state.isOpen) {
-			return;
+			this.setState({
+				isOpen: true,
+			});
 		}
 		// prevent default event handlers
 		event.stopPropagation();
 		event.preventDefault();
 		// close the menu
-		this.closeMenu();
+		if(this.state.isOpen){
+			this.closeMenu();
+		}
 	}
 
 	handleMouseDownOnMenu (event) {


### PR DESCRIPTION
this pull request is intended to fix the issue #2127, now if I set the `openOnClick` prop to `false`, the selectable opens when the arrow is clicked but not if the field is clicked