### PR TITLE
Resolve input ref anomaly

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -537,7 +537,9 @@ export default class Select extends Component<Props, State> {
     this.input = input;
 
     // cache the input height to use when the select is disabled
-    if (input && input.input) this.inputHeight = input.input.clientHeight;
+    if (input && !this.inputHeight) {
+      this.inputHeight = input.clientHeight;
+    }
   };
   onInputChange = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
     const inputValue = event.currentTarget.value;

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -7,13 +7,13 @@ import { spacing } from '../theme';
 import { marginHorizontal } from '../mixins';
 
 type Props = {
-  innerRef: HTMLElement => void
-}
+  innerRef: HTMLElement => void,
+};
 
 const Input = ({ innerRef, ...props }: Props) => (
   <AutosizeInput
     className={className('input')}
-    ref={innerRef}
+    inputRef={innerRef}
     style={marginHorizontal(spacing.baseUnit / 2)}
     {...props}
   />


### PR DESCRIPTION
Take advantage of the [`inputRef`](https://github.com/JedWatson/react-input-autosize/blob/master/src/AutosizeInput.js#L195) property already exposed from react-input-autosize.