### PR TITLE
Fixed broken Focus Select in example

### DIFF
--- a/examples/src/components/States.js
+++ b/examples/src/components/States.js
@@ -43,7 +43,7 @@ var StatesField = createClass({
 		});
 	},
 	focusStateSelect () {
-		this.refs.stateSelect.focus();
+		this.select.focus();
 	},
 	toggleCheckbox (e) {
 		let newState = {};


### PR DESCRIPTION
Hi,
After PR https://github.com/JedWatson/react-select/pull/2259 we got broken 'Focus Select' functionality.