### PR TITLE
Del key should work normal if not deleteRemoves (fixes #2282)

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -546,8 +546,8 @@ class Select extends React.Component {
 				this.focusStartOption();
 				break;
 			case 46: // delete
-				event.preventDefault();
 				if (!this.state.inputValue && this.props.deleteRemoves) {
+					event.preventDefault();
 					this.popValue();
 				}
 				break;


### PR DESCRIPTION
Fixes #2282 as described in the ticket. Same behaviour as for `backspace`