### PR TITLE
[WIP] V2 component props experiment

### DIFF
--- a/src/components/Aria.js
+++ b/src/components/Aria.js
@@ -2,9 +2,8 @@
 import React, { type Node } from 'react';
 
 import { SROnly } from '../primitives';
-import { className } from '../utils';
 
-type StatusProps = { children: Node };
-export const AriaStatus = (props: StatusProps) => (
-  <SROnly className={className('aria-status')} {...props} />
+type StatusProps = { children: Node, ariaStatusProps: {} };
+export const AriaStatus = ({ children, ariaStatusProps }: StatusProps) => (
+  <SROnly {...ariaStatusProps}>{children}</SROnly>
 );

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -2,27 +2,23 @@
 import React, { type Node } from 'react';
 
 import { className } from '../utils';
-import { paddingHorizontal, paddingVertical } from '../mixins';
+import { paddingHorizontal } from '../mixins';
 import { Li, Ul, Strong } from '../primitives';
 import { spacing } from '../theme';
 
 type Props = {
   children: Node,
-  label: Node,
+  data: any,
+  groupProps: any,
 };
 
 // TODO: Group currently expects a `label` property, which must be a string.
 // we could possibly implement a formatter for it, with aria-labelledby here
 
-const Group = ({ children, label, ...props }: Props) => {
+const Group = ({ children, data, groupProps }: Props) => {
   return (
-    <Li
-      aria-label={label}
-      className={className('group')}
-      css={paddingVertical(spacing.baseUnit * 2)}
-      {...props}
-    >
-      <GroupHeading>{label}</GroupHeading>
+    <Li aria-label={data.label} {...groupProps}>
+      <GroupHeading>{data.label}</GroupHeading>
       <Ul>{children}</Ul>
     </Li>
   );

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -3,26 +3,11 @@ import React from 'react';
 
 import { className } from '../utils';
 import { Div, Ul } from '../primitives';
-import { borderRadius, colors, spacing } from '../theme';
-import { marginVertical, paddingHorizontal, paddingVertical } from '../mixins';
+import { colors, spacing } from '../theme';
+import { paddingHorizontal, paddingVertical } from '../mixins';
 
-const Menu = (props: any) => (
-  <Div
-    className={className('menu')}
-    css={{
-      backgroundColor: colors.neutral0,
-      boxShadow: `0 0 0 1px ${colors.neutral10a}, 0 4px 11px ${
-        colors.neutral10a
-      }`,
-      borderRadius: borderRadius,
-      ...marginVertical(spacing.baseUnit * 2),
-      position: 'absolute',
-      top: '100%',
-      width: '100%',
-      zIndex: 1,
-    }}
-    {...props}
-  />
+const Menu = ({ menuProps, children }: any) => (
+  <Div {...menuProps}>{children}</Div>
 );
 
 export default Menu;

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -2,10 +2,7 @@
 import React from 'react';
 
 import type { OptionProps } from '../types';
-import { className } from '../utils';
-import { colors, spacing } from '../theme';
 import { Li } from '../primitives';
-import { paddingHorizontal, paddingVertical } from '../mixins';
 
 const Option = ({
   data,
@@ -13,26 +10,11 @@ const Option = ({
   isFocused,
   isSelected,
   withinGroup,
+  optionStyles,
+  optionClassName,
   ...props
-}: OptionProps) => (
-  <Li
-    className={className('option', { isFocused, isSelected, withinGroup })}
-    css={{
-      backgroundColor: isSelected
-        ? colors.primary
-        : isFocused ? colors.primaryLight : 'transparent',
-      color: isDisabled
-        ? colors.neutral20
-        : isSelected ? colors.neutral0 : 'inherit',
-      cursor: 'default',
-      display: 'block',
-      fontSize: 'inherit',
-      ...paddingHorizontal(spacing.baseUnit * 3),
-      ...paddingVertical(spacing.baseUnit * 2),
-      width: '100%',
-    }}
-    {...props}
-  />
+}: OptionProps & { optionStyles: any, optionClassName: string }) => (
+  <Li className={optionClassName} css={optionStyles} {...props} />
 );
 
 export default Option;


### PR DESCRIPTION
**DO NOT MERGE**

I'm opening this PR for discussion and review. It demonstrates different approaches to how we could encapsulate styles, aria, and other props to make customising components in v2 simpler.

@jossmac as discussed, I think the main areas people will want to be able to independently customise are:

- styles + theme
- component structure (specific ref: Group, MultiValue)
- component wrappers (e.g Transition implementation)
- components and props themselves (advanced mode)
- content (various labels, formatters, messages & aria)
- functional logic (filtering, selected state, etc)

We should also look at how, given the setup, variations on the UI (e.g Checkboxes / Radio menus in Atlaskit) would be implemented.

The two use-cases I've been thinking about are:

- how simple could it be to re-organise the `MultiValue` component, to put the "cross" on the left?
- how simple could it be to set the colour of options and values as per #2295