### PR TITLE
Fixed bug onSelectResetsInput=false for single select

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ function onInputKeyDown(event) {
 | `onInputKeyDown` | function | undefined | input keyDown handler; call `event.preventDefault()` to override default `Select` behaviour: `function(event) {}` |
 | `onMenuScrollToBottom` | function | undefined | called when the menu is scrolled to the bottom |
 | `onOpen` | function | undefined | handler for when the menu opens: `function () {}` |
-| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected, for `multi`. Also input value will be set to empty if 'onSelectResetsInput=true' and Select will get new value that not equal previous value, this is actual for 'multi'=false or true or undefined.
+| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected, for `multi`=true. Also input value will be set to empty if 'onSelectResetsInput=true' and 'Select' will get new value that not equal previous value, this is actual for 'multi'=false or true or undefined.
 | `onValueClick` | function | undefined | onClick handler for value labels: `function (value, event) {}` |
 | `openOnClick` | boolean | true | open the options menu when the control is clicked (requires searchable = true) |
 | `openOnFocus` | boolean | false | open the options menu when the control gets focus |

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ function onInputKeyDown(event) {
 | `onInputKeyDown` | function | undefined | input keyDown handler; call `event.preventDefault()` to override default `Select` behaviour: `function(event) {}` |
 | `onMenuScrollToBottom` | function | undefined | called when the menu is scrolled to the bottom |
 | `onOpen` | function | undefined | handler for when the menu opens: `function () {}` |
-| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected, for `multi`
+| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected, for `multi`. Also input value will be set to empty if 'onSelectResetsInput=true' and Select will get new value that not equal previous value, this is actual for 'multi'=false or true or undefined.
 | `onValueClick` | function | undefined | onClick handler for value labels: `function (value, event) {}` |
 | `openOnClick` | boolean | true | open the options menu when the control is clicked (requires searchable = true) |
 | `openOnFocus` | boolean | false | open the options menu when the control gets focus |

--- a/src/Select.js
+++ b/src/Select.js
@@ -347,7 +347,7 @@ class Select extends React.Component {
 
 		let toOpen = this.state.isOpen || this._openAfterFocus || this.props.openOnFocus;
 		toOpen = this._focusAfterClear ? false : toOpen;  //if focus happens after clear values, don't open dropdown yet.
-		
+
 		if (this.props.onFocus) {
 			this.props.onFocus(event);
 		}
@@ -579,8 +579,8 @@ class Select extends React.Component {
 		if (this.props.closeOnSelect) {
 			this.hasScrolledToOption = false;
 		}
-		const updatedValue = this.props.onSelectResetsInput ? '' : this.state.inputValue;
 		if (this.props.multi) {
+		const updatedValue = this.props.onSelectResetsInput ? '' : this.state.inputValue;
 			this.setState({
 				focusedIndex: null,
 				inputValue: this.handleInputValueChange(updatedValue),
@@ -594,6 +594,7 @@ class Select extends React.Component {
 				}
 			});
 		} else {
+			const updatedValue = '';
 			this.setState({
 				inputValue: this.handleInputValueChange(updatedValue),
 				isOpen: !this.props.closeOnSelect,

--- a/src/Select.js
+++ b/src/Select.js
@@ -522,7 +522,7 @@ class Select extends React.Component {
 	/**
 	 * Turns a value into an array from the given options
 	 * @param {String|Number|Array}	value	- the value of the select input
-	 * @param {Object}  			nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
+	 * @param {Object}		nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
 	 * @returns	{Array}	the value of the select represented in an array
 	 */
 	getValueArray (value, nextProps = undefined) {
@@ -545,7 +545,7 @@ class Select extends React.Component {
 	/**
 	 * Retrieve a value from the given options and valueKey
 	 * @param {String|Number|Array}	value	- the selected value(s)
-	 * @param {Object}				props	- the Select component's props (or nextProps)
+	 * @param {Object}		props	- the Select component's props (or nextProps)
 	 */
 	expandValue (value, props) {
 		const valueType = typeof value;

--- a/src/Select.js
+++ b/src/Select.js
@@ -525,7 +525,7 @@ class Select extends React.Component {
 	 * @param {Object}				nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
 	 * @returns	{Array}	the value of the select represented in an array
 	 */
-	getValueArray (value, nextProps) {
+	getValueArray (value, nextProps = undefined) {
 		/** support optionally passing in the `nextProps` so `componentWillReceiveProps` updates will function as expected */
 		const props = typeof nextProps === 'object' ? nextProps : this.props;
 		if (props.multi) {
@@ -538,7 +538,7 @@ class Select extends React.Component {
 			}
 			return value.map(value => this.expandValue(value, props)).filter(i => i);
 		}
-		var expandedValue = this.expandValue(value, props);
+		const expandedValue = this.expandValue(value, props);
 		return expandedValue ? [expandedValue] : [];
 	}
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -522,7 +522,7 @@ class Select extends React.Component {
 	/**
 	 * Turns a value into an array from the given options
 	 * @param {String|Number|Array}	value	- the value of the select input
-	 * @param {Object}  nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
+	 * @param {Object}  			nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
 	 * @returns	{Array}	the value of the select represented in an array
 	 */
 	getValueArray (value, nextProps = undefined) {
@@ -545,7 +545,7 @@ class Select extends React.Component {
 	/**
 	 * Retrieve a value from the given options and valueKey
 	 * @param {String|Number|Array}	value	- the selected value(s)
-	 * @param {Object}	props	- the Select component's props (or nextProps)
+	 * @param {Object}				props	- the Select component's props (or nextProps)
 	 */
 	expandValue (value, props) {
 		const valueType = typeof value;

--- a/src/Select.js
+++ b/src/Select.js
@@ -521,8 +521,8 @@ class Select extends React.Component {
 
 	/**
 	 * Turns a value into an array from the given options
-	 * @param {String|Number|Array} value		- the value of the select input
-	 * @param {Object}				nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
+	 * @param {String|Number|Array}	value	- the value of the select input
+	 * @param {Object}  nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
 	 * @returns	{Array}	the value of the select represented in an array
 	 */
 	getValueArray (value, nextProps = undefined) {
@@ -545,7 +545,7 @@ class Select extends React.Component {
 	/**
 	 * Retrieve a value from the given options and valueKey
 	 * @param {String|Number|Array}	value	- the selected value(s)
-	 * @param {Object}				props	- the Select component's props (or nextProps)
+	 * @param {Object}	props	- the Select component's props (or nextProps)
 	 */
 	expandValue (value, props) {
 		const valueType = typeof value;

--- a/src/Select.js
+++ b/src/Select.js
@@ -521,8 +521,8 @@ class Select extends React.Component {
 
 	/**
 	 * Turns a value into an array from the given options
-	 * @param	{String|Number|Array}	value		- the value of the select input
-	 * @param	{Object}		nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
+	 * @param {String|Number|Array} value		- the value of the select input
+	 * @param {Object}				nextProps	- optionally specify the nextProps so the returned array uses the latest configuration
 	 * @returns	{Array}	the value of the select represented in an array
 	 */
 	getValueArray (value, nextProps) {
@@ -544,8 +544,8 @@ class Select extends React.Component {
 
 	/**
 	 * Retrieve a value from the given options and valueKey
-	 * @param	{String|Number|Array}	value	- the selected value(s)
-	 * @param	{Object}		props	- the Select component's props (or nextProps)
+	 * @param {String|Number|Array}	value	- the selected value(s)
+	 * @param {Object}				props	- the Select component's props (or nextProps)
 	 */
 	expandValue (value, props) {
 		const valueType = typeof value;

--- a/src/Select.js
+++ b/src/Select.js
@@ -586,7 +586,7 @@ class Select extends React.Component {
 				inputValue: this.handleInputValueChange(updatedValue),
 				isOpen: !this.props.closeOnSelect,
 			}, () => {
-				var valueArray = this.getValueArray(this.props.value);
+				const valueArray = this.getValueArray(this.props.value);
 				if (valueArray.some(i => i[this.props.valueKey] === value[this.props.valueKey])) {
 					this.removeValue(value);
 				} else {

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2160,7 +2160,7 @@ describe('Select', () => {
 			expect(instance.state.inputValue, 'to equal', 'two');
 		});
 
-		it('should have reset the inputValue after accepting selection when onSelectResetsInput= true or not set', () => {
+		it('should have reset the inputValue after accepting selection when onSelectResetsInput=true or not set', () => {
 			options = [
 				{ value: 'one', label: 'One' },
 				{ value: 'two', label: 'Two' },
@@ -2175,6 +2175,58 @@ describe('Select', () => {
 				multi: true,
 				closeOnSelect: false,
 				removeSelected: false
+			});
+
+			instance.setState({
+				isFocused: true
+			});
+
+			clickArrowToOpen();
+			typeSearchText('two');
+			pressEnterToAccept();
+
+			expect(instance.state.inputValue, 'to equal', '');
+		});
+
+		it('should reset inputValue after accepting selection with onSelectResetsInput=false and multi=false or not set', () => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' },
+				{ value: 'four', label: 'Four' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: '',
+				options: options,
+				onSelectResetsInput: false
+			});
+
+			instance.setState({
+				isFocused: true
+			});
+
+			clickArrowToOpen();
+			typeSearchText('two');
+			pressEnterToAccept();
+			setValueProp('two'); // trigger componentWillReceiveProps
+
+			expect(instance.state.inputValue, 'to equal', '');
+		});
+
+		it('should have reset the inputValue after accepting selection when onSelectResetsInput=true or not set and multi=false or not set', () => {
+			options = [
+				{ value: 'one', label: 'One' },
+				{ value: 'two', label: 'Two' },
+				{ value: 'three', label: 'Three' },
+				{ value: 'four', label: 'Four' }
+			];
+
+			// Render an instance of the component
+			wrapper = createControlWithWrapper({
+				value: '',
+				options: options,
 			});
 
 			instance.setState({
@@ -2859,7 +2911,7 @@ describe('Select', () => {
 				expect(options, 'to have length', 2);
 			});
 		});
-		
+
 		describe('empty filterOptions function', () => {
 
 			beforeEach(() => {
@@ -3333,8 +3385,8 @@ describe('Select', () => {
 			const preventDefault = sinon.spy();
 			const event = {
 				'preventDefault': preventDefault,
-				'type': 'mousedown', 
-				'button': 0 
+				'type': 'mousedown',
+				'button': 0
 			};
 
 			beforeEach(() => {
@@ -3345,9 +3397,9 @@ describe('Select', () => {
 					value: ['two', 'one']
 				});
 			});
-						
+
 			it('after clearValue called, menu shall remain closed', () => {
-				
+
 				instance.clearValue(event);
 
 				expect(instance.state.isOpen, 'to be falsy');

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2130,14 +2130,14 @@ describe('Select', () => {
 	});
 
 	describe('with multi=true different onSelectResetsInput', () => {
-		it('should have retained inputValue after accepting selection with onSelectResetsInput=false', () => {
-			options = [
-				{ value: 'one', label: 'One' },
-				{ value: 'two', label: 'Two' },
-				{ value: 'three', label: 'Three' },
-				{ value: 'four', label: 'Four' }
-			];
+		options = [
+			{ value: 'one', label: 'One' },
+			{ value: 'two', label: 'Two' },
+			{ value: 'three', label: 'Three' },
+			{ value: 'four', label: 'Four' }
+		];
 
+		it('should have retained inputValue after accepting selection with onSelectResetsInput=false', () => {
 			// Render an instance of the component
 			wrapper = createControlWithWrapper({
 				value: '',
@@ -2161,13 +2161,6 @@ describe('Select', () => {
 		});
 
 		it('should have reset the inputValue after accepting selection when onSelectResetsInput=true or not set', () => {
-			options = [
-				{ value: 'one', label: 'One' },
-				{ value: 'two', label: 'Two' },
-				{ value: 'three', label: 'Three' },
-				{ value: 'four', label: 'Four' }
-			];
-
 			// Render an instance of the component
 			wrapper = createControlWithWrapper({
 				value: '',
@@ -2189,13 +2182,6 @@ describe('Select', () => {
 		});
 
 		it('should reset inputValue after accepting selection with onSelectResetsInput=false and multi=false or not set', () => {
-			options = [
-				{ value: 'one', label: 'One' },
-				{ value: 'two', label: 'Two' },
-				{ value: 'three', label: 'Three' },
-				{ value: 'four', label: 'Four' }
-			];
-
 			// Render an instance of the component
 			wrapper = createControlWithWrapper({
 				value: '',
@@ -2216,13 +2202,6 @@ describe('Select', () => {
 		});
 
 		it('should have reset the inputValue after accepting selection when onSelectResetsInput=true or not set and multi=false or not set', () => {
-			options = [
-				{ value: 'one', label: 'One' },
-				{ value: 'two', label: 'Two' },
-				{ value: 'three', label: 'Three' },
-				{ value: 'four', label: 'Four' }
-			];
-
 			// Render an instance of the component
 			wrapper = createControlWithWrapper({
 				value: '',


### PR DESCRIPTION
The bug: Select shows selected value as empty when multi=undefined or false and onSelectResetsInput=false but selected value is not empty.