### PR TITLE
Isolate inner props

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -86,7 +86,7 @@ const Nav = props => (
         position: 'fixed',
         top: 0,
         width: '100%',
-        '-webkit-overflow-scrolling': 'touch',
+        WebkitOverflowScrolling: 'touch',
       },
 
       [largeDevice]: {

--- a/examples/pages/Home.js
+++ b/examples/pages/Home.js
@@ -1,8 +1,6 @@
 // @flow
-// @jsx glam
 
 import React, { Component } from 'react';
-import glam from 'glam';
 import { Code, Link, H1, Hr, Note } from '../components';
 import { withValue } from 'react-value';
 
@@ -12,12 +10,24 @@ import { colourOptions, groupedOptions } from '../data';
 const SelectWithValue = withValue(Select);
 type State = { isDisabled: boolean, isLoading: boolean };
 
+const changes = [
+  { icon: '🎨', text: 'CSS-in-JS with a complete styling API' },
+  {
+    icon: '🏗',
+    text: 'Replace any of the built-in rendering components',
+  },
+  {
+    icon: '🤖',
+    text: 'Simpler and more extensible; fewer properties',
+  },
+  { icon: '⚡️', text: 'Attention to performance' },
+];
 const List = ({ items }) => (
-  <ul css={{ listStyle: 'none', padding: 0 }}>
-    {items.map((i, j) => (
-      <li key={j} css={{ alignItems: 'center', display: 'flex ' }}>
-        <span css={{ marginRight: '0.5em' }}>{i.icon}</span>
-        <span css={{ fontSize: 14 }}>{i.text}</span>
+  <ul style={{ listStyle: 'none', padding: 0 }}>
+    {items.map(({ icon, text }, j) => (
+      <li key={j} style={{ alignItems: 'center', display: 'flex ' }}>
+        <span style={{ marginRight: '0.5em' }}>{icon}</span>
+        <span style={{ fontSize: 14 }}>{text}</span>
       </li>
     ))}
   </ul>
@@ -34,23 +44,10 @@ export default class Home extends Component<*, State> {
       <div>
         <H1>
           React Select v2{' '}
-          <small css={{ color: '#999', fontWeight: 500 }}>(alpha)</small>
+          <small style={{ color: '#999', fontWeight: 500 }}>(alpha)</small>
         </H1>
         <h4>Areas of improvement on v1:</h4>
-        <List
-          items={[
-            { icon: '🎨', text: 'CSS-in-JS with a complete styling API' },
-            {
-              icon: '🏗',
-              text: 'Replace any of the built-in rendering components',
-            },
-            {
-              icon: '🤖',
-              text: 'Simpler and more extensible; fewer properties',
-            },
-            { icon: '⚡️', text: 'Attention to performance' },
-          ]}
-        />
+        <List items={changes} />
         <h4>Try it out:</h4>
         <p>
           <Code>yarn add react-select@next</Code>

--- a/examples/pages/Tests.js
+++ b/examples/pages/Tests.js
@@ -28,12 +28,6 @@ export default class Tests extends Component<*, State> {
             isDisabled={this.state.isDisabled}
             isLoading={this.state.isLoading}
             options={colourOptions}
-            onFocus={() => {
-              console.log('Select Focused');
-            }}
-            onBlur={() => {
-              console.log('Select Blurred');
-            }}
           />
         </div>
         <Note Tag="label">

--- a/src/Select.js
+++ b/src/Select.js
@@ -563,7 +563,7 @@ export default class Select extends Component<Props, State> {
     this.input = input;
 
     // cache the input height to use when the select is disabled
-    if (input && !this.inputHeight) {
+    if (input) {
       this.inputHeight = input.clientHeight;
     }
   };

--- a/src/__tests__/__snapshots__/Select.js.snap
+++ b/src/__tests__/__snapshots__/Select.js.snap
@@ -3,8 +3,12 @@
 exports[`defaults 1`] = `
 <SelectContainer
   getStyles={[Function]}
+  innerProps={
+    Object {
+      "onKeyDown": [Function],
+    }
+  }
   isDisabled={false}
-  onKeyDown={[Function]}
 >
   <SROnly
     aria-atomic="true"
@@ -16,10 +20,14 @@ exports[`defaults 1`] = `
   </SROnly>
   <Control
     getStyles={[Function]}
-    innerRef={[Function]}
+    innerProps={
+      Object {
+        "innerRef": [Function],
+        "onMouseDown": [Function],
+      }
+    }
     isDisabled={false}
     isFocused={false}
-    onMouseDown={[Function]}
   >
     <ValueContainer
       getStyles={[Function]}

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -1,15 +1,26 @@
 // @flow
-import React from 'react';
+import React, { type Node } from 'react';
 
 import { className } from '../utils';
 import { Div } from '../primitives';
 import { borderRadius, colors, spacing } from '../theme';
-import { type PropsWithStyles } from '../types';
+import {
+  type InnerRef,
+  type PropsWithStyles,
+  type MouseEventHandler,
+} from '../types';
 
-type ControlProps = { isDisabled: boolean, isFocused: boolean };
-type Props = PropsWithStyles & ControlProps;
+type State = { isDisabled: boolean, isFocused: boolean };
+type Props = PropsWithStyles &
+  State & {
+    children: Node,
+    innerProps: {
+      onMouseDown: MouseEventHandler,
+      innerRef: InnerRef,
+    },
+  };
 
-export const css = ({ isDisabled, isFocused }: ControlProps) => ({
+export const css = ({ isDisabled, isFocused }: State) => ({
   alignItems: 'center',
   backgroundColor: isDisabled
     ? colors.neutral5
@@ -36,13 +47,15 @@ export const css = ({ isDisabled, isFocused }: ControlProps) => ({
 });
 
 const Control = (props: Props) => {
-  const { getStyles, isDisabled, isFocused, ...cleanProps } = props;
+  const { children, getStyles, isDisabled, isFocused, innerProps } = props;
   return (
     <Div
       className={className('control', { isDisabled, isFocused })}
       css={getStyles('control', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Div>
   );
 };
 

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -9,7 +9,12 @@ import { type PropsWithStyles } from '../types';
 
 type GroupProps = {
   children: Node,
-  components: { Heading: typeof GroupHeading },
+  Heading: typeof GroupHeading,
+  innerProps: {
+    'aria-expanded': boolean,
+    'aria-label': string,
+    role: 'group',
+  },
   label: string,
 };
 type Props = PropsWithStyles & GroupProps;
@@ -17,14 +22,12 @@ type Props = PropsWithStyles & GroupProps;
 export const groupCSS = () => paddingVertical(spacing.baseUnit * 2);
 
 const Group = (props: Props) => {
-  const { components, getStyles, children, label, ...cleanProps } = props;
-  const { Heading } = components;
+  const { children, getStyles, Heading, label, innerProps } = props;
   return (
     <Li
-      aria-label={label}
       className={className('group')}
       css={getStyles('group', props)}
-      {...cleanProps}
+      {...innerProps}
     >
       <Heading getStyles={getStyles}>{label}</Heading>
       <Ul>{children}</Ul>

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -12,20 +12,21 @@ import type { PropsWithInnerRef, PropsWithStyles } from '../types';
 type Props = PropsWithStyles & PropsWithInnerRef & { isHidden: boolean };
 
 export const css = () => marginHorizontal(spacing.baseUnit / 2);
+const inputStyle = isHidden => ({
+  background: 0,
+  border: 0,
+  fontSize: 'inherit',
+  opacity: isHidden ? 0 : 1,
+  outline: 0,
+  padding: 0,
+});
 
 const Input = ({ getStyles, innerRef, isHidden, ...props }: Props) => (
   <Div css={getStyles('input', props)}>
     <AutosizeInput
       className={className('input')}
       inputRef={innerRef}
-      inputStyle={{
-        background: 0,
-        border: 0,
-        padding: 0,
-        fontSize: 'inherit',
-        outline: 0,
-        opacity: isHidden ? 0 : 1,
-      }}
+      inputStyle={inputStyle(isHidden)}
       {...props}
     />
   </Div>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -5,7 +5,7 @@ import { className } from '../utils';
 import { Div, Ul } from '../primitives';
 import { borderRadius, colors, spacing } from '../theme';
 import { marginVertical, paddingHorizontal, paddingVertical } from '../mixins';
-import { type PropsWithStyles } from '../types';
+import { type PropsWithStyles, type InnerRef } from '../types';
 
 // ==============================
 // Menu
@@ -36,26 +36,37 @@ export default Menu;
 // Menu List
 // ==============================
 
-type MenuListProps = {
-  id: string,
+type MenuListState = {
   isMulti: boolean,
   maxHeight: number,
 };
-type Props = PropsWithStyles & MenuListProps;
-export const menuListCSS = ({ maxHeight }: MenuListProps) => ({
+
+type MenuListProps = {
+  children: Node,
+  innerProps: {
+    'aria-multiselectable': boolean,
+    id: string,
+    innerRef: InnerRef,
+    role: 'listbox',
+  },
+};
+type Props = PropsWithStyles & MenuListProps & MenuListState;
+export const menuListCSS = ({ maxHeight }: MenuListState) => ({
   maxHeight,
   overflowY: 'auto',
   ...paddingVertical(spacing.baseUnit),
   position: 'relative', // required for offset[Height, Top] > keyboard scroll
 });
 export const MenuList = (props: Props) => {
-  const { getStyles, isMulti, maxHeight, ...cleanProps } = props;
+  const { children, getStyles, isMulti, innerProps } = props;
   return (
     <Ul
       className={className('menu-list', { isMulti })}
       css={getStyles('menuList', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Ul>
   );
 };
 

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -14,8 +14,10 @@ export type ValueProps = {
   data: any,
   isDisabled: boolean,
   label: string,
-  onRemoveClick: any => void,
-  onRemoveMouseDown: any => void,
+  removeProps: {
+    onClick: any => void,
+    onMouseDown: any => void,
+  },
 };
 type Props = PropsWithStyles & ValueProps;
 
@@ -56,8 +58,7 @@ const MultiValue = (props: Props) => {
     getStyles,
     isDisabled,
     label,
-    onRemoveClick,
-    onRemoveMouseDown,
+    removeProps,
     ...cleanProps
   } = props;
   const cn = {
@@ -77,12 +78,7 @@ const MultiValue = (props: Props) => {
       <Label className={cn.label} css={css.label}>
         {children}
       </Label>
-      <Remove
-        className={cn.remove}
-        css={css.remove}
-        onClick={onRemoveClick}
-        onMouseDown={onRemoveMouseDown}
-      >
+      <Remove className={cn.remove} css={css.remove} {...removeProps}>
         <CrossIcon size={14} />
       </Remove>
     </Container>

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -1,16 +1,37 @@
 // @flow
-import React from 'react';
+import React, { type Node } from 'react';
 
-import type { OptionProps } from '../types';
 import { className } from '../utils';
 import { colors, spacing } from '../theme';
 import { Li } from '../primitives';
 import { paddingHorizontal, paddingVertical } from '../mixins';
-import { type PropsWithStyles } from '../types';
+import { type PropsWithStyles, type InnerRef } from '../types';
 
-type Props = PropsWithStyles & OptionProps;
+type State = {
+  isDisabled: boolean,
+  isFocused: boolean,
+  isSelected: boolean,
+};
+type InnerProps = {
+  'aria-selected': boolean,
+  id: string,
+  innerRef: InnerRef,
+  key: string,
+  onClick: MouseEventHandler,
+  onMouseOver: MouseEventHandler,
+  role: 'option',
+  tabIndex: number,
+};
+type Props = PropsWithStyles &
+  State & {
+    children: Node,
+    data: {},
+    innerProps: InnerProps,
+    label: string,
+    type: 'option',
+  };
 
-export const css = ({ isDisabled, isFocused, isSelected }: OptionProps) => ({
+export const css = ({ isDisabled, isFocused, isSelected }: State) => ({
   backgroundColor: isSelected
     ? colors.primary
     : isFocused ? colors.primaryLight : 'transparent',
@@ -26,20 +47,26 @@ export const css = ({ isDisabled, isFocused, isSelected }: OptionProps) => ({
 });
 
 const Option = (props: Props) => {
+  /* eslint-disable no-unused-vars */
   const {
-    data,
+    children,
+    data, // invalid DOM attr, must be removed before spreading
     getStyles,
-    isDisabled,
+    isDisabled, // invalid DOM attr, must be removed before spreading
     isFocused,
     isSelected,
-    ...cleanProps
+    innerProps,
   } = props;
+  /* eslint-enable no-unused-vars */
+
   return (
     <Li
       className={className('option', { isFocused, isSelected })}
       css={getStyles('option', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Li>
   );
 };
 

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -7,8 +7,8 @@ import { Div } from '../primitives';
 import { marginHorizontal } from '../mixins';
 import { type PropsWithStyles } from '../types';
 
-type PlaceholderProps = { isDisabled: boolean, isMulti: boolean };
-type Props = PropsWithStyles & PlaceholderProps;
+type State = { isDisabled: boolean, isMulti: boolean };
+type Props = PropsWithStyles & State;
 
 export const css = () => ({
   ...marginHorizontal(spacing.baseUnit / 2),

--- a/src/components/SingleValue.js
+++ b/src/components/SingleValue.js
@@ -7,29 +7,27 @@ import { colors, spacing } from '../theme';
 import { className } from '../utils';
 import { type PropsWithStyles } from '../types';
 
+type State = { isDisabled: boolean };
 type ValueProps = {
   children: string,
   data: any,
-  isDisabled: boolean,
 };
-type Props = PropsWithStyles & ValueProps;
+type Props = PropsWithStyles & ValueProps & State;
 
-export const css = ({ isDisabled }: ValueProps) => ({
+export const css = ({ isDisabled }: State) => ({
   ...marginHorizontal(spacing.baseUnit / 2),
   color: isDisabled ? colors.neutral40 : colors.text,
   position: 'absolute',
 });
 
 const SingleValue = (props: Props) => {
-  const { children, data, getStyles, isDisabled, ...cleanProps } = props;
+  const { data, getStyles, isDisabled, ...cleanProps } = props;
   return (
     <Div
       className={className('single-value', { isDisabled })}
       css={getStyles('singleValue', props)}
       {...cleanProps}
-    >
-      {children}
-    </Div>
+    />
   );
 };
 

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -1,32 +1,36 @@
 // @flow
-import React, { Component } from 'react';
+import React, { type Node, Component } from 'react';
 
 import { className } from '../utils';
 import { Div } from '../primitives';
 import { paddingHorizontal, paddingVertical } from '../mixins';
 import { spacing } from '../theme';
-import { type PropsWithStyles } from '../types';
+import { type PropsWithStyles, type KeyboardEventHandler } from '../types';
 
 // ==============================
 // Root Container
 // ==============================
 
-type ContainerProps = PropsWithStyles & {
-  isDisabled: boolean,
-  onKeyDown: (SyntheticKeyboardEvent<HTMLElement>) => void,
-};
-export const containerCSS = ({ isDisabled }: { isDisabled: boolean }) => ({
+type ContainerState = { isDisabled: boolean };
+type ContainerProps = PropsWithStyles &
+  ContainerState & {
+    children: Node,
+    innerProps: { onKeyDown: KeyboardEventHandler },
+  };
+export const containerCSS = ({ isDisabled }: ContainerState) => ({
   pointerEvents: isDisabled ? 'none' : 'initial', // cancel mouse events when disabled
   position: 'relative',
 });
 export const SelectContainer = (props: ContainerProps) => {
-  const { getStyles, isDisabled, ...cleanProps } = props;
+  const { children, getStyles, isDisabled, innerProps } = props;
   return (
     <Div
       css={getStyles('container', props)}
       className={className('container', { isDisabled })}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Div>
   );
 };
 

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -164,11 +164,7 @@ const LoadingIcon = ({ isFocused, size = 4 }: LoadingIconProps) => {
   );
 };
 
-export const LoadingIndicator = ({
-  children,
-  isFocused,
-  ...props
-}: IndicatorProps) => (
+export const LoadingIndicator = ({ isFocused, ...props }: IndicatorProps) => (
   <Indicator
     role="presentation"
     className={className(['indicator', 'loading-indicator'])}

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,5 @@
 // @flow
-
-type MouseEventHandler = (SyntheticMouseEvent<HTMLElement>) => void;
+import { type ElementRef } from 'react';
 
 export type OptionType = {
   [string]: any,
@@ -10,8 +9,15 @@ export type OptionsType = Array<OptionType>;
 
 export type ValueType = OptionType | OptionsType | null | void;
 
+export type FocusEventHandler = (SyntheticFocusEvent<HTMLElement>) => void;
+export type MouseEventHandler = (SyntheticMouseEvent<HTMLElement>) => void;
+export type KeyboardEventHandler = (
+  SyntheticKeyboardEvent<HTMLElement>
+) => void;
+
+export type InnerRef = ElementRef<typeof HTMLElement>;
 export type PropsWithInnerRef = {
-  innerRef: (?HTMLElement) => void,
+  innerRef: InnerRef,
 };
 export type PropsWithStyles = {
   getStyles: (string, any) => {},


### PR DESCRIPTION
Isolate properties necessary to functionality, making it simpler for consumers to pass the correct props to components if they are replaced.