### PR TITLE
Fix rendering with arrowRenderer and no autosize.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -925,7 +925,7 @@ class Select extends React.Component {
 			);
 		}
 		return (
-			<div className={ className } key="input-wrap">
+			<div className={ className } key="input-wrap" style={{display: 'inline-block'}}>
 				<input id={this.props.id} {...inputProps} />
 			</div>
 		);


### PR DESCRIPTION
The container for the input element lacked `display: inline-block`,
which is present on both the `AutosizeInput` component and the disabled
version of the input component.

This should fix #2082 and #2202.