### PR TITLE
V2 RTL support and edge detection for the menu

### DIFF
--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -27,8 +27,8 @@ describe('New Select', function() {
       it('Should clear the default value ' + view, function() {
         cy
           .get(selector.clearValues)
-          .should('have.length', 3)
-          .click({ multiple: true })
+          .should('have.length', 1)
+          .click()
           .each(function(element) {
             expect(element).to.not.be.visible; // eslint-disable-line no-unused-expressions
           });

--- a/examples/pages/Home.js
+++ b/examples/pages/Home.js
@@ -8,7 +8,6 @@ import Select from '../../src';
 import { colourOptions, groupedOptions } from '../data';
 
 const SelectWithValue = withValue(Select);
-type State = { isDisabled: boolean, isLoading: boolean };
 
 const changes = [
   { icon: '🎨', text: 'CSS-in-JS with a complete styling API' },
@@ -57,12 +56,27 @@ const formatGroupLabel = data => (
   </div>
 );
 
+type State = {
+  isClearable: boolean,
+  isDisabled: boolean,
+  isLoading: boolean,
+  isRtl: boolean,
+};
+
 export default class Home extends Component<*, State> {
-  state = { isDisabled: false, isLoading: false };
+  state = {
+    isClearable: false,
+    isDisabled: false,
+    isLoading: false,
+    isRtl: false,
+  };
+  toggleClearable = () =>
+    this.setState(state => ({ isClearable: !state.isClearable }));
   toggleDisabled = () =>
     this.setState(state => ({ isDisabled: !state.isDisabled }));
   toggleLoading = () =>
     this.setState(state => ({ isLoading: !state.isLoading }));
+  toggleRtl = () => this.setState(state => ({ isRtl: !state.isRtl }));
   render() {
     return (
       <div>
@@ -98,8 +112,10 @@ export default class Home extends Component<*, State> {
           <SelectWithValue
             autoFocus
             defaultValue={colourOptions[0]}
+            isClearable={this.state.isClearable}
             isDisabled={this.state.isDisabled}
             isLoading={this.state.isLoading}
+            isRtl={this.state.isRtl}
             name="color"
             options={colourOptions}
             onFocus={() => {
@@ -111,12 +127,20 @@ export default class Home extends Component<*, State> {
           />
         </div>
         <Note Tag="label">
+          <input type="checkbox" onChange={this.toggleClearable} />
+          Clearable
+        </Note>
+        <Note Tag="label" style={{ marginLeft: '1em' }}>
           <input type="checkbox" onChange={this.toggleDisabled} />
           Disabled
         </Note>
         <Note Tag="label" style={{ marginLeft: '1em' }}>
           <input type="checkbox" onChange={this.toggleLoading} />
           Loading
+        </Note>
+        <Note Tag="label" style={{ marginLeft: '1em' }}>
+          <input type="checkbox" onChange={this.toggleRtl} />
+          RTL
         </Note>
         <h4>Grouped</h4>
         <div>

--- a/src/Select.js
+++ b/src/Select.js
@@ -83,6 +83,8 @@ type Props = {
   isOptionSelected?: (OptionType, OptionsType) => boolean,
   /* Support multiple selected options */
   isMulti: boolean,
+  /* Is the select direction right-to-left */
+  isRtl: boolean,
   /* Async: Text to display when loading options */
   loadingMessage: ({ inputValue: string }) => string,
   /* Maximum height of the menu before scrolling */
@@ -127,10 +129,11 @@ const defaultProps = {
   getOptionLabel: getOptionLabel,
   getOptionValue: getOptionValue,
   hideSelectedOptions: true,
-  isClearable: true,
+  isClearable: false,
   isDisabled: false,
   isLoading: false,
   isMulti: false,
+  isRtl: false,
   isOptionDisabled: isOptionDisabled,
   loadingMessage: () => 'Loading...',
   maxMenuHeight: 300,
@@ -368,6 +371,9 @@ export default class Select extends Component<Props, State> {
   countOptions() {
     return this.state.menuOptions.focusable.length;
   }
+  isClearable(): boolean {
+    return this.props.isClearable || this.props.isMulti;
+  }
   isOptionDisabled(option: OptionType): boolean {
     return typeof this.props.isOptionDisabled === 'function'
       ? this.props.isOptionDisabled(option)
@@ -517,7 +523,6 @@ export default class Select extends Component<Props, State> {
   onKeyDown = (event: SyntheticKeyboardEvent<HTMLElement>) => {
     const {
       backspaceRemovesValue,
-      isClearable,
       escapeClearsValue,
       isDisabled,
       onKeyDown,
@@ -564,7 +569,7 @@ export default class Select extends Component<Props, State> {
             menuIsOpen: false,
             ...this.buildStateForInputValue(),
           });
-        } else if (isClearable && escapeClearsValue) {
+        } else if (this.isClearable() && escapeClearsValue) {
           this.clearValue();
         }
         break;
@@ -820,11 +825,11 @@ export default class Select extends Component<Props, State> {
   renderClearIndicator() {
     const { ClearIndicator } = this.components;
     const { commonProps } = this;
-    const { isClearable, isDisabled, isLoading } = this.props;
+    const { isDisabled, isLoading } = this.props;
     const { isFocused } = this.state;
 
     if (
-      !isClearable ||
+      !this.isClearable() ||
       !ClearIndicator ||
       isDisabled ||
       !this.hasValue() ||
@@ -860,6 +865,24 @@ export default class Select extends Component<Props, State> {
 
     return (
       <LoadingIndicator
+        {...commonProps}
+        innerProps={innerProps}
+        isDisabled={isDisabled}
+        isFocused={isFocused}
+      />
+    );
+  }
+  renderIndicatorSeparator() {
+    const { IndicatorSeparator } = this.components;
+    if (!IndicatorSeparator) return null;
+    const { commonProps } = this;
+    const { isDisabled } = this.props;
+    const { isFocused } = this.state;
+
+    const innerProps = { role: 'presentation' };
+
+    return (
+      <IndicatorSeparator
         {...commonProps}
         innerProps={innerProps}
         isDisabled={isDisabled}
@@ -1028,7 +1051,7 @@ export default class Select extends Component<Props, State> {
   }
   getCommonProps() {
     const { clearValue, getStyles, setValue, selectOption, props } = this;
-    const { isMulti, options } = props;
+    const { isMulti, isRtl, options } = props;
     const { selectValue } = this.state;
     const hasValue = this.hasValue();
     const getValue = () => selectValue;
@@ -1038,6 +1061,7 @@ export default class Select extends Component<Props, State> {
       getValue,
       hasValue,
       isMulti,
+      isRtl,
       options,
       selectOption,
       setValue,
@@ -1088,6 +1112,7 @@ export default class Select extends Component<Props, State> {
           <IndicatorsContainer {...commonProps} isDisabled={isDisabled}>
             {this.renderClearIndicator()}
             {this.renderLoadingIndicator()}
+            {this.renderIndicatorSeparator()}
             {this.renderDropdownIndicator()}
           </IndicatorsContainer>
         </Control>

--- a/src/__tests__/__snapshots__/Select.js.snap
+++ b/src/__tests__/__snapshots__/Select.js.snap
@@ -14,6 +14,7 @@ exports[`defaults 1`] = `
   isDisabled={false}
   isFocused={false}
   isMulti={false}
+  isRtl={false}
   options={Array []}
   selectOption={[Function]}
   selectProps={
@@ -27,11 +28,12 @@ exports[`defaults 1`] = `
       "getOptionLabel": [Function],
       "getOptionValue": [Function],
       "hideSelectedOptions": true,
-      "isClearable": true,
+      "isClearable": false,
       "isDisabled": false,
       "isLoading": false,
       "isMulti": false,
       "isOptionDisabled": [Function],
+      "isRtl": false,
       "loadingMessage": [Function],
       "maxMenuHeight": 300,
       "maxValueHeight": 100,
@@ -66,6 +68,7 @@ exports[`defaults 1`] = `
     isDisabled={false}
     isFocused={false}
     isMulti={false}
+    isRtl={false}
     options={Array []}
     selectOption={[Function]}
     selectProps={
@@ -79,11 +82,12 @@ exports[`defaults 1`] = `
         "getOptionLabel": [Function],
         "getOptionValue": [Function],
         "hideSelectedOptions": true,
-        "isClearable": true,
+        "isClearable": false,
         "isDisabled": false,
         "isLoading": false,
         "isMulti": false,
         "isOptionDisabled": [Function],
+        "isRtl": false,
         "loadingMessage": [Function],
         "maxMenuHeight": 300,
         "maxValueHeight": 100,
@@ -104,6 +108,7 @@ exports[`defaults 1`] = `
       hasValue={false}
       isDisabled={false}
       isMulti={false}
+      isRtl={false}
       maxHeight={100}
       options={Array []}
       selectOption={[Function]}
@@ -118,11 +123,12 @@ exports[`defaults 1`] = `
           "getOptionLabel": [Function],
           "getOptionValue": [Function],
           "hideSelectedOptions": true,
-          "isClearable": true,
+          "isClearable": false,
           "isDisabled": false,
           "isLoading": false,
           "isMulti": false,
           "isOptionDisabled": [Function],
+          "isRtl": false,
           "loadingMessage": [Function],
           "maxMenuHeight": 300,
           "maxValueHeight": 100,
@@ -143,6 +149,7 @@ exports[`defaults 1`] = `
         hasValue={false}
         isDisabled={false}
         isMulti={false}
+        isRtl={false}
         key="placeholder"
         options={Array []}
         selectOption={[Function]}
@@ -157,11 +164,12 @@ exports[`defaults 1`] = `
             "getOptionLabel": [Function],
             "getOptionValue": [Function],
             "hideSelectedOptions": true,
-            "isClearable": true,
+            "isClearable": false,
             "isDisabled": false,
             "isLoading": false,
             "isMulti": false,
             "isOptionDisabled": [Function],
+            "isRtl": false,
             "loadingMessage": [Function],
             "maxMenuHeight": 300,
             "maxValueHeight": 100,
@@ -206,6 +214,7 @@ exports[`defaults 1`] = `
       hasValue={false}
       isDisabled={false}
       isMulti={false}
+      isRtl={false}
       options={Array []}
       selectOption={[Function]}
       selectProps={
@@ -219,11 +228,12 @@ exports[`defaults 1`] = `
           "getOptionLabel": [Function],
           "getOptionValue": [Function],
           "hideSelectedOptions": true,
-          "isClearable": true,
+          "isClearable": false,
           "isDisabled": false,
           "isLoading": false,
           "isMulti": false,
           "isOptionDisabled": [Function],
+          "isRtl": false,
           "loadingMessage": [Function],
           "maxMenuHeight": 300,
           "maxValueHeight": 100,
@@ -237,6 +247,52 @@ exports[`defaults 1`] = `
       }
       setValue={[Function]}
     >
+      <IndicatorSeparator
+        clearValue={[Function]}
+        getStyles={[Function]}
+        getValue={[Function]}
+        hasValue={false}
+        innerProps={
+          Object {
+            "role": "presentation",
+          }
+        }
+        isDisabled={false}
+        isFocused={false}
+        isMulti={false}
+        isRtl={false}
+        options={Array []}
+        selectOption={[Function]}
+        selectProps={
+          Object {
+            "backspaceRemovesValue": true,
+            "closeMenuOnSelect": true,
+            "components": Object {},
+            "escapeClearsValue": false,
+            "filterOption": [Function],
+            "formatGroupLabel": [Function],
+            "getOptionLabel": [Function],
+            "getOptionValue": [Function],
+            "hideSelectedOptions": true,
+            "isClearable": false,
+            "isDisabled": false,
+            "isLoading": false,
+            "isMulti": false,
+            "isOptionDisabled": [Function],
+            "isRtl": false,
+            "loadingMessage": [Function],
+            "maxMenuHeight": 300,
+            "maxValueHeight": 100,
+            "noOptionsMessage": [Function],
+            "options": Array [],
+            "placeholder": "Select...",
+            "screenReaderStatus": [Function],
+            "styles": Object {},
+            "tabSelectsValue": true,
+          }
+        }
+        setValue={[Function]}
+      />
       <DropdownIndicator
         clearValue={[Function]}
         getStyles={[Function]}
@@ -251,6 +307,7 @@ exports[`defaults 1`] = `
         isDisabled={false}
         isFocused={false}
         isMulti={false}
+        isRtl={false}
         options={Array []}
         selectOption={[Function]}
         selectProps={
@@ -264,11 +321,12 @@ exports[`defaults 1`] = `
             "getOptionLabel": [Function],
             "getOptionValue": [Function],
             "hideSelectedOptions": true,
-            "isClearable": true,
+            "isClearable": false,
             "isDisabled": false,
             "isLoading": false,
             "isMulti": false,
             "isOptionDisabled": [Function],
+            "isRtl": false,
             "loadingMessage": [Function],
             "maxMenuHeight": 300,
             "maxValueHeight": 100,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,7 +1,7 @@
 // @flow
-import React, { type Node } from 'react';
+import React, { Component, type ElementRef, type Node } from 'react';
 
-import { className } from '../utils';
+import { className, inViewport } from '../utils';
 import { Div } from '../primitives';
 import { borderRadius, colors, spacing } from '../theme';
 import { type PropsWithStyles, type InnerRef } from '../types';
@@ -11,31 +11,49 @@ import { type PropsWithStyles, type InnerRef } from '../types';
 // ==============================
 
 type MenuProps = PropsWithStyles & { children: Node, innerProps: Object };
+type MenuState = { placement: 'bottom' | 'top' };
 
-export const menuCSS = () => ({
+const placementToPosition = { bottom: 'top', top: 'bottom' };
+
+export const menuCSS = ({ placement }: MenuState) => ({
   backgroundColor: colors.neutral0,
   boxShadow: `0 0 0 1px ${colors.neutral10a}, 0 4px 11px ${colors.neutral10a}`,
   borderRadius: borderRadius,
   marginBottom: spacing.baseUnit * 2,
   marginTop: spacing.baseUnit * 2,
   position: 'absolute',
-  top: '100%',
   width: '100%',
   zIndex: 1,
+  [placementToPosition[placement]]: '100%',
 });
+const initialState = { placement: 'bottom' };
 
-const Menu = (props: MenuProps) => {
-  const { children, getStyles, innerProps } = props;
-  return (
-    <Div
-      className={className('menu')}
-      css={getStyles('menu', props)}
-      {...innerProps}
-    >
-      {children}
-    </Div>
-  );
-};
+export class Menu extends Component<MenuProps, MenuState> {
+  state = initialState;
+  getPlacement = (ref: ElementRef<*>) => {
+    if (!ref) return;
+
+    if (!inViewport(ref)) {
+      this.setState({ placement: 'top' });
+    }
+  };
+  render() {
+    const { children, getStyles, innerProps } = this.props;
+    const { placement } = this.state;
+    const shouldFlip = placement === 'top';
+
+    return (
+      <Div
+        className={className('menu', { shouldFlip })}
+        css={getStyles('menu', { ...this.props, ...this.state })}
+        innerRef={this.getPlacement}
+        {...innerProps}
+      >
+        {children}
+      </Div>
+    );
+  }
+}
 
 export default Menu;
 

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -10,22 +10,23 @@ import { type PropsWithStyles, type KeyboardEventHandler } from '../types';
 // Root Container
 // ==============================
 
-type ContainerState = { isDisabled: boolean };
+type ContainerState = { isDisabled: boolean, isRtl: boolean };
 type ContainerProps = PropsWithStyles &
   ContainerState & {
     children: Node,
     innerProps: { onKeyDown: KeyboardEventHandler },
   };
-export const containerCSS = ({ isDisabled }: ContainerState) => ({
-  pointerEvents: isDisabled ? 'none' : 'initial', // cancel mouse events when disabled
+export const containerCSS = ({ isDisabled, isRtl }: ContainerState) => ({
+  direction: isRtl ? 'rtl' : null,
+  pointerEvents: isDisabled ? 'none' : null, // cancel mouse events when disabled
   position: 'relative',
 });
 export const SelectContainer = (props: ContainerProps) => {
-  const { children, getStyles, isDisabled, innerProps } = props;
+  const { children, getStyles, innerProps, isDisabled, isRtl } = props;
   return (
     <Div
       css={getStyles('container', props)}
-      className={className('container', { isDisabled })}
+      className={className('container', { isDisabled, isRtl })}
       {...innerProps}
     >
       {children}
@@ -92,15 +93,19 @@ export class ValueContainer extends Component<ValueContainerProps> {
 // ==============================
 // Indicator Container
 // ==============================
-type IndicatorsContainerProps = PropsWithStyles & {
-  children: Node,
-};
+
+type IndicatorsState = { isRtl: boolean };
+type IndicatorsProps = PropsWithStyles & IndicatorsState & { children: Node };
+
 export const indicatorsContainerCSS = () => ({
+  alignItems: 'center',
+  alignSelf: 'stretch',
   display: 'flex ',
   flexShrink: 0,
 });
-export const IndicatorsContainer = (props: IndicatorsContainerProps) => {
+export const IndicatorsContainer = (props: IndicatorsProps) => {
   const { children, getStyles } = props;
+
   return (
     <Div
       className={className('indicators')}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ import {
   ClearIndicator,
   DropdownIndicator,
   LoadingIndicator,
+  IndicatorSeparator,
 } from './indicators';
 
 import Control from './Control';
@@ -30,6 +31,7 @@ export type SelectComponents = {
   Group: typeof Group,
   GroupHeading: typeof GroupHeading,
   IndicatorsContainer: typeof IndicatorsContainer,
+  IndicatorSeparator: typeof IndicatorSeparator,
   Input: typeof Input,
   LoadingIndicator: typeof LoadingIndicator,
   Menu: typeof Menu,
@@ -56,6 +58,7 @@ export const components: SelectComponents = {
   Group: Group,
   GroupHeading: GroupHeading,
   IndicatorsContainer: IndicatorsContainer,
+  IndicatorSeparator: IndicatorSeparator,
   Input: Input,
   LoadingIndicator: LoadingIndicator,
   Menu: Menu,

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -56,31 +56,29 @@ export const DownChevron = (props: any) => (
 
 type IndicatorProps = PropsWithStyles & {
   children: ElementType,
-  isFocused: boolean,
   innerProps: any,
+  isFocused: boolean,
+  isRtl: boolean,
 };
 
-export const css = ({ isFocused }: IndicatorProps) => ({
-  color: isFocused ? colors.text : colors.neutral20,
-  cursor: 'pointer',
+const baseCSS = ({ isFocused }: IndicatorProps) => ({
+  color: isFocused ? colors.neutral60 : colors.neutral20,
   display: 'flex ',
-  padding: '8px 2px',
-  transition: 'opacity 200ms',
-
-  ':first-child': { paddingLeft: spacing.baseUnit * 2 },
-  ':last-child': { paddingRight: spacing.baseUnit * 2 },
+  padding: spacing.baseUnit * 2,
+  transition: 'color 150ms',
 
   ':hover': {
-    color: isFocused ? colors.text : colors.neutral40,
+    color: isFocused ? colors.neutral100 : colors.neutral40,
   },
 });
 
+export const dropdownIndicatorCSS = baseCSS;
 export const DropdownIndicator = (props: IndicatorProps) => {
   const { children = <DownChevron />, getStyles, innerProps } = props;
   return (
     <Div
       {...innerProps}
-      css={getStyles('indicator', props)}
+      css={getStyles('dropdownIndicator', props)}
       className={className(['indicator', 'dropdown-indicator'])}
     >
       {children}
@@ -88,12 +86,13 @@ export const DropdownIndicator = (props: IndicatorProps) => {
   );
 };
 
+export const clearIndicatorCSS = baseCSS;
 export const ClearIndicator = (props: IndicatorProps) => {
   const { children = <CrossIcon />, getStyles, innerProps } = props;
   return (
     <Div
       {...innerProps}
-      css={getStyles('indicator', props)}
+      css={getStyles('clearIndicator', props)}
       className={className(['indicator', 'clear-indicator'])}
     >
       {children}
@@ -102,10 +101,35 @@ export const ClearIndicator = (props: IndicatorProps) => {
 };
 
 // ==============================
+// Separator
+// ==============================
+
+type SeparatorState = { isDisabled: boolean };
+export const indicatorSeparatorCSS = ({ isDisabled }: SeparatorState) => ({
+  alignSelf: 'stretch',
+  backgroundColor: isDisabled ? colors.neutral10 : colors.neutral20,
+  marginBottom: spacing.baseUnit * 2,
+  marginTop: spacing.baseUnit * 2,
+  width: 1,
+});
+export const IndicatorSeparator = (props: IndicatorProps) => {
+  const { getStyles, innerProps } = props;
+  return (
+    <Span
+      {...innerProps}
+      css={getStyles('indicatorSeparator', props)}
+      className={className('indicator-separator')}
+    />
+  );
+};
+
+// ==============================
 // Loading
 // ==============================
 
 const keyframesName = 'react-select-loading-indicator';
+
+export const loadingIndicatorCSS = baseCSS;
 
 const LoadingContainer = ({ size, ...props }: { size: number }) => (
   <Div
@@ -153,20 +177,20 @@ const loadingAnimation = (
 
 type LoadingIconProps = IndicatorProps & { isFocused: boolean, size: number };
 export const LoadingIndicator = (props: LoadingIconProps) => {
-  const { getStyles, isFocused, innerProps, size = 4 } = props;
+  const { getStyles, innerProps, isFocused, isRtl, size = 4 } = props;
   const clr = isFocused ? colors.text : colors.neutral20;
 
   return (
     <LoadingContainer
       {...innerProps}
-      css={getStyles('indicator', props)}
+      css={getStyles('loadingIndicator', props)}
       className={className(['indicator', 'loading-indicator'])}
       size={size}
     >
       {loadingAnimation}
-      <LoadingDot color={clr} />
+      <LoadingDot color={clr} offset={isRtl} />
       <LoadingDot color={clr} delay={160} offset />
-      <LoadingDot color={clr} delay={320} offset />
+      <LoadingDot color={clr} delay={320} offset={!isRtl} />
       <A11yText>Loading</A11yText>
     </LoadingContainer>
   );

--- a/src/styles.js
+++ b/src/styles.js
@@ -7,7 +7,12 @@ import {
 } from './components/containers';
 import { css as controlCSS } from './components/Control';
 import { groupCSS, groupHeadingCSS } from './components/Group';
-import { css as indicatorCSS } from './components/indicators';
+import {
+  clearIndicatorCSS,
+  dropdownIndicatorCSS,
+  loadingIndicatorCSS,
+  indicatorSeparatorCSS,
+} from './components/indicators';
 import { css as inputCSS } from './components/Input';
 import { css as placeholderCSS } from './components/Placeholder';
 import { css as optionCSS } from './components/Option';
@@ -27,20 +32,23 @@ import {
 type Props = { [key: string]: any };
 
 export type Styles = {
+  clearIndicator?: Props => {},
   container?: Props => {},
   control?: Props => {},
+  dropdownIndicator?: Props => {},
   group?: Props => {},
   groupHeading?: Props => {},
-  indicator?: Props => {},
   indicatorsContainer?: Props => {},
+  indicatorSeparator?: Props => {},
   input?: Props => {},
+  loadingIndicator?: Props => {},
+  loadingMessageCSS?: Props => {},
   menu?: Props => {},
   menuList?: Props => {},
-  noOptionsMessageCSS?: Props => {},
-  loadingMessageCSS?: Props => {},
   multiValue?: Props => {},
   multiValueLabel?: Props => {},
   multiValueRemove?: Props => {},
+  noOptionsMessageCSS?: Props => {},
   option?: Props => {},
   placeholder?: Props => {},
   singleValue?: Props => {},
@@ -50,20 +58,23 @@ export type StylesConfig = $Shape<Styles>;
 export type GetStyles = (string, Props) => {};
 
 export const defaultStyles: Styles = {
+  clearIndicator: clearIndicatorCSS,
   container: containerCSS,
   control: controlCSS,
+  dropdownIndicator: dropdownIndicatorCSS,
   group: groupCSS,
   groupHeading: groupHeadingCSS,
-  indicator: indicatorCSS,
   indicatorsContainer: indicatorsContainerCSS,
+  indicatorSeparator: indicatorSeparatorCSS,
   input: inputCSS,
+  loadingIndicator: loadingIndicatorCSS,
+  loadingMessage: loadingMessageCSS,
   menu: menuCSS,
   menuList: menuListCSS,
-  loadingMessage: loadingMessageCSS,
-  noOptionsMessage: noOptionsMessageCSS,
   multiValue: multiValueCSS,
   multiValueLabel: multiValueLabelCSS,
   multiValueRemove: multiValueRemoveCSS,
+  noOptionsMessage: noOptionsMessageCSS,
   option: optionCSS,
   placeholder: placeholderCSS,
   singleValue: singleValueCSS,

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,14 @@
 
 import type { OptionsType, ValueType } from './types';
 
+// ==============================
+// Class Name Prefixer
+// ==============================
+
 type State = { [key: string]: boolean };
 type List = Array<string>;
+
+export const CLASS_PREFIX = 'react-select';
 
 /**
  String representation of component state for styling with class names.
@@ -30,11 +36,19 @@ export function className(name: string | List, state?: State): string {
   return arr.map(cn => `${CLASS_PREFIX}__${cn}`).join(' ');
 }
 
+// ==============================
+// Clean Value
+// ==============================
+
 export const cleanValue = (value: ValueType): OptionsType => {
   if (Array.isArray(value)) return value.filter(Boolean);
   if (typeof value === 'object' && value !== null) return [value];
   return [];
 };
+
+// ==============================
+// Handle Input Change
+// ==============================
 
 export function handleInputChange(
   inputValue: string,
@@ -47,7 +61,9 @@ export function handleInputChange(
   return inputValue;
 }
 
-export const CLASS_PREFIX = 'react-select';
+// ==============================
+// Scroll Into View
+// ==============================
 
 export const scrollIntoView = (
   menuEl: HTMLElement,
@@ -73,3 +89,19 @@ export const scrollIntoView = (
 export const toKey = (str: string): string => {
   return str.replace(/\W/g, '-');
 };
+
+// ==============================
+// Is Element In the Viewport
+// ==============================
+
+export function inViewport(element: HTMLElement): boolean {
+  const { top, right, bottom, left } = element.getBoundingClientRect();
+  const docEl = document.documentElement;
+
+  return (
+    top >= 0 &&
+    left >= 0 &&
+    bottom <= (window.innerHeight || (docEl && docEl.clientHeight) || 0) &&
+    right <= (window.innerWidth || (docEl && docEl.clientWidth) || 0)
+  );
+}


### PR DESCRIPTION
- split indicator styles into their respective components and cleaned up a bit
- added indicator separator for better affordance
- `isClearable` now defaults to `false` for single select and `true` for multi
- edge detection for the menu, which now renders above the control when there isn't enough space beneath