### PR TITLE
feat: add `values` to `ValueComponent` in multi-select

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -827,6 +827,7 @@ class Select extends React.Component {
 						onRemove={this.removeValue}
 						placeholder={this.props.placeholder}
 						value={value}
+						values={valueArray}
 					>
 						{renderLabel(value, i)}
 						<span className="Select-aria-only">&nbsp;</span>


### PR DESCRIPTION
for a custom `ValueComponent` I need to display the total amount of selected values. Having the complete `valueArray` available might be incredible helpful.