### PR TITLE
V2 menuIsOpen, inputValue as controllabe props

### DIFF
--- a/.TODO.md
+++ b/.TODO.md
@@ -1,12 +1,12 @@
 # Order of focus:
 
-* [ ] Lock scrolling on Menu (enable with prop)
+* [x] Lock scrolling on Menu (enable with prop)
 * [ ] Tags mode (Creatable)
-* [ ] Make inputValue a controllable prop
-* [ ] Make menuIsOpen a controllable prop
-* [ ] Render menu always open | as a dropdown | not at all
+* [x] Make inputValue a controllable prop
+* [x] Make menuIsOpen a controllable prop
 * [ ] Handle changing of isDisabled prop
-* [ ] Virtualisation
+* [ ] Better mobile support and touch handling
+* [ ] Better control of flip behaviour
 * [ ] Documentation
 * [ ] * Props
 * [ ] * Customisation
@@ -27,13 +27,13 @@
 * [ ] * `clearAllText` / `clearValueText` (can override component?)
 * [ ] * `id` (for container) / `inputId`
 * [ ] * `onBlurResetsInput` / `onCloseResetsInput` / `onSelectResetsInput`
-* [ ] * `onClose` / `onOpen`
+* [x] * `onClose` / `onOpen`
 * [ ] * `onMenuScrollToBottom`
 * [ ] * `openOnClick` / `openOnFocus`
 * [ ] * `pageSize`
 * [ ] * `required`
 * [ ] * `resetValue`
-* [ ] * `rtl`
+* [x] * `rtl` -> `isRTL`
 * [ ] * `scrollMenuIntoView`
 * [ ] * `searchable` / `searchPromptText`
 * [ ] * `tabIndex`
@@ -42,6 +42,7 @@
 
 # Maybe:
 
+* [ ] Virtualisation
 * [ ] Prevent values from being popped, was `option.clearableValue === false`
 * [ ] Scroll behaviour: should we detect parent? how do we handle the footer?
 * [ ] Scroll behaviour: can we overscroll up to show the group heading?

--- a/examples/pages/Home.js
+++ b/examples/pages/Home.js
@@ -2,12 +2,9 @@
 
 import React, { Component } from 'react';
 import { Code, Link, H1, Hr, Note } from '../components';
-import { withValue } from 'react-value';
 
 import Select from '../../src';
 import { colourOptions, groupedOptions } from '../data';
-
-const SelectWithValue = withValue(Select);
 
 const changes = [
   { icon: '🎨', text: 'CSS-in-JS with a complete styling API' },
@@ -109,7 +106,7 @@ export default class Home extends Component<*, State> {
         <h2 css={{ marginTop: '2em' }}>Basic Usage</h2>
         <h4>Single Select</h4>
         <div>
-          <SelectWithValue
+          <Select
             autoFocus
             defaultValue={colourOptions[0]}
             isClearable={this.state.isClearable}
@@ -144,7 +141,7 @@ export default class Home extends Component<*, State> {
         </Note>
         <h4>Grouped</h4>
         <div>
-          <SelectWithValue
+          <Select
             defaultValue={colourOptions[1]}
             formatGroupLabel={formatGroupLabel}
             options={groupedOptions}
@@ -153,7 +150,7 @@ export default class Home extends Component<*, State> {
         <Hr />
         <h4>Multi Select</h4>
         <div>
-          <SelectWithValue
+          <Select
             defaultValue={[colourOptions[2], colourOptions[3]]}
             isMulti
             name="colors"

--- a/src/Async.js
+++ b/src/Async.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import Select from './Select';
+import Select from './StateManager';
 import { handleInputChange } from './utils';
 import type { OptionsType } from './types';
 
@@ -73,6 +73,7 @@ export default class Async extends Component<Props, State> {
   }
   handleInputChange = (newValue: string) => {
     const { cacheOptions, onInputChange } = this.props;
+    // TODO
     const inputValue = handleInputChange(newValue, onInputChange);
     if (!inputValue) {
       delete this.lastRequest;

--- a/src/Select.js
+++ b/src/Select.js
@@ -4,7 +4,7 @@ import React, { Component, type ElementRef, type Node } from 'react';
 
 import { createFilter } from './filters';
 import { ScrollLock } from './internal';
-import { cleanValue, handleInputChange, scrollIntoView } from './utils';
+import { cleanValue, scrollIntoView } from './utils';
 import {
   formatGroupLabel,
   getOptionLabel,
@@ -72,6 +72,8 @@ type Props = {
   getOptionValue: typeof getOptionValue,
   /* Hide the selected option from the menu */
   hideSelectedOptions: boolean,
+  /* The value of the search input */
+  inputValue: string,
   /* Define an id prefix for the select components e.g. {your-id}-value */
   instanceId?: number | string,
   /* Is the select value clearable */
@@ -94,6 +96,8 @@ type Props = {
   maxMenuHeight: number,
   /* Maximum height of the value container before scrolling */
   maxValueHeight: number,
+  /* Whether the menu is open */
+  menuIsOpen: boolean,
   /* Name of the HTML Input (optional - without this, no input will be rendered) */
   name?: string,
   /* Text to display when there are no options */
@@ -101,13 +105,17 @@ type Props = {
   /* Handle blur events on the control */
   onBlur?: FocusEventHandler,
   /* Handle change events on the select */
-  onChange?: (ValueType, ActionMeta) => void,
+  onChange: (ValueType, ActionMeta) => void,
   /* Handle focus events on the control */
   onFocus?: FocusEventHandler,
-  /* Handle change events on the input; return a string to modify the value */
-  onInputChange?: string => string | void,
+  /* Handle change events on the input */
+  onInputChange: string => void,
   /* Handle key down events on the select */
   onKeyDown?: KeyboardEventHandler,
+  /* Handle the menu opening */
+  onMenuOpen: () => void,
+  /* Handle the menu closing */
+  onMenuClose: () => void,
   /* Array of options that populate the select menu */
   options: OptionsType,
   /* Placeholder text for the select value */
@@ -157,11 +165,9 @@ type MenuOptions = {
 };
 
 type State = {
-  inputValue: string,
   inputIsHidden: boolean,
   isFocused: boolean,
   focusedOption: OptionType | null,
-  menuIsOpen: boolean,
   menuOptions: MenuOptions,
   selectValue: OptionsType,
 };
@@ -183,15 +189,14 @@ export default class Select extends Component<Props, State> {
   hasGroups: boolean = false;
   input: ?ElRef;
   inputHeight: ?number = 20;
+  inputIsHiddenAfterUpdate: ?boolean;
   instancePrefix: string = '';
   menuRef: ?HTMLElement;
   openAfterFocus: boolean = false;
   scrollToFocusedOptionOnUpdate: boolean = false;
   state = {
     inputIsHidden: false,
-    inputValue: '',
     isFocused: false,
-    menuIsOpen: false,
     menuOptions: { render: [], focusable: [] },
     focusedOption: null,
     selectValue: [],
@@ -215,32 +220,41 @@ export default class Select extends Component<Props, State> {
     }
   }
   componentWillReceiveProps(nextProps: Props) {
-    const { components, options, value } = this.props;
-    const { inputValue } = this.state;
+    const { components, options, value, inputValue } = this.props;
+    // re-cache custom components
     if (nextProps.components !== components) {
       this.components = defaultComponents(nextProps);
     }
-    if (nextProps.value !== value || nextProps.options !== options) {
+    // rebuild the menu options
+    if (
+      nextProps.value !== value ||
+      nextProps.options !== options ||
+      nextProps.inputValue !== inputValue
+    ) {
       const selectValue = cleanValue(nextProps.value);
       const menuOptions = this.buildMenuOptions(
         nextProps.options,
         selectValue,
-        inputValue
+        nextProps.inputValue
       );
       const focusedOption = this.getNextFocusedOption(menuOptions.focusable);
       this.setState({ menuOptions, selectValue, focusedOption });
     }
+    // some updates should toggle the state of the input visibility
+    if (this.inputIsHiddenAfterUpdate != null) {
+      this.setState({
+        inputIsHidden: this.inputIsHiddenAfterUpdate,
+      });
+      delete this.inputIsHiddenAfterUpdate;
+    }
   }
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate() {
     if (
       this.menuRef &&
       this.focusedOptionRef &&
       this.scrollToFocusedOptionOnUpdate
     ) {
       scrollIntoView(this.menuRef, this.focusedOptionRef);
-    }
-    if (prevState.menuIsOpen !== this.state.menuIsOpen) {
-      this.blockOptionHover = false;
     }
     this.scrollToFocusedOptionOnUpdate = false;
   }
@@ -294,54 +308,50 @@ export default class Select extends Component<Props, State> {
       };
     };
 
-    return options.reduce((acc, item, itemIndex) => {
-      if (item.options) {
-        // TODO needs a tidier implementation
-        if (!this.hasGroups) this.hasGroups = true;
+    return options.reduce(
+      (acc, item, itemIndex) => {
+        if (item.options) {
+          // TODO needs a tidier implementation
+          if (!this.hasGroups) this.hasGroups = true;
 
-        const { options: items } = item;
-        const children = items
-          .map((child, i) => {
-            const option = toOption(child, `${itemIndex}-${i}`);
-            if (option && !option.isDisabled) acc.focusable.push(child);
-            return option;
-          })
-          .filter(Boolean);
-        if (children.length) {
-          const groupId = `${this.getElementId('group')}-${itemIndex}`;
-          acc.render.push({
-            type: 'group',
-            key: groupId,
-            data: item,
-            options: children,
-          });
+          const { options: items } = item;
+          const children = items
+            .map((child, i) => {
+              const option = toOption(child, `${itemIndex}-${i}`);
+              if (option && !option.isDisabled) acc.focusable.push(child);
+              return option;
+            })
+            .filter(Boolean);
+          if (children.length) {
+            const groupId = `${this.getElementId('group')}-${itemIndex}`;
+            acc.render.push({
+              type: 'group',
+              key: groupId,
+              data: item,
+              options: children,
+            });
+          }
+        } else {
+          const option = toOption(item, itemIndex);
+          if (option) {
+            acc.render.push(option);
+            if (!option.isDisabled) acc.focusable.push(item);
+          }
         }
-      } else {
-        const option = toOption(item, itemIndex);
-        if (option) {
-          acc.render.push(option);
-          if (!option.isDisabled) acc.focusable.push(item);
-        }
-      }
-      return acc;
-    }, { render: [], focusable: [] });
+        return acc;
+      },
+      { render: [], focusable: [] }
+    );
   }
   filterOption(option: {}, inputValue: string) {
     return this.props.filterOption
       ? this.props.filterOption(option, inputValue)
       : true;
   }
-  buildStateForInputValue(newValue: string = '') {
-    const inputValue = handleInputChange(newValue, this.props.onInputChange);
-    const { options } = this.props;
-    const { selectValue } = this.state;
-    const menuOptions = this.buildMenuOptions(options, selectValue, inputValue);
-    const focusedOption = this.getNextFocusedOption(menuOptions.focusable);
-    return { inputValue, menuOptions, focusedOption };
-  }
   formatOptionLabel(data: OptionType, context: FormatOptionLabelContext): Node {
     if (typeof this.props.formatOptionLabel === 'function') {
-      const { inputValue, selectValue } = this.state;
+      const { inputValue } = this.props;
+      const { selectValue } = this.state;
       return this.props.formatOptionLabel(data, {
         context,
         inputValue,
@@ -400,6 +410,15 @@ export default class Select extends Component<Props, State> {
     if (!this.input) return;
     this.input.blur();
   }
+  onMenuOpen() {
+    this.props.onMenuOpen();
+  }
+  onMenuClose() {
+    this.props.onMenuClose();
+  }
+  onInputChange(newValue: string) {
+    this.props.onInputChange(newValue);
+  }
   openMenu(focusOption: 'first' | 'last' = 'first') {
     const { menuOptions, selectValue } = this.state;
     const { isMulti } = this.props;
@@ -415,16 +434,13 @@ export default class Select extends Component<Props, State> {
     }
 
     this.scrollToFocusedOptionOnUpdate = true;
+    this.inputIsHiddenAfterUpdate = false;
+    this.onMenuOpen();
     this.setState({
       focusedOption: menuOptions.focusable[openAtIndex],
-      inputIsHidden: false,
-      menuIsOpen: true,
     });
   }
-  focusOption(
-    direction: FocusDirection = 'first',
-    blockOptionHover: boolean = false
-  ) {
+  focusOption(direction: FocusDirection = 'first') {
     const { focusedOption, menuOptions } = this.state;
     const options = menuOptions.focusable;
     if (!options.length) return;
@@ -443,9 +459,6 @@ export default class Select extends Component<Props, State> {
     } else if (direction === 'last') {
       nextFocus = options.length - 1;
     }
-    if (blockOptionHover) {
-      this.blockOptionHover = true;
-    }
     this.scrollToFocusedOptionOnUpdate = true;
     this.setState({
       focusedOption: options[nextFocus],
@@ -456,15 +469,12 @@ export default class Select extends Component<Props, State> {
     // We update the state first because we should clear inputValue when an
     // option is selected; the onChange event fires when that's reconciled
     // otherwise the new menu items will be filtered with the old inputValue
-    const newState: any = this.buildStateForInputValue();
+    this.onInputChange('');
     if (closeMenuOnSelect) {
-      newState.menuIsOpen = false;
-      newState.inputIsHidden = isMulti ? false : true;
+      this.inputIsHiddenAfterUpdate = !isMulti;
+      this.onMenuClose();
     }
-    this.setState(
-      newState,
-      onChange ? () => onChange(newValue, { action }) : undefined
-    );
+    onChange(newValue, { action });
   };
   selectOption = (newValue: OptionType) => {
     const { isMulti } = this.props;
@@ -484,28 +494,22 @@ export default class Select extends Component<Props, State> {
   };
   removeValue = (removedValue: OptionType) => {
     const { onChange } = this.props;
-    if (onChange) {
-      const { selectValue } = this.state;
-      onChange(selectValue.filter(i => i !== removedValue), {
-        action: 'remove-value',
-      });
-    }
+    const { selectValue } = this.state;
+    onChange(selectValue.filter(i => i !== removedValue), {
+      action: 'remove-value',
+    });
     this.focus();
   };
   clearValue = () => {
     const { isMulti, onChange } = this.props;
-    if (onChange) {
-      onChange(isMulti ? [] : null, { action: 'clear' });
-    }
+    onChange(isMulti ? [] : null, { action: 'clear' });
   };
   popValue = () => {
     const { onChange } = this.props;
-    if (onChange) {
-      const { selectValue } = this.state;
-      onChange(selectValue.slice(0, selectValue.length - 1), {
-        action: 'pop-value',
-      });
-    }
+    const { selectValue } = this.state;
+    onChange(selectValue.slice(0, selectValue.length - 1), {
+      action: 'pop-value',
+    });
   };
   onControlRef = (ref: ElementRef<*>) => {
     this.controlRef = ref;
@@ -517,9 +521,7 @@ export default class Select extends Component<Props, State> {
     } else if (!this.state.menuIsOpen) {
       this.openMenu('first');
     } else {
-      this.setState({
-        menuIsOpen: false,
-      });
+      this.onMenuClose();
     }
     if (event.target.tagName !== 'INPUT') {
       event.preventDefault();
@@ -529,11 +531,14 @@ export default class Select extends Component<Props, State> {
     const {
       backspaceRemovesValue,
       escapeClearsValue,
+      inputValue,
+      isClearable,
       isDisabled,
+      menuIsOpen,
       onKeyDown,
       tabSelectsValue,
     } = this.props;
-    const { focusedOption, inputValue, menuIsOpen } = this.state;
+    const { focusedOption } = this.state;
 
     if (isDisabled) return;
 
@@ -543,6 +548,9 @@ export default class Select extends Component<Props, State> {
         return;
       }
     }
+
+    // Block option hover events when the user has just pressed a key
+    this.blockOptionHover = true;
 
     switch (event.keyCode) {
       case 8: // backspace
@@ -565,16 +573,15 @@ export default class Select extends Component<Props, State> {
           if (!focusedOption) return;
           this.selectOption(focusedOption);
         } else {
-          this.focusOption();
+          this.focusOption('first');
         }
         break;
       case 27: // escape
         if (menuIsOpen) {
-          this.setState({
-            menuIsOpen: false,
-            ...this.buildStateForInputValue(),
-          });
-        } else if (this.isClearable() && escapeClearsValue) {
+          this.inputIsHiddenAfterUpdate = false;
+          this.onInputChange('');
+          this.onMenuClose();
+        } else if (isClearable && escapeClearsValue) {
           this.clearValue();
         }
         break;
@@ -591,39 +598,40 @@ export default class Select extends Component<Props, State> {
         break;
       case 38: // up
         if (menuIsOpen) {
-          this.focusOption('up', true);
+          this.focusOption('up');
         } else {
           this.openMenu('last');
         }
         break;
       case 40: // down
         if (menuIsOpen) {
-          this.focusOption('down', true);
+          this.focusOption('down');
         } else {
           this.openMenu('first');
         }
         break;
       case 33: // page up
         if (!menuIsOpen) return;
-        this.focusOption('pageup', true);
+        this.focusOption('pageup');
         break;
       case 34: // page down
         if (!menuIsOpen) return;
-        this.focusOption('pagedown', true);
+        this.focusOption('pagedown');
         break;
       case 36: // home key
         if (!menuIsOpen) return;
-        this.focusOption('first', true);
+        this.focusOption('first');
         break;
       case 35: // end key
         if (!menuIsOpen) return;
-        this.focusOption('last', true);
+        this.focusOption('last');
         break;
       default:
         return;
     }
     event.preventDefault();
   };
+  // TODO: Review whether this is necessary
   onInputRef = (input: ElRef) => {
     this.input = input;
 
@@ -632,20 +640,18 @@ export default class Select extends Component<Props, State> {
       this.inputHeight = input.clientHeight;
     }
   };
-  onInputChange = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+  handleInputChange = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
     const inputValue = event.currentTarget.value;
-    this.setState({
-      inputIsHidden: false,
-      menuIsOpen: true,
-      ...this.buildStateForInputValue(inputValue),
-    });
+    this.inputIsHiddenAfterUpdate = false;
+    this.onInputChange(inputValue);
+    this.onMenuOpen();
   };
   onInputFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
+    this.inputIsHiddenAfterUpdate = false;
     this.setState({
-      inputIsHidden: false,
       isFocused: true,
     });
     if (this.openAfterFocus) {
@@ -657,10 +663,10 @@ export default class Select extends Component<Props, State> {
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }
+    this.onInputChange('');
+    this.onMenuClose();
     this.setState({
       isFocused: false,
-      menuIsOpen: false,
-      ...this.buildStateForInputValue(''),
     });
   };
   onMenuRef = (ref: ElementRef<*>) => {
@@ -692,16 +698,13 @@ export default class Select extends Component<Props, State> {
       return;
     }
     if (this.props.isDisabled) return;
-    const { isMulti } = this.props;
-    const { menuIsOpen } = this.state;
+    const { isMulti, menuIsOpen } = this.props;
     if (!this.focused) {
       this.focus();
     }
     if (menuIsOpen) {
-      this.setState({
-        menuIsOpen: false,
-        inputIsHidden: isMulti ? false : true,
-      });
+      this.inputIsHiddenAfterUpdate = !isMulti;
+      this.onMenuClose();
     } else {
       this.openMenu();
     }
@@ -722,7 +725,8 @@ export default class Select extends Component<Props, State> {
     return `${this.instancePrefix}-${element}`;
   };
   getActiveDescendentId = () => {
-    const { focusedOption, menuIsOpen } = this.state;
+    const { menuIsOpen } = this.props;
+    const { focusedOption } = this.state;
     return focusedOption && menuIsOpen ? focusedOption.key : undefined;
   };
   renderScreenReaderStatus() {
@@ -734,9 +738,9 @@ export default class Select extends Component<Props, State> {
     );
   }
   renderInput(id: string) {
-    const { isDisabled, isLoading } = this.props;
+    const { isDisabled, isLoading, inputValue, menuIsOpen } = this.props;
     const { Input } = this.components;
-    const { inputIsHidden, inputValue, menuIsOpen } = this.state;
+    const { inputIsHidden } = this.state;
 
     // maintain baseline alignment when the input is removed for disabled state
     if (isDisabled) return <div style={{ height: this.inputHeight }} />;
@@ -765,7 +769,7 @@ export default class Select extends Component<Props, State> {
         innerRef={this.onInputRef}
         isHidden={inputIsHidden}
         onBlur={this.onInputBlur}
-        onChange={this.onInputChange}
+        onChange={this.handleInputChange}
         onFocus={this.onInputFocus}
         spellCheck="false"
         tabIndex="0"
@@ -785,8 +789,8 @@ export default class Select extends Component<Props, State> {
       Placeholder,
     } = this.components;
     const { commonProps } = this;
-    const { isDisabled, isMulti, placeholder } = this.props;
-    const { inputValue, selectValue } = this.state;
+    const { isDisabled, isMulti, inputValue, placeholder } = this.props;
+    const { selectValue } = this.state;
 
     if (!this.hasValue()) {
       return inputValue ? null : (
@@ -927,13 +931,15 @@ export default class Select extends Component<Props, State> {
       Option,
     } = this.components;
     const { commonProps } = this;
-    const { inputValue, focusedOption, menuIsOpen, menuOptions } = this.state;
+    const { focusedOption, menuOptions } = this.state;
     const {
       captureMenuScroll,
+      inputValue,
       isLoading,
       isMulti,
-      maxMenuHeight,
       loadingMessage,
+      maxMenuHeight,
+      menuIsOpen,
       noOptionsMessage,
     } = this.props;
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -150,6 +150,7 @@ const defaultProps = {
   loadingMessage: () => 'Loading...',
   maxMenuHeight: 300,
   maxValueHeight: 100,
+  menuIsOpen: false,
   noOptionsMessage: () => 'No options',
   options: [],
   placeholder: 'Select...',
@@ -157,6 +158,7 @@ const defaultProps = {
     `${count} result${count !== 1 ? 's' : ''} available.`,
   styles: {},
   tabSelectsValue: true,
+  value: '',
 };
 
 type MenuOptions = {
@@ -195,10 +197,10 @@ export default class Select extends Component<Props, State> {
   openAfterFocus: boolean = false;
   scrollToFocusedOptionOnUpdate: boolean = false;
   state = {
+    focusedOption: null,
     inputIsHidden: false,
     isFocused: false,
     menuOptions: { render: [], focusable: [] },
-    focusedOption: null,
     selectValue: [],
   };
   constructor(props: Props) {

--- a/src/StateManager.js
+++ b/src/StateManager.js
@@ -3,16 +3,25 @@
 import React, { Component } from 'react';
 
 import Select from './Select';
+import { type OptionType } from './types';
 
-export default class StateManager extends Component<*, *> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      inputValue: this.props.inputValue || '',
-      menuIsOpen: this.props.menuIsOpen || false,
-      value: this.props.value || null,
-    };
-  }
+type Props = {
+  inputValue?: string,
+  menuIsOpen?: boolean,
+  value?: OptionType,
+};
+type State = {
+  inputValue: string,
+  menuIsOpen: boolean,
+  value: OptionType | null,
+};
+
+export default class StateManager extends Component<Props, State> {
+  state = {
+    inputValue: this.props.inputValue || '',
+    menuIsOpen: this.props.menuIsOpen || false,
+    value: this.props.value || null,
+  };
   getSelectProp(key: string) {
     return this.props[key] !== undefined ? this.props[key] : this.state[key];
   }
@@ -52,9 +61,9 @@ export default class StateManager extends Component<*, *> {
         menuIsOpen={menuIsOpen}
         onChange={this.onChange}
         onInputChange={this.onInputChange}
-        value={value}
         onMenuClose={this.onMenuClose}
         onMenuOpen={this.onMenuOpen}
+        value={value}
       />
     );
   }

--- a/src/StateManager.js
+++ b/src/StateManager.js
@@ -1,0 +1,61 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import Select from './Select';
+
+export default class StateManager extends Component<*, *> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      inputValue: this.props.inputValue || '',
+      menuIsOpen: this.props.menuIsOpen || false,
+      value: this.props.value || null,
+    };
+  }
+  getSelectProp(key: string) {
+    return this.props[key] !== undefined ? this.props[key] : this.state[key];
+  }
+  callProp(name: string, ...args: any) {
+    if (typeof this.props[name] === 'function') {
+      return this.props[name](...args);
+    }
+  }
+  onChange = (value: any) => {
+    this.callProp('onChange', value);
+    this.setState({ value });
+  };
+  onInputChange = (inputValue: any) => {
+    // TODO: for backwards compatibility, we allow the prop to return a new
+    // value, but now inputValue is a controllable prop we probably shouldn't
+    const newValue = this.callProp('onInputChange', inputValue);
+    this.setState({
+      inputValue: newValue !== undefined ? newValue : inputValue,
+    });
+  };
+  onMenuOpen = () => {
+    this.callProp('onMenuOpen');
+    this.setState({ menuIsOpen: true });
+  };
+  onMenuClose = () => {
+    this.callProp('onMenuClose');
+    this.setState({ menuIsOpen: false });
+  };
+  render() {
+    const inputValue = this.getSelectProp('inputValue');
+    const menuIsOpen = this.getSelectProp('menuIsOpen');
+    const value = this.getSelectProp('value');
+    return (
+      <Select
+        {...this.props}
+        inputValue={inputValue}
+        menuIsOpen={menuIsOpen}
+        onChange={this.onChange}
+        onInputChange={this.onInputChange}
+        value={value}
+        onMenuClose={this.onMenuClose}
+        onMenuOpen={this.onMenuOpen}
+      />
+    );
+  }
+}

--- a/src/__tests__/Select.js
+++ b/src/__tests__/Select.js
@@ -33,7 +33,7 @@ test('formatOptionLabel', () => {
   );
   const value = tree.find(SingleValue).at(0);
   expect(value.props().children).toBe('2 two value');
-  tree.setState({ menuIsOpen: true });
+  tree.setProps({ menuIsOpen: true });
   const menu = tree.find(Option);
   expect(menu).toHaveLength(3);
   expect(menu.at(0).props().children).toBe('1 one menu');

--- a/src/__tests__/__snapshots__/Select.js.snap
+++ b/src/__tests__/__snapshots__/Select.js.snap
@@ -38,12 +38,14 @@ exports[`defaults 1`] = `
       "loadingMessage": [Function],
       "maxMenuHeight": 300,
       "maxValueHeight": 100,
+      "menuIsOpen": false,
       "noOptionsMessage": [Function],
       "options": Array [],
       "placeholder": "Select...",
       "screenReaderStatus": [Function],
       "styles": Object {},
       "tabSelectsValue": true,
+      "value": "",
     }
   }
   setValue={[Function]}
@@ -93,12 +95,14 @@ exports[`defaults 1`] = `
         "loadingMessage": [Function],
         "maxMenuHeight": 300,
         "maxValueHeight": 100,
+        "menuIsOpen": false,
         "noOptionsMessage": [Function],
         "options": Array [],
         "placeholder": "Select...",
         "screenReaderStatus": [Function],
         "styles": Object {},
         "tabSelectsValue": true,
+        "value": "",
       }
     }
     setValue={[Function]}
@@ -135,12 +139,14 @@ exports[`defaults 1`] = `
           "loadingMessage": [Function],
           "maxMenuHeight": 300,
           "maxValueHeight": 100,
+          "menuIsOpen": false,
           "noOptionsMessage": [Function],
           "options": Array [],
           "placeholder": "Select...",
           "screenReaderStatus": [Function],
           "styles": Object {},
           "tabSelectsValue": true,
+          "value": "",
         }
       }
       setValue={[Function]}
@@ -177,12 +183,14 @@ exports[`defaults 1`] = `
             "loadingMessage": [Function],
             "maxMenuHeight": 300,
             "maxValueHeight": 100,
+            "menuIsOpen": false,
             "noOptionsMessage": [Function],
             "options": Array [],
             "placeholder": "Select...",
             "screenReaderStatus": [Function],
             "styles": Object {},
             "tabSelectsValue": true,
+            "value": "",
           }
         }
         setValue={[Function]}
@@ -208,7 +216,6 @@ exports[`defaults 1`] = `
         spellCheck="false"
         tabIndex="0"
         type="text"
-        value=""
       />
     </ValueContainer>
     <IndicatorsContainer
@@ -242,12 +249,14 @@ exports[`defaults 1`] = `
           "loadingMessage": [Function],
           "maxMenuHeight": 300,
           "maxValueHeight": 100,
+          "menuIsOpen": false,
           "noOptionsMessage": [Function],
           "options": Array [],
           "placeholder": "Select...",
           "screenReaderStatus": [Function],
           "styles": Object {},
           "tabSelectsValue": true,
+          "value": "",
         }
       }
       setValue={[Function]}
@@ -289,12 +298,14 @@ exports[`defaults 1`] = `
             "loadingMessage": [Function],
             "maxMenuHeight": 300,
             "maxValueHeight": 100,
+            "menuIsOpen": false,
             "noOptionsMessage": [Function],
             "options": Array [],
             "placeholder": "Select...",
             "screenReaderStatus": [Function],
             "styles": Object {},
             "tabSelectsValue": true,
+            "value": "",
           }
         }
         setValue={[Function]}
@@ -337,12 +348,14 @@ exports[`defaults 1`] = `
             "loadingMessage": [Function],
             "maxMenuHeight": 300,
             "maxValueHeight": 100,
+            "menuIsOpen": false,
             "noOptionsMessage": [Function],
             "options": Array [],
             "placeholder": "Select...",
             "screenReaderStatus": [Function],
             "styles": Object {},
             "tabSelectsValue": true,
+            "value": "",
           }
         }
         setValue={[Function]}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-import Select from './Select';
+import Select from './StateManager';
 
 export default Select;
 export { createFilter } from './filters';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 // @flow
-import Select from './StateManager';
 
-export default Select;
+import SelectStateful from './StateManager';
+
+export default SelectStateful;
+export { default as SelectStateless } from './Select';
 export { createFilter } from './filters';
 export { components } from './components/index';


### PR DESCRIPTION
I've done some significant refactoring to move `menuIsOpen` and `inputValue` from internal state to props that can be controlled.

This PR also includes a new component, `StateManager` which is the component actually exported and cleanly handles the default behaviour of the new props by managing them as internal state that can be overridden by props.

Based on my initial testing, it looks good (and is arguably simpler from an implementation perspective) and these has been a highly requested feature.

@jossmac would appreciate your review + testing before we merge this in!