### PR TITLE
Update code styles in Creatable.js

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -12,7 +12,7 @@ class CreatableSelect extends React.Component {
 		this.menuRenderer = this.menuRenderer.bind(this);
 		this.onInputKeyDown = this.onInputKeyDown.bind(this);
 		this.onInputChange = this.onInputChange.bind(this);
-		this.onOptionSelect  = this.onOptionSelect .bind(this);
+		this.onOptionSelect  = this.onOptionSelect.bind(this);
 	}
 
 	createNewOption () {
@@ -42,7 +42,7 @@ class CreatableSelect extends React.Component {
 	}
 
 	filterOptions (...params) {
-		const { filterOptions, isValidNewOption, options, promptTextCreator } = this.props;
+		const { filterOptions, isValidNewOption, promptTextCreator } = this.props;
 
 		// TRICKY Check currently selected options as well.
 		// Don't display a create-prompt for a value that's selected.
@@ -231,6 +231,8 @@ function shouldKeyDownEventCreateNewOption ({ keyCode }) {
 		case 13:  // ENTER
 		case 188: // COMMA
 			return true;
+		default:
+			return false;
 	}
 
 	return false;

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -234,8 +234,6 @@ function shouldKeyDownEventCreateNewOption ({ keyCode }) {
 		default:
 			return false;
 	}
-
-	return false;
 };
 
 	// Default prop methods


### PR DESCRIPTION
There're a couple of code style issues in `Creatable.js` that should probably be addressed for an easy win (warnings on those code have been thrown when running lint on my test project): 1. removing an unnecessary space when binding `onOptionSelect` to the control instance; 2. removing `options` variable in function `filterOptions` since it's not used; 3. adding default condition to the switch statement in function `shouldKeyDownEventCreateNewOption`.

No functional changes are expected from this PR.