### PR TITLE
Keep dropdown open during load options (fixes #2281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ You can manipulate the input by providing a `onInputChange` callback that return
 function cleanInput(inputValue) {
     // Strip all non-number characters from the input
     return inputValue.replace(/[^0-9]/g, "");
-}   
+}
 
 <Select
     name="form-field-name"
@@ -425,6 +425,7 @@ function onInputKeyDown(event) {
 |:---|:---|:---|:---|
 | `autoload` | boolean | true | automatically call the `loadOptions` prop on-mount |
 | `cache` | object | undefined | Sets the cache object used for options. Set to `false` if you would like to disable caching.
+| `keepMenuOpenDuringLoading` | boolean | false | keep the menu dropdown open while waiting for `loadOptions` to return |
 | `loadingPlaceholder` | string or node | 'Loading...' | label to prompt for loading search result |
 | `loadOptions` | function | undefined | function that returns a promise or calls a callback with the options: `function(input, [callback])` |
 

--- a/src/Async.js
+++ b/src/Async.js
@@ -10,6 +10,7 @@ const propTypes = {
 	children: PropTypes.func.isRequired,       // Child function responsible for creating the inner Select component; (props: Object): PropTypes.element
 	ignoreAccents: PropTypes.bool,             // strip diacritics when filtering; defaults to true
 	ignoreCase: PropTypes.bool,                // perform case-insensitive filtering; defaults to true
+	keepMenuOpenWhileLoading: PropTypes.bool,  // keep dropdown open while waiting for loadOptions; defaults to false
 	loadOptions: PropTypes.func.isRequired,    // callback to load options asynchronously; (inputValue: string, callback: Function): ?Promise
 	loadingPlaceholder: PropTypes.oneOfType([  // replaces the placeholder while options are loading
 		PropTypes.string,
@@ -44,6 +45,7 @@ const defaultProps = {
 	children: defaultChildren,
 	ignoreAccents: true,
 	ignoreCase: true,
+	keepMenuOpenWhileLoading: false,
 	loadingPlaceholder: 'Loading...',
 	options: [],
 	searchPromptText: 'Type to search',
@@ -132,6 +134,7 @@ export default class Async extends Component {
 
 		if (
 			this._callback &&
+			!this.props.keepMenuOpenWhileLoading &&
 			!this.state.isLoading
 		) {
 			this.setState({


### PR DESCRIPTION
This allows for a dropdown to stay open as one is used to from DDG or google. Fixes #2281 