### PR TITLE
[v2] Refactor internal component props

### DIFF
--- a/cypress/fixtures/selectors.json
+++ b/cypress/fixtures/selectors.json
@@ -6,9 +6,9 @@
   "menuMulti": "#react-select-4--listbox",
   "menuOption": "[role='option']",
   "menuSingle": "#react-select-2--listbox",
-  "multiSelectDefaultValues": ".css-1f99qyp.css-1ycyyax",
+  "multiSelectDefaultValues": "#cypress-multi .react-select__multi-value",
   "multiSelectInput": "#react-select-4--input",
-  "noOptionsValue": ".css-59b0oj.css-1ycyyax",
+  "noOptionsValue": ".react-select__menu-notice--no-options",
   "firstMultiValueRemove":
     "#cypress-multi .react-select__multi-value__remove:first",
   "singleGroupedInputValue":

--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -22,7 +22,7 @@ describe('New Select', function() {
           .get(selector.singleSelectDefaultValues)
           .should('have.length', 2)
           .get(selector.singleSelectFirstValue)
-          .should('contain', 'Red');
+          .should('contain', 'Ocean');
       });
       it('Should clear the default value ' + view, function() {
         cy
@@ -142,7 +142,7 @@ describe('New Select', function() {
             .get(selector.menuMulti)
             .should('be.visible')
             .get(selector.menuOption)
-            .contains('Purple')
+            .contains('Orange')
             .click()
             .get(selector.toggleMenuMulti)
             .click()
@@ -151,16 +151,16 @@ describe('New Select', function() {
             .click()
             .get(selector.multiSelectInput)
             .click({ force: true })
-            .type('Grey', { force: true })
+            .type('Slate', { force: true })
             .type('{enter}', { force: true })
             .get(selector.multiSelectDefaultValues)
             .then(function($defaultValue) {
               expect($defaultValue).to.have.length(5);
-              expect($defaultValue.eq(0)).to.contain('Blue');
-              expect($defaultValue.eq(1)).to.contain('Green');
-              expect($defaultValue.eq(2)).to.contain('Purple');
+              expect($defaultValue.eq(0)).to.contain('Purple');
+              expect($defaultValue.eq(1)).to.contain('Red');
+              expect($defaultValue.eq(2)).to.contain('Orange');
               expect($defaultValue.eq(3)).to.contain('Yellow');
-              expect($defaultValue.eq(4)).to.contain('Grey');
+              expect($defaultValue.eq(4)).to.contain('Slate');
             });
         }
       );

--- a/examples/data.js
+++ b/examples/data.js
@@ -3,7 +3,7 @@ export const colourOptions = [
   { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },
   { value: 'red', label: 'Red', color: '#FF5630' },
-  { value: 'ochre', label: 'Ochre', color: '#FF8B00' },
+  { value: 'orange', label: 'Orange', color: '#FF8B00' },
   { value: 'yellow', label: 'Yellow', color: '#FFC400' },
   { value: 'green', label: 'Green', color: '#36B37E' },
   { value: 'forest', label: 'Forest', color: '#00875A' },

--- a/src/Select.js
+++ b/src/Select.js
@@ -339,6 +339,7 @@ export default class Select extends Component<Props, State> {
   }
   getStyles = (key: string, props: {}): {} => {
     const base = defaultStyles[key](props);
+    base.boxSizing = 'border-box';
     const custom = this.props.styles[key];
     return custom ? custom(base, props) : base;
   };

--- a/src/Select.js
+++ b/src/Select.js
@@ -1,7 +1,6 @@
 // @flow
-// @jsx glam
+
 import React, { Component, type ElementRef, type Node } from 'react';
-import glam from 'glam';
 
 import { createFilter } from './filters';
 import { getOptionLabel, getOptionValue, isOptionDisabled } from './builtins';
@@ -702,7 +701,9 @@ export default class Select extends Component<Props, State> {
   };
   getActiveDescendentId = () => {
     const { focusedOption, menuIsOpen } = this.state;
-    return focusedOption && menuIsOpen ? this.getOptionId(focusedOption) : undefined;
+    return focusedOption && menuIsOpen
+      ? this.getOptionId(focusedOption)
+      : undefined;
   };
   renderScreenReaderStatus() {
     const { screenReaderStatus } = this.props;

--- a/src/Select.js
+++ b/src/Select.js
@@ -267,6 +267,7 @@ export default class Select extends Component<Props, State> {
       return {
         innerProps: {
           'aria-selected': isSelected,
+          id: this.getOptionId(option),
           onClick: onSelect,
           onMouseMove: onHover,
           onMouseOver: onHover,
@@ -696,11 +697,12 @@ export default class Select extends Component<Props, State> {
   getElementId = (element: 'input' | 'listbox' | 'option') => {
     return `${this.instancePrefix}-${element}`;
   };
+  getOptionId = (option: OptionType) => {
+    return `${this.getElementId('option')}-${this.getOptionValue(option)}`;
+  };
   getActiveDescendentId = () => {
     const { focusedOption, menuIsOpen } = this.state;
-    return menuIsOpen && focusedOption
-      ? `${this.getElementId('option')}-${this.getOptionValue(focusedOption)}`
-      : undefined;
+    return focusedOption && menuIsOpen ? this.getOptionId(focusedOption) : undefined;
   };
   renderScreenReaderStatus() {
     const { screenReaderStatus } = this.props;

--- a/src/Select.js
+++ b/src/Select.js
@@ -961,6 +961,7 @@ export default class Select extends Component<Props, State> {
         {...commonProps}
         innerProps={{
           onMouseDown: this.onMenuMouseDown,
+          onMouseMove: this.onMenuMouseMove,
         }}
         isLoading={isLoading}
       >

--- a/src/__tests__/__snapshots__/Select.js.snap
+++ b/src/__tests__/__snapshots__/Select.js.snap
@@ -2,13 +2,47 @@
 
 exports[`defaults 1`] = `
 <SelectContainer
+  clearValue={[Function]}
   getStyles={[Function]}
+  getValue={[Function]}
+  hasValue={false}
   innerProps={
     Object {
       "onKeyDown": [Function],
     }
   }
   isDisabled={false}
+  isFocused={false}
+  isMulti={false}
+  options={Array []}
+  selectOption={[Function]}
+  selectProps={
+    Object {
+      "backspaceRemovesValue": true,
+      "closeMenuOnSelect": true,
+      "components": Object {},
+      "escapeClearsValue": false,
+      "filterOption": [Function],
+      "getOptionLabel": [Function],
+      "getOptionValue": [Function],
+      "hideSelectedOptions": true,
+      "isClearable": true,
+      "isDisabled": false,
+      "isLoading": false,
+      "isMulti": false,
+      "isOptionDisabled": [Function],
+      "loadingMessage": [Function],
+      "maxMenuHeight": 300,
+      "maxValueHeight": 100,
+      "noOptionsMessage": [Function],
+      "options": Array [],
+      "placeholder": "Select...",
+      "screenReaderStatus": [Function],
+      "styles": Object {},
+      "tabSelectsValue": true,
+    }
+  }
+  setValue={[Function]}
 >
   <SROnly
     aria-atomic="true"
@@ -18,7 +52,10 @@ exports[`defaults 1`] = `
     0 results available.
   </SROnly>
   <Control
+    clearValue={[Function]}
     getStyles={[Function]}
+    getValue={[Function]}
+    hasValue={false}
     innerProps={
       Object {
         "innerRef": [Function],
@@ -27,18 +64,112 @@ exports[`defaults 1`] = `
     }
     isDisabled={false}
     isFocused={false}
+    isMulti={false}
+    options={Array []}
+    selectOption={[Function]}
+    selectProps={
+      Object {
+        "backspaceRemovesValue": true,
+        "closeMenuOnSelect": true,
+        "components": Object {},
+        "escapeClearsValue": false,
+        "filterOption": [Function],
+        "getOptionLabel": [Function],
+        "getOptionValue": [Function],
+        "hideSelectedOptions": true,
+        "isClearable": true,
+        "isDisabled": false,
+        "isLoading": false,
+        "isMulti": false,
+        "isOptionDisabled": [Function],
+        "loadingMessage": [Function],
+        "maxMenuHeight": 300,
+        "maxValueHeight": 100,
+        "noOptionsMessage": [Function],
+        "options": Array [],
+        "placeholder": "Select...",
+        "screenReaderStatus": [Function],
+        "styles": Object {},
+        "tabSelectsValue": true,
+      }
+    }
+    setValue={[Function]}
   >
     <ValueContainer
+      clearValue={[Function]}
       getStyles={[Function]}
+      getValue={[Function]}
       hasValue={false}
+      isDisabled={false}
       isMulti={false}
       maxHeight={100}
+      options={Array []}
+      selectOption={[Function]}
+      selectProps={
+        Object {
+          "backspaceRemovesValue": true,
+          "closeMenuOnSelect": true,
+          "components": Object {},
+          "escapeClearsValue": false,
+          "filterOption": [Function],
+          "getOptionLabel": [Function],
+          "getOptionValue": [Function],
+          "hideSelectedOptions": true,
+          "isClearable": true,
+          "isDisabled": false,
+          "isLoading": false,
+          "isMulti": false,
+          "isOptionDisabled": [Function],
+          "loadingMessage": [Function],
+          "maxMenuHeight": 300,
+          "maxValueHeight": 100,
+          "noOptionsMessage": [Function],
+          "options": Array [],
+          "placeholder": "Select...",
+          "screenReaderStatus": [Function],
+          "styles": Object {},
+          "tabSelectsValue": true,
+        }
+      }
+      setValue={[Function]}
     >
       <Placeholder
+        clearValue={[Function]}
         getStyles={[Function]}
+        getValue={[Function]}
+        hasValue={false}
         isDisabled={false}
         isMulti={false}
         key="placeholder"
+        options={Array []}
+        selectOption={[Function]}
+        selectProps={
+          Object {
+            "backspaceRemovesValue": true,
+            "closeMenuOnSelect": true,
+            "components": Object {},
+            "escapeClearsValue": false,
+            "filterOption": [Function],
+            "getOptionLabel": [Function],
+            "getOptionValue": [Function],
+            "hideSelectedOptions": true,
+            "isClearable": true,
+            "isDisabled": false,
+            "isLoading": false,
+            "isMulti": false,
+            "isOptionDisabled": [Function],
+            "loadingMessage": [Function],
+            "maxMenuHeight": 300,
+            "maxValueHeight": 100,
+            "noOptionsMessage": [Function],
+            "options": Array [],
+            "placeholder": "Select...",
+            "screenReaderStatus": [Function],
+            "styles": Object {},
+            "tabSelectsValue": true,
+          }
+        }
+        setValue={[Function]}
       >
         Select...
       </Placeholder>
@@ -65,13 +196,85 @@ exports[`defaults 1`] = `
       />
     </ValueContainer>
     <IndicatorsContainer
+      clearValue={[Function]}
       getStyles={[Function]}
+      getValue={[Function]}
+      hasValue={false}
+      isDisabled={false}
+      isMulti={false}
+      options={Array []}
+      selectOption={[Function]}
+      selectProps={
+        Object {
+          "backspaceRemovesValue": true,
+          "closeMenuOnSelect": true,
+          "components": Object {},
+          "escapeClearsValue": false,
+          "filterOption": [Function],
+          "getOptionLabel": [Function],
+          "getOptionValue": [Function],
+          "hideSelectedOptions": true,
+          "isClearable": true,
+          "isDisabled": false,
+          "isLoading": false,
+          "isMulti": false,
+          "isOptionDisabled": [Function],
+          "loadingMessage": [Function],
+          "maxMenuHeight": 300,
+          "maxValueHeight": 100,
+          "noOptionsMessage": [Function],
+          "options": Array [],
+          "placeholder": "Select...",
+          "screenReaderStatus": [Function],
+          "styles": Object {},
+          "tabSelectsValue": true,
+        }
+      }
+      setValue={[Function]}
     >
       <DropdownIndicator
+        clearValue={[Function]}
         getStyles={[Function]}
+        getValue={[Function]}
+        hasValue={false}
+        innerProps={
+          Object {
+            "onMouseDown": [Function],
+            "role": "button",
+          }
+        }
+        isDisabled={false}
         isFocused={false}
-        onMouseDown={[Function]}
-        role="button"
+        isMulti={false}
+        options={Array []}
+        selectOption={[Function]}
+        selectProps={
+          Object {
+            "backspaceRemovesValue": true,
+            "closeMenuOnSelect": true,
+            "components": Object {},
+            "escapeClearsValue": false,
+            "filterOption": [Function],
+            "getOptionLabel": [Function],
+            "getOptionValue": [Function],
+            "hideSelectedOptions": true,
+            "isClearable": true,
+            "isDisabled": false,
+            "isLoading": false,
+            "isMulti": false,
+            "isOptionDisabled": [Function],
+            "loadingMessage": [Function],
+            "maxMenuHeight": 300,
+            "maxValueHeight": 100,
+            "noOptionsMessage": [Function],
+            "options": Array [],
+            "placeholder": "Select...",
+            "screenReaderStatus": [Function],
+            "styles": Object {},
+            "tabSelectsValue": true,
+          }
+        }
+        setValue={[Function]}
       >
         <DownChevron />
       </DropdownIndicator>

--- a/src/animated/MultiValue.js
+++ b/src/animated/MultiValue.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { components } from '../components';
 import { Collapse, type fn } from './transitions';
 
-// strip transition props off before spreading onto select component
+// strip transition props off before spreading onto actual component
 type Props = {
   in: boolean,
   onExited: fn,

--- a/src/animated/transitions.js
+++ b/src/animated/transitions.js
@@ -31,10 +31,12 @@ export const Fade = ({
   return (
     <Transition mountOnEnter unmountOnExit in={inProp} timeout={duration}>
       {state => {
-        const style = {
-          ...transition[state],
+        const innerProps = {
+          style: {
+            ...transition[state],
+          }
         };
-        return <Tag style={style} {...props} />;
+        return <Tag innerProps={innerProps} {...props} />;
       }}
     </Transition>
   );
@@ -60,17 +62,24 @@ export class Collapse extends Component<CollapseProps, CollapseState> {
     exiting: { width: 0, transition: `width ${this.duration}ms ease-out` },
     exited: { width: 0 },
   };
+
+  // width must be calculated; cannot transition from `undefined` to `number`
   getWidth = (ref: ElementRef<*>) => {
     if (ref && isNaN(this.state.width)) {
       this.setState({ width: ref.offsetWidth });
     }
   };
+
+  // get base styles
   getStyle = (width: Width) => ({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     width,
   });
+
+  // get transition styles
   getTransition = (state: TransitionState) => this.transition[state];
+
   render() {
     const { children, in: inProp } = this.props;
     const { width } = this.state;

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -1,22 +1,18 @@
 // @flow
-import React, { type Node } from 'react';
+import React, { type ElementRef, type Node } from 'react';
 
 import { className } from '../utils';
 import { Div } from '../primitives';
 import { borderRadius, colors, spacing } from '../theme';
-import {
-  type InnerRef,
-  type PropsWithStyles,
-  type MouseEventHandler,
-} from '../types';
+import { type PropsWithStyles } from '../types';
 
 type State = { isDisabled: boolean, isFocused: boolean };
 type Props = PropsWithStyles &
   State & {
     children: Node,
     innerProps: {
-      onMouseDown: MouseEventHandler,
-      innerRef: InnerRef,
+      onMouseDown: (SyntheticMouseEvent<HTMLElement>) => void,
+      innerRef: (ElementRef<*>) => void,
     },
   };
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { type ElementRef } from 'react';
 import AutosizeInput from 'react-input-autosize';
 
 import { className } from '../utils';
@@ -7,9 +7,12 @@ import { spacing } from '../theme';
 import { Div } from '../primitives';
 import { marginHorizontal } from '../mixins';
 
-import type { PropsWithInnerRef, PropsWithStyles } from '../types';
+import type { PropsWithStyles } from '../types';
 
-type Props = PropsWithStyles & PropsWithInnerRef & { isHidden: boolean };
+type Props = PropsWithStyles & {
+  innerRef: (ElementRef<*>) => void,
+  isHidden: boolean,
+};
 
 export const css = () => marginHorizontal(spacing.baseUnit / 2);
 const inputStyle = isHidden => ({

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -92,16 +92,19 @@ export const loadingMessageCSS = noticeCSS;
 
 type NoticeProps = PropsWithStyles & {
   children: Node,
+  innerProps: { [string]: any },
 };
 
 export const NoOptionsMessage = (props: NoticeProps) => {
-  const { getStyles, ...cleanProps } = props;
+  const { children, getStyles, innerProps } = props;
   return (
     <Div
       className={className(['menu-notice', 'menu-notice--no-options'])}
       css={getStyles('noOptionsMessage', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Div>
   );
 };
 NoOptionsMessage.defaultProps = {
@@ -109,13 +112,15 @@ NoOptionsMessage.defaultProps = {
 };
 
 export const LoadingMessage = (props: NoticeProps) => {
-  const { getStyles, ...cleanProps } = props;
+  const { children, getStyles, innerProps } = props;
   return (
     <Div
       className={className(['menu-notice', 'menu-notice--loading'])}
       css={getStyles('loadingMessage', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Div>
   );
 };
 LoadingMessage.defaultProps = {

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -98,7 +98,7 @@ export const NoOptionsMessage = (props: NoticeProps) => {
   const { getStyles, ...cleanProps } = props;
   return (
     <Div
-      className={className('menu-notice menu-notice--no-options')}
+      className={className(['menu-notice', 'menu-notice--no-options'])}
       css={getStyles('noOptionsMessage', props)}
       {...cleanProps}
     />
@@ -112,7 +112,7 @@ export const LoadingMessage = (props: NoticeProps) => {
   const { getStyles, ...cleanProps } = props;
   return (
     <Div
-      className={className('menu-notice menu-notice--loading')}
+      className={className(['menu-notice', 'menu-notice--loading'])}
       css={getStyles('loadingMessage', props)}
       {...cleanProps}
     />

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -11,9 +11,8 @@ import { type PropsWithStyles } from '../types';
 export type ValueProps = {
   children: Node,
   components: any,
-  data: any,
+  innerProps: any,
   isDisabled: boolean,
-  label: string,
   removeProps: {
     onClick: any => void,
     onMouseDown: any => void,
@@ -54,12 +53,10 @@ const MultiValue = (props: Props) => {
   const {
     children,
     components,
-    data,
     getStyles,
+    innerProps,
     isDisabled,
-    label,
     removeProps,
-    ...cleanProps
   } = props;
   const cn = {
     container: className('multi-value', { isDisabled }),
@@ -74,7 +71,7 @@ const MultiValue = (props: Props) => {
   const { Container, Label, Remove } = components;
 
   return (
-    <Container className={cn.container} css={css.container} {...cleanProps}>
+    <Container className={cn.container} css={css.container} {...innerProps}>
       <Label className={cn.label} css={css.label}>
         {children}
       </Label>

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -25,7 +25,6 @@ type InnerProps = {
 type Props = PropsWithStyles &
   State & {
     children: Node,
-    data: {},
     innerProps: InnerProps,
     label: string,
     type: 'option',
@@ -47,17 +46,7 @@ export const css = ({ isDisabled, isFocused, isSelected }: State) => ({
 });
 
 const Option = (props: Props) => {
-  /* eslint-disable no-unused-vars */
-  const {
-    children,
-    data, // invalid DOM attr, must be removed before spreading
-    getStyles,
-    isDisabled, // invalid DOM attr, must be removed before spreading
-    isFocused,
-    isSelected,
-    innerProps,
-  } = props;
-  /* eslint-enable no-unused-vars */
+  const { children, getStyles, isFocused, isSelected, innerProps } = props;
 
   return (
     <Li

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -9,6 +9,7 @@ import { type PropsWithStyles } from '../types';
 
 type Props = PropsWithStyles & {
   children: Node,
+  innerProps: { [string]: any },
 };
 
 export const css = () => ({
@@ -18,11 +19,12 @@ export const css = () => ({
 });
 
 const Placeholder = (props: Props) => {
-  const { children, getStyles } = props;
+  const { children, getStyles, innerProps } = props;
   return (
     <Div
       className={className('placeholder')}
       css={getStyles('placeholder', props)}
+      {...innerProps}
     >
       {children}
     </Div>

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { type Node } from 'react';
 
 import { className } from '../utils';
 import { colors, spacing } from '../theme';
@@ -7,8 +7,9 @@ import { Div } from '../primitives';
 import { marginHorizontal } from '../mixins';
 import { type PropsWithStyles } from '../types';
 
-type State = { isDisabled: boolean, isMulti: boolean };
-type Props = PropsWithStyles & State;
+type Props = PropsWithStyles & {
+  children: Node,
+};
 
 export const css = () => ({
   ...marginHorizontal(spacing.baseUnit / 2),
@@ -17,13 +18,14 @@ export const css = () => ({
 });
 
 const Placeholder = (props: Props) => {
-  const { getStyles, isDisabled, isMulti, ...cleanProps } = props;
+  const { children, getStyles } = props;
   return (
     <Div
       className={className('placeholder')}
       css={getStyles('placeholder', props)}
-      {...cleanProps}
-    />
+    >
+      {children}
+    </Div>
   );
 };
 

--- a/src/components/SingleValue.js
+++ b/src/components/SingleValue.js
@@ -11,6 +11,7 @@ type State = { isDisabled: boolean };
 type ValueProps = {
   children: string,
   data: any,
+  innerProps: any,
 };
 type Props = PropsWithStyles & ValueProps & State;
 
@@ -21,13 +22,15 @@ export const css = ({ isDisabled }: State) => ({
 });
 
 const SingleValue = (props: Props) => {
-  const { data, getStyles, isDisabled, ...cleanProps } = props;
+  const { children, getStyles, isDisabled, innerProps } = props;
   return (
     <Div
       className={className('single-value', { isDisabled })}
       css={getStyles('singleValue', props)}
-      {...cleanProps}
-    />
+      {...innerProps}
+    >
+      {children}
+    </Div>
   );
 };
 

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -42,6 +42,8 @@ type ValueContainerProps = PropsWithStyles & {
   isMulti: boolean,
   hasValue: boolean,
   maxHeight: number,
+  innerProps: any,
+  children: Node,
 };
 export const valueContainerCSS = ({ maxHeight }: ValueContainerProps) => ({
   alignItems: 'baseline',
@@ -67,7 +69,7 @@ export class ValueContainer extends Component<ValueContainerProps> {
     if (!this.props.isMulti) return;
 
     // ensure we're showing items being added by forcing scroll to the bottom
-    if (this.shouldScrollBottom) {
+    if (this.shouldScrollBottom && this.node) {
       this.node.scrollTop = this.node.scrollHeight;
     }
   }
@@ -75,21 +77,16 @@ export class ValueContainer extends Component<ValueContainerProps> {
     this.node = ref;
   };
   render() {
-    const {
-      isMulti,
-      getStyles,
-      hasValue,
-      maxHeight, // Unused var: invalid DOM attribute, React will warn if not removed
-      ...cleanProps
-    } = this.props;
+    const { children, isMulti, getStyles, hasValue } = this.props;
 
     return (
       <Div
         innerRef={isMulti ? this.getScrollContainer : null}
         className={className('value-container', { isMulti, hasValue })}
         css={getStyles('valueContainer', this.props)}
-        {...cleanProps}
-      />
+      >
+        {children}
+      </Div>
     );
   }
 }
@@ -97,20 +94,21 @@ export class ValueContainer extends Component<ValueContainerProps> {
 // ==============================
 // Indicator Container
 // ==============================
-
+type IndicatorsContainerProps = PropsWithStyles & {
+  children: Node,
+};
 export const indicatorsContainerCSS = () => ({
   display: 'flex ',
   flexShrink: 0,
 });
-export const IndicatorsContainer = ({
-  getStyles,
-  ...props
-}: PropsWithStyles) => {
+export const IndicatorsContainer = (props: IndicatorsContainerProps) => {
+  const { children, getStyles } = props;
   return (
     <Div
       className={className('indicators')}
       css={getStyles('indicatorsContainer', props)}
-      {...props}
-    />
+    >
+      {children}
+    </Div>
   );
 };

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -42,7 +42,6 @@ type ValueContainerProps = PropsWithStyles & {
   isMulti: boolean,
   hasValue: boolean,
   maxHeight: number,
-  innerProps: any,
   children: Node,
 };
 export const valueContainerCSS = ({ maxHeight }: ValueContainerProps) => ({

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -75,31 +75,34 @@ export const css = ({ isFocused }: IndicatorProps) => ({
   },
 });
 
-const Indicator = (props: IndicatorProps) => {
+export const DropdownIndicator = (props: IndicatorProps) => {
   const { children, getStyles, innerProps } = props;
   return (
-    <Div css={getStyles('indicator', props)} {...innerProps}>
+    <Div
+      {...innerProps}
+      css={getStyles('indicator', props)}
+      className={className(['indicator', 'dropdown-indicator'])}
+    >
       {children}
     </Div>
   );
 };
-
-export const DropdownIndicator = (props: IndicatorProps) => (
-  <Indicator
-    {...props}
-    className={className(['indicator', 'dropdown-indicator'])}
-  />
-);
 DropdownIndicator.defaultProps = {
   children: <DownChevron />,
 };
 
-export const ClearIndicator = (props: IndicatorProps) => (
-  <Indicator
-    {...props}
-    className={className(['indicator', 'clear-indicator'])}
-  />
-);
+export const ClearIndicator = (props: IndicatorProps) => {
+  const { children, getStyles, innerProps } = props;
+  return (
+    <Div
+      {...innerProps}
+      css={getStyles('indicator', props)}
+      className={className(['indicator', 'clear-indicator'])}
+    >
+      {children}
+    </Div>
+  );
+};
 ClearIndicator.defaultProps = {
   children: <CrossIcon />,
 };
@@ -167,11 +170,15 @@ const LoadingIcon = ({ isFocused, size = 4 }: LoadingIconProps) => {
   );
 };
 
-export const LoadingIndicator = (props: IndicatorProps) => (
-  <Indicator
-    {...props}
-    className={className(['indicator', 'loading-indicator'])}
-  >
-    <LoadingIcon isFocused={props.isFocused} />
-  </Indicator>
-);
+export const LoadingIndicator = (props: IndicatorProps) => {
+  const { getStyles, innerProps } = props;
+  return (
+    <Div
+      {...innerProps}
+      css={getStyles('indicator', props)}
+      className={className(['indicator', 'loading-indicator'])}
+    >
+      <LoadingIcon isFocused={props.isFocused} />
+    </Div>
+  );
+};

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -57,6 +57,7 @@ export const DownChevron = (props: any) => (
 type IndicatorProps = PropsWithStyles & {
   children: ElementType,
   isFocused: boolean,
+  innerProps: any,
 };
 
 export const css = ({ isFocused }: IndicatorProps) => ({
@@ -75,26 +76,29 @@ export const css = ({ isFocused }: IndicatorProps) => ({
 });
 
 const Indicator = (props: IndicatorProps) => {
-  const { getStyles, isFocused, ...cleanProps } = props;
-  return <Div css={getStyles('indicator', props)} {...cleanProps} />;
+  const { children, getStyles, innerProps } = props;
+  return (
+    <Div css={getStyles('indicator', props)} {...innerProps}>
+      {children}
+    </Div>
+  );
 };
 
-export const DropdownIndicator = ({ children, ...props }: IndicatorProps) => (
+export const DropdownIndicator = (props: IndicatorProps) => (
   <Indicator
-    className={className(['indicator', 'dropdown-indicator'])}
     {...props}
-  >
-    {children}
-  </Indicator>
+    className={className(['indicator', 'dropdown-indicator'])}
+  />
 );
 DropdownIndicator.defaultProps = {
   children: <DownChevron />,
 };
 
-export const ClearIndicator = ({ children, ...props }: IndicatorProps) => (
-  <Indicator className={className(['indicator', 'clear-indicator'])} {...props}>
-    {children}
-  </Indicator>
+export const ClearIndicator = (props: IndicatorProps) => (
+  <Indicator
+    {...props}
+    className={className(['indicator', 'clear-indicator'])}
+  />
 );
 ClearIndicator.defaultProps = {
   children: <CrossIcon />,
@@ -106,7 +110,7 @@ ClearIndicator.defaultProps = {
 
 const keyframesName = 'react-select-loading-indicator';
 
-const LoadingContainer = ({ size, ...props }: { size: number }) => (
+const LoadingContainer = ({ size }: { size: number }) => (
   <Div
     css={{
       alignSelf: 'center',
@@ -116,7 +120,6 @@ const LoadingContainer = ({ size, ...props }: { size: number }) => (
       textAlign: 'center',
       verticalAlign: 'middle',
     }}
-    {...props}
   />
 );
 type DotProps = { color: string, delay: number, offset: boolean };
@@ -164,12 +167,11 @@ const LoadingIcon = ({ isFocused, size = 4 }: LoadingIconProps) => {
   );
 };
 
-export const LoadingIndicator = ({ isFocused, ...props }: IndicatorProps) => (
+export const LoadingIndicator = (props: IndicatorProps) => (
   <Indicator
-    role="presentation"
-    className={className(['indicator', 'loading-indicator'])}
     {...props}
+    className={className(['indicator', 'loading-indicator'])}
   >
-    <LoadingIcon isFocused={isFocused} />
+    <LoadingIcon isFocused={props.isFocused} />
   </Indicator>
 );

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export const Base = ({ css, innerRef, tag: Tag, ...props }: Props) => (
-  <Tag ref={innerRef} css={{ boxSizing: 'border-box', ...css }} {...props} />
+  <Tag ref={innerRef} css={css} {...props} />
 );
 
 export const Button = (props: {}) => <Base tag="button" {...props} />;

--- a/src/types.js
+++ b/src/types.js
@@ -19,8 +19,21 @@ export type InnerRef = ElementRef<typeof HTMLElement>;
 export type PropsWithInnerRef = {
   innerRef: InnerRef,
 };
+
 export type PropsWithStyles = {
   getStyles: (string, any) => {},
+};
+
+export type CommonProps = {
+  clearValue: () => void,
+  getStyles: (string, any) => {},
+  getValue: () => ValueType,
+  hasValue: boolean,
+  isMulti: boolean,
+  options: OptionsType,
+  selectOption: OptionType => void,
+  selectProps: any,
+  setValue: (ValueType, ActionTypes) => void,
 };
 
 export type ActionTypes =


### PR DESCRIPTION
I've refactored the props that are passed to the internal components, including:

- More consistently passing `innerProps` to all components
- Creating and passing `commonProps` to all components on render, so we can ensure consistency around the API

This is a pretty big change and has some rough edges, so will need review and testing before merge.