### PR TITLE
Fix issue #2182

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -292,8 +292,7 @@ class Select extends React.Component {
 			event.preventDefault();
 			// close the menu
 			this.closeMenu();
-		}
-		else {
+		} else {
 			// If the menu isn't open, let the event bubble to the main handleMouseDown
 			this.setState({
 				isOpen: true,

--- a/src/Select.js
+++ b/src/Select.js
@@ -285,18 +285,19 @@ class Select extends React.Component {
 		if (this.props.disabled || (event.type === 'mousedown' && event.button !== 0)) {
 			return;
 		}
-		// If the menu isn't open, let the event bubble to the main handleMouseDown
-		if (!this.state.isOpen) {
+
+		if (this.state.isOpen) {
+			// prevent default event handlers
+			event.stopPropagation();
+			event.preventDefault();
+			// close the menu
+			this.closeMenu();
+		}
+		else {
+			// If the menu isn't open, let the event bubble to the main handleMouseDown
 			this.setState({
 				isOpen: true,
 			});
-		}
-		// prevent default event handlers
-		event.stopPropagation();
-		event.preventDefault();
-		// close the menu
-		if(this.state.isOpen){
-			this.closeMenu();
 		}
 	}
 


### PR DESCRIPTION
There was a change made in commit f6920de that results in multiple dropdowns being open at the same time because stopping propagation of the arrow mouse down event in select 2 when opening its dropdown does not allow the blur event to happen for select 1, so the dropdown for select 1 remains open.