### PR TITLE
Fix/is option unique crash

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -26,7 +26,7 @@ class CreatableSelect extends React.Component {
 
 		if (isValidNewOption({ label: this.inputValue })) {
 			const option = newOptionCreator({ label: this.inputValue, labelKey: this.labelKey, valueKey: this.valueKey });
-			const isOptionUnique = this.isOptionUnique({ option });
+			const isOptionUnique = this.isOptionUnique({ option, options });
 
 			// Don't add the same option twice.
 			if (isOptionUnique) {

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -201,6 +201,10 @@ function defaultChildren (props) {
 };
 
 function isOptionUnique ({ option, options, labelKey, valueKey }) {
+	if (!options || !options.length) {
+		return true;
+	}
+	
 	return options
 		.filter((existingOption) =>
 			existingOption[labelKey] === option[labelKey] ||

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -221,6 +221,46 @@ describe('Creatable', () => {
 		expect(test(newOption('qux', 4)), 'to be', true);
 		expect(test(newOption('Foo', 11)), 'to be', true);
 	});
+	
+	it('default: isOptionUnique function should always return true if given options are empty', () => {
+		const options = [];
+
+		function newOption (label, value) {
+			return { label, value };
+		};
+
+		function test (option) {
+			return Select.Creatable.isOptionUnique({
+				option,
+				options,
+				labelKey: 'label',
+				valueKey: 'value'
+			});
+		};
+
+		expect(test(newOption('foo', 0)), 'to be', true);
+		expect(test(newOption('qux', 1)), 'to be', true);
+	});
+
+	it('default: isOptionUnique function should not crash if given options are null or undefined', () => {
+		const options = null;
+
+		function newOption (label, value) {
+			return { label, value };
+		};
+
+		function test (option) {
+			return Select.Creatable.isOptionUnique({
+				option,
+				options,
+				labelKey: 'label',
+				valueKey: 'value'
+			});
+		};
+
+		expect(test(newOption('foo', 0)), 'to be', true);
+		expect(test(newOption('qux', 1)), 'to be', true);
+	});
 
 	it('default :isValidNewOption function should just ensure a non-empty string is provided', () => {
 		function test (label) {


### PR DESCRIPTION
This PR is trying to fix issue #2184, where for some edge cases, if we try to create a new option while the `options` property is null or undefined, the control will crash because function `isOptionUnique` will call `filter` on `options` before checking if it's valid to be performed on. 