### PR TITLE
Better support for menu notices

### DIFF
--- a/cypress/fixtures/selectors.json
+++ b/cypress/fixtures/selectors.json
@@ -9,7 +9,8 @@
   "multiSelectDefaultValues": ".css-1f99qyp.css-1ycyyax",
   "multiSelectInput": "#react-select-4--input",
   "noOptionsValue": ".css-59b0oj.css-1ycyyax",
-  "removeOption": ".react-select__multi-value__remove",
+  "firstMultiValueRemove":
+    "#cypress-multi .react-select__multi-value__remove:first",
   "singleGroupedInputValue":
     "#cypress-single-grouped .react-select__single-value",
   "singleInputValue": ".react-select__single-value",

--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -118,8 +118,7 @@ describe('New Select', function() {
             });
 
           cy
-            .get(selector.removeOption)
-            .first()
+            .get(selector.firstMultiValueRemove)
             .click()
             .get(selector.multiSelectDefaultValues)
             .then(function($defaultValue) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -820,8 +820,8 @@ export default class Select extends Component<Props, State> {
       GroupHeading,
       Menu,
       MenuList,
-      MenuNoticeLoading,
-      MenuNoticeNoOptions,
+      LoadingMessage,
+      NoOptionsMessage,
       Option,
     } = this.components;
     const { focusedOption, menuIsOpen, menuOptions } = this.state;
@@ -873,9 +873,9 @@ export default class Select extends Component<Props, State> {
         }
       });
     } else if (isLoading) {
-      menuUI = <MenuNoticeLoading getStyles={this.getStyles} />;
+      menuUI = <LoadingMessage getStyles={this.getStyles} />;
     } else {
-      menuUI = <MenuNoticeNoOptions getStyles={this.getStyles} />;
+      menuUI = <NoOptionsMessage getStyles={this.getStyles} />;
     }
 
     return (

--- a/src/Select.js
+++ b/src/Select.js
@@ -710,6 +710,7 @@ export default class Select extends Component<Props, State> {
   renderPlaceholderOrValue() {
     const {
       MultiValue,
+      MultiValueContainer,
       MultiValueLabel,
       MultiValueRemove,
       SingleValue,
@@ -734,6 +735,7 @@ export default class Select extends Component<Props, State> {
       return selectValue.map(opt => (
         <MultiValue
           components={{
+            Container: MultiValueContainer,
             Label: MultiValueLabel,
             Remove: MultiValueRemove,
           }}

--- a/src/Select.js
+++ b/src/Select.js
@@ -816,10 +816,10 @@ export default class Select extends Component<Props, State> {
     const {
       Group,
       GroupHeading,
-      LoadingMessage,
       Menu,
       MenuList,
-      NoOptionsMessage,
+      MenuNoticeLoading,
+      MenuNoticeNoOptions,
       Option,
     } = this.components;
     const { focusedOption, menuIsOpen, menuOptions } = this.state;
@@ -871,9 +871,9 @@ export default class Select extends Component<Props, State> {
         }
       });
     } else if (isLoading) {
-      menuUI = <LoadingMessage>Loading...</LoadingMessage>;
+      menuUI = <MenuNoticeLoading getStyles={this.getStyles} />;
     } else {
-      menuUI = <NoOptionsMessage>No options</NoOptionsMessage>;
+      menuUI = <MenuNoticeNoOptions getStyles={this.getStyles} />;
     }
 
     return (

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -69,37 +69,37 @@ const noticeCSS = () => ({
   ...paddingVertical(spacing.baseUnit * 2),
   textAlign: 'center',
 });
-export const menuNoticeNoOptionsCSS = noticeCSS;
-export const menuNoticeLoadingCSS = noticeCSS;
+export const noOptionsMessageCSS = noticeCSS;
+export const loadingMessageCSS = noticeCSS;
 
 type NoticeProps = PropsWithStyles & {
   children: Node,
 };
 
-export const MenuNoticeNoOptions = (props: NoticeProps) => {
+export const NoOptionsMessage = (props: NoticeProps) => {
   const { getStyles, ...cleanProps } = props;
   return (
     <Div
       className={className('menu-notice menu-notice--no-options')}
-      css={getStyles('menuNoticeNoOptions', props)}
+      css={getStyles('noOptionsMessage', props)}
       {...cleanProps}
     />
   );
 };
-MenuNoticeNoOptions.defaultProps = {
+NoOptionsMessage.defaultProps = {
   children: 'No options',
 };
 
-export const MenuNoticeLoading = (props: NoticeProps) => {
+export const LoadingMessage = (props: NoticeProps) => {
   const { getStyles, ...cleanProps } = props;
   return (
     <Div
       className={className('menu-notice menu-notice--loading')}
-      css={getStyles('menuNoticeLoading', props)}
+      css={getStyles('loadingMessage', props)}
       {...cleanProps}
     />
   );
 };
-MenuNoticeLoading.defaultProps = {
+LoadingMessage.defaultProps = {
   children: 'Loading...',
 };

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,11 +1,15 @@
 // @flow
-import React from 'react';
+import React, { type Node } from 'react';
 
 import { className } from '../utils';
 import { Div, Ul } from '../primitives';
 import { borderRadius, colors, spacing } from '../theme';
 import { marginVertical, paddingHorizontal, paddingVertical } from '../mixins';
 import { type PropsWithStyles } from '../types';
+
+// ==============================
+// Menu
+// ==============================
 
 export const menuCSS = () => ({
   backgroundColor: colors.neutral0,
@@ -28,13 +32,17 @@ const Menu = ({ getStyles, ...props }: PropsWithStyles) => (
 
 export default Menu;
 
+// ==============================
+// Menu List
+// ==============================
+
 type MenuListProps = {
   id: string,
   isMulti: boolean,
   maxHeight: number,
 };
 type Props = PropsWithStyles & MenuListProps;
-export const menulistCSS = ({ maxHeight }: MenuListProps) => ({
+export const menuListCSS = ({ maxHeight }: MenuListProps) => ({
   maxHeight,
   overflowY: 'auto',
   ...paddingVertical(spacing.baseUnit),
@@ -45,34 +53,53 @@ export const MenuList = (props: Props) => {
   return (
     <Ul
       className={className('menu-list', { isMulti })}
-      css={getStyles('menulist', props)}
+      css={getStyles('menuList', props)}
       {...cleanProps}
     />
   );
 };
 
-export const NoOptionsMessage = (props: any) => (
-  <Div
-    className={className('menu-no-options-message')}
-    css={{
-      color: colors.neutral40,
-      ...paddingHorizontal(spacing.baseUnit * 3),
-      ...paddingVertical(spacing.baseUnit * 2),
-      textAlign: 'center',
-    }}
-    {...props}
-  />
-);
+// ==============================
+// Menu Notices
+// ==============================
 
-export const LoadingMessage = (props: any) => (
-  <Div
-    className={className('menu-loading-message')}
-    css={{
-      color: colors.neutral40,
-      ...paddingHorizontal(spacing.baseUnit * 3),
-      ...paddingVertical(spacing.baseUnit * 2),
-      textAlign: 'center',
-    }}
-    {...props}
-  />
-);
+const noticeCSS = () => ({
+  color: colors.neutral40,
+  ...paddingHorizontal(spacing.baseUnit * 3),
+  ...paddingVertical(spacing.baseUnit * 2),
+  textAlign: 'center',
+});
+export const menuNoticeNoOptionsCSS = noticeCSS;
+export const menuNoticeLoadingCSS = noticeCSS;
+
+type NoticeProps = PropsWithStyles & {
+  children: Node,
+};
+
+export const MenuNoticeNoOptions = (props: NoticeProps) => {
+  const { getStyles, ...cleanProps } = props;
+  return (
+    <Div
+      className={className('menu-notice menu-notice--no-options')}
+      css={getStyles('menuNoticeNoOptions', props)}
+      {...cleanProps}
+    />
+  );
+};
+MenuNoticeNoOptions.defaultProps = {
+  children: 'No options',
+};
+
+export const MenuNoticeLoading = (props: NoticeProps) => {
+  const { getStyles, ...cleanProps } = props;
+  return (
+    <Div
+      className={className('menu-notice menu-notice--loading')}
+      css={getStyles('menuNoticeLoading', props)}
+      {...cleanProps}
+    />
+  );
+};
+MenuNoticeLoading.defaultProps = {
+  children: 'Loading...',
+};

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -44,6 +44,7 @@ export const multiValueRemoveCSS = () => ({
   },
 });
 
+export const MultiValueContainer = Div;
 export const MultiValueLabel = Div;
 export const MultiValueRemove = Div;
 
@@ -60,19 +61,19 @@ const MultiValue = (props: Props) => {
     ...cleanProps
   } = props;
   const cn = {
-    root: className('multi-value', { isDisabled }),
+    container: className('multi-value', { isDisabled }),
     label: className('multi-value__label'),
     remove: className('multi-value__remove'),
   };
   const css = {
-    root: getStyles('multiValue', props),
+    container: getStyles('multiValue', props),
     label: getStyles('multiValueLabel', props),
     remove: getStyles('multiValueRemove', props),
   };
-  const { Label, Remove } = components;
+  const { Container, Label, Remove } = components;
 
   return (
-    <Div className={cn.root} css={css.root} {...cleanProps}>
+    <Container className={cn.container} css={css.container} {...cleanProps}>
       <Label className={cn.label} css={css.label}>
         {children}
       </Label>
@@ -84,7 +85,7 @@ const MultiValue = (props: Props) => {
       >
         <CrossIcon size={14} />
       </Remove>
-    </Div>
+    </Container>
   );
 };
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,7 +13,7 @@ import {
 import Control from './Control';
 import Group, { GroupHeading } from './Group';
 import Input from './Input';
-import Menu, { MenuList, MenuNoticeNoOptions, MenuNoticeLoading } from './Menu';
+import Menu, { MenuList, NoOptionsMessage, LoadingMessage } from './Menu';
 import MultiValue, {
   MultiValueContainer,
   MultiValueLabel,
@@ -34,8 +34,8 @@ export type SelectComponents = {
   LoadingIndicator: typeof LoadingIndicator,
   Menu: typeof Menu,
   MenuList: typeof MenuList,
-  MenuNoticeLoading: typeof MenuNoticeLoading,
-  MenuNoticeNoOptions: typeof MenuNoticeNoOptions,
+  LoadingMessage: typeof LoadingMessage,
+  NoOptionsMessage: typeof NoOptionsMessage,
   MultiValue: typeof MultiValue,
   MultiValueContainer: typeof MultiValueContainer,
   MultiValueLabel: typeof MultiValueLabel,
@@ -60,8 +60,8 @@ export const components: SelectComponents = {
   LoadingIndicator: LoadingIndicator,
   Menu: Menu,
   MenuList: MenuList,
-  MenuNoticeLoading: MenuNoticeLoading,
-  MenuNoticeNoOptions: MenuNoticeNoOptions,
+  LoadingMessage: LoadingMessage,
+  NoOptionsMessage: NoOptionsMessage,
   MultiValue: MultiValue,
   MultiValueContainer: MultiValueContainer,
   MultiValueLabel: MultiValueLabel,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,7 +13,7 @@ import {
 import Control from './Control';
 import Group, { GroupHeading } from './Group';
 import Input from './Input';
-import Menu, { MenuList, NoOptionsMessage, LoadingMessage } from './Menu';
+import Menu, { MenuList, MenuNoticeNoOptions, MenuNoticeLoading } from './Menu';
 import MultiValue, { MultiValueLabel, MultiValueRemove } from './MultiValue';
 import Option from './Option';
 import Placeholder from './Placeholder';
@@ -28,13 +28,13 @@ export type SelectComponents = {
   IndicatorsContainer: typeof IndicatorsContainer,
   Input: typeof Input,
   LoadingIndicator: typeof LoadingIndicator,
-  LoadingMessage: typeof LoadingMessage,
   Menu: typeof Menu,
   MenuList: typeof MenuList,
+  MenuNoticeLoading: typeof MenuNoticeLoading,
+  MenuNoticeNoOptions: typeof MenuNoticeNoOptions,
   MultiValue: typeof MultiValue,
   MultiValueLabel: typeof MultiValueLabel,
   MultiValueRemove: typeof MultiValueRemove,
-  NoOptionsMessage: typeof NoOptionsMessage,
   Option: typeof Option,
   Placeholder: typeof Placeholder,
   SelectContainer: typeof SelectContainer,
@@ -53,13 +53,13 @@ export const components: SelectComponents = {
   IndicatorsContainer: IndicatorsContainer,
   Input: Input,
   LoadingIndicator: LoadingIndicator,
-  LoadingMessage: LoadingMessage,
   Menu: Menu,
   MenuList: MenuList,
+  MenuNoticeLoading: MenuNoticeLoading,
+  MenuNoticeNoOptions: MenuNoticeNoOptions,
   MultiValue: MultiValue,
   MultiValueLabel: MultiValueLabel,
   MultiValueRemove: MultiValueRemove,
-  NoOptionsMessage: NoOptionsMessage,
   Option: Option,
   Placeholder: Placeholder,
   SelectContainer: SelectContainer,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,7 +14,11 @@ import Control from './Control';
 import Group, { GroupHeading } from './Group';
 import Input from './Input';
 import Menu, { MenuList, MenuNoticeNoOptions, MenuNoticeLoading } from './Menu';
-import MultiValue, { MultiValueLabel, MultiValueRemove } from './MultiValue';
+import MultiValue, {
+  MultiValueContainer,
+  MultiValueLabel,
+  MultiValueRemove,
+} from './MultiValue';
 import Option from './Option';
 import Placeholder from './Placeholder';
 import SingleValue from './SingleValue';
@@ -33,6 +37,7 @@ export type SelectComponents = {
   MenuNoticeLoading: typeof MenuNoticeLoading,
   MenuNoticeNoOptions: typeof MenuNoticeNoOptions,
   MultiValue: typeof MultiValue,
+  MultiValueContainer: typeof MultiValueContainer,
   MultiValueLabel: typeof MultiValueLabel,
   MultiValueRemove: typeof MultiValueRemove,
   Option: typeof Option,
@@ -58,6 +63,7 @@ export const components: SelectComponents = {
   MenuNoticeLoading: MenuNoticeLoading,
   MenuNoticeNoOptions: MenuNoticeNoOptions,
   MultiValue: MultiValue,
+  MultiValueContainer: MultiValueContainer,
   MultiValueLabel: MultiValueLabel,
   MultiValueRemove: MultiValueRemove,
   Option: Option,

--- a/src/styles.js
+++ b/src/styles.js
@@ -14,8 +14,8 @@ import { css as optionCSS } from './components/Option';
 import {
   menuCSS,
   menuListCSS,
-  menuNoticeNoOptionsCSS,
-  menuNoticeLoadingCSS,
+  noOptionsMessageCSS,
+  loadingMessageCSS,
 } from './components/Menu';
 import { css as singleValueCSS } from './components/SingleValue';
 import {
@@ -36,8 +36,8 @@ export type Styles = {
   input?: Props => {},
   menu?: Props => {},
   menuList?: Props => {},
-  menuNoticeNoOptionsCSS?: Props => {},
-  menuNoticeLoadingCSS?: Props => {},
+  noOptionsMessageCSS?: Props => {},
+  loadingMessageCSS?: Props => {},
   multiValue?: Props => {},
   multiValueLabel?: Props => {},
   multiValueRemove?: Props => {},
@@ -59,8 +59,8 @@ export const defaultStyles: Styles = {
   input: inputCSS,
   menu: menuCSS,
   menuList: menuListCSS,
-  menuNoticeLoading: menuNoticeLoadingCSS,
-  menuNoticeNoOptions: menuNoticeNoOptionsCSS,
+  loadingMessage: loadingMessageCSS,
+  noOptionsMessage: noOptionsMessageCSS,
   multiValue: multiValueCSS,
   multiValueLabel: multiValueLabelCSS,
   multiValueRemove: multiValueRemoveCSS,

--- a/src/styles.js
+++ b/src/styles.js
@@ -11,7 +11,12 @@ import { css as indicatorCSS } from './components/indicators';
 import { css as inputCSS } from './components/Input';
 import { css as placeholderCSS } from './components/Placeholder';
 import { css as optionCSS } from './components/Option';
-import { menuCSS, menulistCSS } from './components/Menu';
+import {
+  menuCSS,
+  menuListCSS,
+  menuNoticeNoOptionsCSS,
+  menuNoticeLoadingCSS,
+} from './components/Menu';
 import { css as singleValueCSS } from './components/SingleValue';
 import {
   multiValueCSS,
@@ -30,7 +35,9 @@ export type Styles = {
   indicatorsContainer?: Props => {},
   input?: Props => {},
   menu?: Props => {},
-  menulist?: Props => {},
+  menuList?: Props => {},
+  menuNoticeNoOptionsCSS?: Props => {},
+  menuNoticeLoadingCSS?: Props => {},
   multiValue?: Props => {},
   multiValueLabel?: Props => {},
   multiValueRemove?: Props => {},
@@ -51,7 +58,9 @@ export const defaultStyles: Styles = {
   indicatorsContainer: indicatorsContainerCSS,
   input: inputCSS,
   menu: menuCSS,
-  menulist: menulistCSS,
+  menuList: menuListCSS,
+  menuNoticeLoading: menuNoticeLoadingCSS,
+  menuNoticeNoOptions: menuNoticeNoOptionsCSS,
   multiValue: multiValueCSS,
   multiValueLabel: multiValueLabelCSS,
   multiValueRemove: multiValueRemoveCSS,


### PR DESCRIPTION
Move text content to default children:
- `LoadingMessage`
- `NoOptionsMessage`

Expose styles for:
- `loadingMessage`
- `noOptionsMessage`