### PR TITLE
onSelectResetsInput regression fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
     "cover": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha",
     "coveralls": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha && cat coverage/lcov.info | coveralls",
     "lint": "eslint .",
-    "deploy": "NODE_ENV=production nps publish",
+    "deploy": "cross-env NODE_ENV=production nps publish",
     "start": "webpack-dev-server --progress",
-    "test": "NODE_ENV=test mocha --compilers js:babel-core/register",
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register",
     "precommit": "lint-staged && yarn run test"
   },
   "files": [

--- a/src/Select.js
+++ b/src/Select.js
@@ -102,7 +102,7 @@ class Select extends React.Component {
 			this.setState({ required: false });
 		}
 
-		if (this.state.inputValue && this.props.value !== nextProps.value) {
+		if (this.state.inputValue && this.props.value !== nextProps.value && this.props.onSelectResetsInput) {
 			this.setState({ inputValue: this.handleInputValueChange('') });
 		}
 	}
@@ -565,6 +565,7 @@ class Select extends React.Component {
 			this.hasScrolledToOption = false;
 		}
 		const updatedValue = this.props.onSelectResetsInput ? '' : this.state.inputValue;
+		console.log(this.props.onSelectResetsInput, this.state.inputValue, updatedValue);
 		if (this.props.multi) {
 			this.setState({
 				focusedIndex: null,

--- a/src/Select.js
+++ b/src/Select.js
@@ -565,7 +565,6 @@ class Select extends React.Component {
 			this.hasScrolledToOption = false;
 		}
 		const updatedValue = this.props.onSelectResetsInput ? '' : this.state.inputValue;
-		console.log(this.props.onSelectResetsInput, this.state.inputValue, updatedValue);
 		if (this.props.multi) {
 			this.setState({
 				focusedIndex: null,

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2160,7 +2160,7 @@ describe('Select', () => {
 			expect(instance.state.inputValue, 'to equal', 'two');
 		});
 
-		it('should have reset the inputValue after accepting selection', () => {
+		it('should have reset the inputValue after accepting selection when onSelectResetsInput= true or not set', () => {
 			options = [
 				{ value: 'one', label: 'One' },
 				{ value: 'two', label: 'Two' },

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2129,8 +2129,8 @@ describe('Select', () => {
 
 	});
 
-	describe('with multi=true and onSelectResetsInput=false', () => {
-		it('should have retained inputValue after accepting selection', () => {
+	describe('with multi=true different onSelectResetsInput', () => {
+		it('should have retained inputValue after accepting selection with onSelectResetsInput=false', () => {
 			options = [
 				{ value: 'one', label: 'One' },
 				{ value: 'two', label: 'Two' },

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2129,6 +2129,66 @@ describe('Select', () => {
 
 	});
 
+	describe('with multi=true and onSelectResetsInput=false', () => {
+		it('should have retained inputValue after accepting selection', () => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' },
+				{ value: 'four', label: 'Four' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: '',
+				options: options,
+				multi: true,
+				closeOnSelect: false,
+				removeSelected: false,
+				onSelectResetsInput: false
+			});
+
+			instance.setState({
+				isFocused: true
+			});
+
+			clickArrowToOpen();
+			typeSearchText('two');
+			pressEnterToAccept();
+			setValueProp('two'); // trigger componentWillReceiveProps
+
+			expect(instance.state.inputValue, 'to equal', 'two');
+		});
+
+		it('should have reset the inputValue after accepting selection', () => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' },
+				{ value: 'four', label: 'Four' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: '',
+				options: options,
+				multi: true,
+				closeOnSelect: false,
+				removeSelected: false
+			});
+
+			instance.setState({
+				isFocused: true
+			});
+
+			clickArrowToOpen();
+			typeSearchText('two');
+			pressEnterToAccept();
+
+			expect(instance.state.inputValue, 'to equal', '');
+		});
+	});
+
 	describe('with removeSelected=false', () => {
 		beforeEach(() => {
 			options = [


### PR DESCRIPTION
Recent changes to componentWillReceiveProps prevented the input from retaining values even if onSelectResetsInput was false. This PR resolves that regression and adds tests around onSelectResetsInput, which I didn't notice anywhere. Also updated package.json to use cross-env for all scripts.