### PR TITLE
Add explicit docs on how to disable client side filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,14 @@ const getOptions = (input, callback) => {
 
 #### Note about filtering async options
 
-The `Async` component doesn't change the default behaviour for filtering the options based on user input, but if you're already filtering the options server-side you may want to customise or disable this feature (see [filtering options](#filtering-options) below)
+The `Async` component doesn't change the default behaviour for filtering the options based on user input, but if you're already filtering the options server-side you may want to customise or disable this feature (see [filtering options](#filtering-options) below). For example, if you would like to completely disable client side filtering, you can do so with:
+
+```js
+filterOptions={(options, filter, currentValues) => {
+  // Do no filtering, just return all options
+  return options;
+}}
+```
 
 ### Async options with Promises
 


### PR DESCRIPTION
I found the docs in the Readme not explicit enough to answer the question on how one would really disable client side filtering (eventually I found it to be answered in an issue). I think a small code snippet to answer this would be good. 