### PR TITLE
Add conditional scrolling into view of focused option

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -108,7 +108,19 @@ class Select extends React.Component {
 		if (this.menu && this.focused && this.state.isOpen && !this.hasScrolledToOption) {
 			let focusedOptionNode = findDOMNode(this.focused);
 			let menuNode = findDOMNode(this.menu);
-			menuNode.scrollTop = focusedOptionNode.offsetTop;
+
+			const scrollTop = menuNode.scrollTop;
+			const scrollBottom = scrollTop + menuNode.offsetHeight;
+			const optionTop = focusedOptionNode.offsetTop;
+			const optionBottom = optionTop + focusedOptionNode.offsetHeight;
+
+			if (scrollTop > optionTop || scrollBottom < optionBottom) {
+				menuNode.scrollTop = focusedOptionNode.offsetTop;
+			}
+
+			// We still set hasScrolledToOption to true even if we didn't
+			// actually need to scroll, as we've still confirmed that the
+			// option is in view.
 			this.hasScrolledToOption = true;
 		} else if (!this.state.isOpen) {
 			this.hasScrolledToOption = false;


### PR DESCRIPTION
Previously the focused option would be scrolled to the top of the scroll window when the menu is opened, regardless of whether it was already in view.  An example of a situation where this is problematic is when a list starts with one or more disabled items. In this situation, the disabled items are scrolled out of view when the menu opens, and because they're at the top of the list it's hard to notice they're there.

This PR modifies the behavior such that when the menu is opened, it will only scroll the focused option into view if it's not already fully in view.

The current behavior is reproducible in the live demo:
1. Open the live demo at http://jedwatson.github.io/react-select/
2. Change the states demo to the US dataset
3. Without typing, open the menu by clicking the input.
4. Notice that it's hard to tell that there's a disabled option at the top of the list, especially in environments where the scrollbar is not always visible.
     