### PR TITLE
Fixed console error in GitHub users example

### DIFF
--- a/examples/src/components/GithubUsers.js
+++ b/examples/src/components/GithubUsers.js
@@ -13,7 +13,8 @@ const GithubUsers = createClass({
 	getInitialState () {
 		return {
 			backspaceRemoves: true,
-			multi: true
+			multi: true,
+			creatable: false,
 		};
 	},
 	onChange (value) {


### PR DESCRIPTION
Appears error after clicking on "Creatable?" checkbox in GitHub users (Async with fetch.js) example.

The error:
`app.js:323 Warning: GithubUsers is changing an uncontrolled input of type checkbox to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components`