### PR TITLE
Sets context of onNewOptionClick

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -31,7 +31,7 @@ class CreatableSelect extends React.Component {
 			// Don't add the same option twice.
 			if (isOptionUnique) {
 				if (onNewOptionClick) {
-					onNewOptionClick(option);
+					onNewOptionClick.call(this, option);
 				} else {
 					options.unshift(option);
 


### PR DESCRIPTION
Literally just changing
```js
onNewOptionClick(option);
```
to
```js
onNewOptionClick.call(this, option);
```

This allows you to access `this.select.selectValue(option)` within your `onNewOptionClick` callback without having to generate a bunch of extra refs. 

Should not break anything, because `this` would have been undefined previously.