### PR TITLE
Fixed regression inputValue reset on componentWillReceiveProps ( issue #2277 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ function onInputKeyDown(event) {
 | `onInputKeyDown` | function | undefined | input keyDown handler; call `event.preventDefault()` to override default `Select` behaviour: `function(event) {}` |
 | `onMenuScrollToBottom` | function | undefined | called when the menu is scrolled to the bottom |
 | `onOpen` | function | undefined | handler for when the menu opens: `function () {}` |
-| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected. Also input value will be set to empty if 'onSelectResetsInput=true' and Select will get new value that not equal previous value. |
+| `onSelectResetsInput` | boolean | true | whether the input value should be reset when options are selected |
 | `onValueClick` | function | undefined | onClick handler for value labels: `function (value, event) {}` |
 | `openOnClick` | boolean | true | open the options menu when the control is clicked (requires searchable = true) |
 | `openOnFocus` | boolean | false | open the options menu when the control gets focus |

--- a/src/Select.js
+++ b/src/Select.js
@@ -140,10 +140,6 @@ class Select extends React.Component {
 			// Used to be required but it's not any more
 			this.setState({ required: false });
 		}
-
-		if (this.state.inputValue && this.props.value !== nextProps.value && nextProps.onSelectResetsInput) {
-			this.setState({ inputValue: this.handleInputValueChange('') });
-		}
 	}
 
 	componentDidUpdate (prevProps, prevState) {
@@ -925,7 +921,7 @@ class Select extends React.Component {
 			);
 		}
 		return (
-			<div className={ className } key="input-wrap" style={{display: 'inline-block'}}>
+			<div className={className} key="input-wrap" style={{ display: 'inline-block' }}>
 				<input id={this.props.id} {...inputProps} />
 			</div>
 		);

--- a/src/Select.js
+++ b/src/Select.js
@@ -921,7 +921,7 @@ class Select extends React.Component {
 			);
 		}
 		return (
-			<div className={className} key="input-wrap" style={{ display: 'inline-block' }}>
+			<div className={className} key="input-wrap" style={{display: 'inline-block'}}>
 				<input id={this.props.id} {...inputProps} />
 			</div>
 		);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2367,21 +2367,21 @@ describe('Select', () => {
 			});
 		});
 
-		describe('clear the display value on receiving props', () => {
+		describe('should not clear display value on receiving props', () => {
 			beforeEach(() => {
 				var wrapper = createControlWithWrapper({
 					options: defaultOptions,
 					value: 'one',
 				});
 			});
-			it('should clear display value if display is not empty', () => {
+			it('should not clear display value if display is not empty', () => {
 				expect(instance.state.inputValue, 'to equal', '');
 				typeSearchText('and');
 				expect(instance.state.inputValue, 'to equal', 'and');
 				wrapper.setPropsForChild({
 					value: 'newValue',
 				});
-				expect(instance.state.inputValue, 'to equal', '');
+				expect(instance.state.inputValue, 'to equal', 'and');
 			});
 
 			it('should not clear display value if value in next props is equal to previous', () => {


### PR DESCRIPTION
Hi,
Following code:
`if (this.state.inputValue && this.props.value !== nextProps.value && nextProps.onSelectResetsInput) {
this.setState({ inputValue: this.handleInputValueChange('') });
}`
was inserted for https://github.com/JedWatson/react-select/issues/2155 and it provides issues like https://github.com/JedWatson/react-select/issues/2277. Fortunately @gwyneplaine provided better solution via ref and reset inputValue in componentWillReceiveProps is redundant.