### PR TITLE
#1370 Feature: Custom outer component

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -25,8 +25,8 @@ ReactDOM.render(
 		<GithubUsers label="GitHub users (Async with fetch.js)" />
 		<NumericSelect label="Numeric Values" />
 		<BooleanSelect label="Boolean Values" />
-		<CustomRender label="Custom Render Methods"/>
-		<CustomComponents label="Custom Placeholder, Option, Value, and Arrow Components" />
+		<CustomRender label="Custom Render Methods" />
+		<CustomComponents label="Custom Placeholder, Outer, Option, Value, and Arrow Components" />
 		<Creatable
 			hint="Enter a value that's NOT in the list, then hit return"
 			label="Custom tag creation"

--- a/examples/src/components/CustomComponents.js
+++ b/examples/src/components/CustomComponents.js
@@ -12,6 +12,55 @@ const stringOrNode = PropTypes.oneOfType([
 	PropTypes.node,
 ]);
 
+const GravatarSearchableMenuComponent = createClass({
+	propTypes: {
+		children: PropTypes.node,
+		instancePrefix: PropTypes.string,
+		menuContainerStyle: PropTypes.string,
+		menuStyle: PropTypes.string,
+		onMenuContainerRef: PropTypes.func,
+		onMenuMouseDown: PropTypes.func,
+		onMenuRef: PropTypes.func,
+		onMenuScroll: PropTypes.func
+	},
+	render () {
+		const { onMenuContainerRef, menuContainerStyle, instancePrefix, onMenuMouseDown, onMenuScroll, onMenuRef, menuStyle, children } = this.props;
+
+		const headerFooterStyle = {
+			border: 1,
+			borderColor: '#aaa',
+			color: '#aaa',
+			borderStyle: 'dashed',
+			textAlign: 'center',
+			padding: 10,
+			margin: 10
+		};
+
+		const customStyle = menuContainerStyle || {};
+		customStyle.maxHeight = 230;
+
+		return (<div
+			ref={onMenuContainerRef}
+			className="Select-menu-outer"
+			style={customStyle}>
+			<div style={headerFooterStyle}>Perhaps a header...</div>
+			<div
+				className="Select-menu"
+				id={`${instancePrefix}-list`}
+				onMouseDown={onMenuMouseDown}
+				onScroll={onMenuScroll}
+				ref={onMenuRef}
+				role="listbox"
+				style={menuStyle}
+				tabIndex={-1}
+			>
+				{children}
+			</div>
+			<div style={headerFooterStyle}>or a footer...</div>
+		</div>);
+	}
+});
+
 const GravatarOption = createClass({
 	propTypes: {
 		children: PropTypes.node,
@@ -108,7 +157,8 @@ const UsersField = createClass({
 					placeholder={placeholder}
 					value={this.state.value}
 					valueComponent={GravatarValue}
-					/>
+					outerComponent={GravatarSearchableMenuComponent}
+				/>
 				<div className="hint">
 					This example implements custom Option and Value components to render a Gravatar image for each user based on their email.
 					It also demonstrates rendering HTML elements as the placeholder.

--- a/src/Outer.js
+++ b/src/Outer.js
@@ -1,0 +1,41 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class Outer extends React.Component {
+
+	render () {
+		const { onMenuContainerRef, menuContainerStyle, instancePrefix, onMenuMouseDown, onMenuScroll, onMenuRef, menuStyle, children } = this.props;
+
+		return (<div
+			ref={onMenuContainerRef}
+			className="Select-menu-outer"
+			style={menuContainerStyle}>
+			<div
+				className="Select-menu"
+				id={`${instancePrefix}-list`}
+				onMouseDown={onMenuMouseDown}
+				onScroll={onMenuScroll}
+				ref={onMenuRef}
+				role="listbox"
+				style={menuStyle}
+				tabIndex={-1}
+			>
+				{children}
+			</div>
+		</div>);
+	}
+}
+
+Outer.propTypes = {
+	children: PropTypes.node,
+	instancePrefix: PropTypes.string,			// instance prefix
+	menuContainerStyle: PropTypes.object,		// menu container style
+	menuStyle: PropTypes.object,				// menu style
+	onMenuContainerRef: PropTypes.func,			// method to handle setting menuContainer ref
+	onMenuMouseDown: PropTypes.func,			// method to handle mouseDown on the menu
+	onMenuRef: PropTypes.func,					// method to handle setting menu ref
+	onMenuScroll: PropTypes.func
+};
+
+export default Outer;

--- a/src/Select.js
+++ b/src/Select.js
@@ -13,8 +13,10 @@ import defaultArrowRenderer from './utils/defaultArrowRenderer';
 import defaultClearRenderer from './utils/defaultClearRenderer';
 import defaultFilterOptions from './utils/defaultFilterOptions';
 import defaultMenuRenderer from './utils/defaultMenuRenderer';
+import defaultOuterRenderer from './utils/defaultOuterRenderer';
 
 import Option from './Option';
+import Outer from './Outer';
 import Value from './Value';
 
 const stringifyValue = value =>
@@ -95,6 +97,8 @@ class Select extends React.Component {
 			'handleTouchOutside',
 			'handleTouchStart',
 			'handleValueClick',
+			'onMenuRef',
+			'onMenuContainerRef',
 			'onOptionRef',
 			'removeValue',
 			'selectValue',
@@ -1011,6 +1015,14 @@ class Select extends React.Component {
 		}
 	}
 
+	onMenuRef (ref) {
+		this.menu = ref;
+	}
+
+	onMenuContainerRef (ref) {
+		this.menuContainer = ref;
+	}
+
 	renderMenu (options, valueArray, focusedOption) {
 		if (options && options.length) {
 			return this.props.menuRenderer({
@@ -1095,27 +1107,22 @@ class Select extends React.Component {
 	}
 
 	renderOuter (options, valueArray, focusedOption) {
-		let menu = this.renderMenu(options, valueArray, focusedOption);
+		const menu = this.renderMenu(options, valueArray, focusedOption);
 		if (!menu) {
 			return null;
 		}
 
-		return (
-			<div ref={ref => this.menuContainer = ref} className="Select-menu-outer" style={this.props.menuContainerStyle}>
-				<div
-					className="Select-menu"
-					id={`${this._instancePrefix}-list`}
-					onMouseDown={this.handleMouseDownOnMenu}
-					onScroll={this.handleMenuScroll}
-					ref={ref => this.menu = ref}
-					role="listbox"
-					style={this.props.menuStyle}
-					tabIndex={-1}
-				>
-					{menu}
-				</div>
-			</div>
-		);
+		return this.props.outerRenderer({
+			instancePrefix: this._instancePrefix,
+			menuComponent: menu,
+			menuContainerStyle: this.props.menuContainerStyle,
+			menuStyle: this.props.menuStyle,
+			onMenuContainerRef: this.onMenuContainerRef,
+			onMenuMouseDown: this.handleMouseDownOnMenu,
+			onMenuRef: this.onMenuRef,
+			onMenuScroll: this.handleMenuScroll,
+			outerComponent: this.props.outerComponent
+		});
 	}
 
 	render () {
@@ -1247,6 +1254,8 @@ Select.propTypes = {
 	optionComponent: PropTypes.func,      // option component to render in dropdown
 	optionRenderer: PropTypes.func,       // optionRenderer: function (option) {}
 	options: PropTypes.array,             // array of options
+	outerComponent: PropTypes.func,		  // outer component to render around child menu
+	outerRenderer: PropTypes.func,		  // renders a custom outer div
 	pageSize: PropTypes.number,           // number of entries to page when using page up/down keys
 	placeholder: stringOrNode,            // field placeholder, displayed when there's no value
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
@@ -1299,6 +1308,8 @@ Select.defaultProps = {
 	onSelectResetsInput: true,
 	openOnClick: true,
 	optionComponent: Option,
+	outerComponent: Outer,
+	outerRenderer: defaultOuterRenderer,
 	pageSize: 5,
 	placeholder: 'Select...',
 	removeSelected: true,

--- a/src/utils/defaultOuterRenderer.js
+++ b/src/utils/defaultOuterRenderer.js
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const outerRenderer = ({
+	instancePrefix,
+	menuComponent,
+	menuContainerStyle,
+	menuStyle,
+	onMenuContainerRef,
+	onMenuMouseDown,
+	onMenuRef,
+	onMenuScroll,
+	outerComponent
+}) => {
+
+	const Outer = outerComponent;
+
+	return (
+		<Outer
+			onMenuContainerRef={onMenuContainerRef}
+			menuContainerStyle={menuContainerStyle}
+			instancePrefix={instancePrefix}
+			onMenuMouseDown={onMenuMouseDown}
+			onMenuScroll={onMenuScroll}
+			onMenuRef={onMenuRef}
+			menuStyle={menuStyle}>
+			{menuComponent}
+		</Outer>
+	);
+};
+
+outerRenderer.propTypes = {
+	instancePrefix: PropTypes.string,
+	menuComponent: PropTypes.object,
+	menuContainerStyle: PropTypes.object,
+	menuStyle: PropTypes.object,
+	onMenuContainerRef: PropTypes.func,
+	onMenuMouseDown: PropTypes.func,
+	onMenuRef: PropTypes.func,
+	onMenuScroll: PropTypes.func,
+	outerComponent: PropTypes.node
+};
+
+export default outerRenderer;
+
+

--- a/test/Outer.test.js
+++ b/test/Outer.test.js
@@ -1,0 +1,85 @@
+/* global describe, it, beforeEach */
+
+import helper from '../testHelpers/jsdomHelper';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import sinon from 'sinon';
+import TestUtils from 'react-dom/test-utils';
+import unexpected from 'unexpected';
+import unexpectedDom from 'unexpected-dom';
+import unexpectedSinon from 'unexpected-sinon';
+
+import Outer from '../src/Outer';
+
+helper();
+const expect = unexpected
+	.clone()
+	.installPlugin(unexpectedSinon)
+	.installPlugin(unexpectedDom);
+
+describe('Outer component', () => {
+
+	let onMenuMouseDown, onMenuScroll, menuContainer, menu, instance;
+	const createOuter = props => {
+		onMenuMouseDown = sinon.spy();
+		onMenuScroll = sinon.spy();
+		// Render an instance of the component
+		let instance = TestUtils.renderIntoDocument(
+			<Outer
+				onMenuContainerRef={ref => menuContainer = ref}
+				onMenuRef={ref => menu = ref}
+				onMenuMouseDown={onMenuMouseDown}
+				onMenuScroll={onMenuScroll}
+				{...props}>
+				{props.children}
+			</Outer>
+		);
+
+		return instance;
+	};
+
+	beforeEach(() => {
+		const props = {
+			instancePrefix: 'test',
+			menuComponent: <div>Menu here</div>,
+			menuContainerStyle: { color: 'red' },
+			menuStyle: { color: 'blue' },
+			children: <div>Menu here</div>
+		};
+		instance = createOuter(props);
+	});
+
+	it('sets the menu container ref', () => {
+		expect(menuContainer, 'not to equal', undefined);
+	});
+
+	it('sets the menu ref', () => {
+		expect(menu, 'not to equal', undefined);
+	});
+
+	it('renders the menu container', () => {
+		expect(menuContainer.className, 'to equal', 'Select-menu-outer');
+		expect(menuContainer.style.cssText, 'to equal', 'color: red;');
+	});
+
+	it('renders the menu', () => {
+		expect(menu.className, 'to equal', 'Select-menu');
+		expect(menu.style.cssText, 'to equal', 'color: blue;');
+	});
+
+	it('renders the menu options', () => {
+		expect(menu.textContent, 'to equal', 'Menu here');
+	});
+
+	it('simulates menu click', () => {
+		expect(onMenuMouseDown, 'was not called');
+		TestUtils.Simulate.mouseDown(menu, { button: 0 });
+		expect(onMenuMouseDown, 'was called');
+	});
+
+	it('simulates menu scroll', () => {
+		expect(onMenuScroll, 'was not called');
+		TestUtils.Simulate.scroll(menu);
+		expect(onMenuScroll, 'was called');
+	});
+});

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -4233,6 +4233,40 @@ describe('Select', () => {
 		});
 	});
 
+
+	describe('custom outerRenderer option', () => {
+		it('should render the custom outer', () => {
+			const instance = createControl({
+				options: [1, 2, 3],
+				outerRenderer: () => <div className="customOuter" />
+			});
+			clickArrowToOpen();
+			expect(ReactDOM.findDOMNode(instance), 'to contain elements matching', '.customOuter');
+		});
+
+		it('should pass the expected parameters', () => {
+			let paramsReceived;
+			const instance = createControl({
+				options: [1, 2, 3],
+				outerRenderer: (params) => {
+					paramsReceived = params;
+					return <div>Custom outer</div>;
+				}
+			});
+			clickArrowToOpen();
+			const keys = Object.keys(paramsReceived);
+			expect(keys, 'to contain', 'instancePrefix');
+			expect(keys, 'to contain', 'menuComponent');
+			expect(keys, 'to contain', 'menuContainerStyle');
+			expect(keys, 'to contain', 'menuStyle');
+			expect(keys, 'to contain', 'onMenuContainerRef');
+			expect(keys, 'to contain', 'onMenuMouseDown');
+			expect(keys, 'to contain', 'onMenuRef');
+			expect(keys, 'to contain', 'onMenuScroll');
+			expect(keys, 'to contain', 'outerComponent');
+		});
+	});
+
 	describe('custom arrowRenderer option', () => {
 		it('should render the custom arrow', () => {
 			const instance = createControl({


### PR DESCRIPTION
Allows the end-user to supply a custom outerRenderer or outerComponent, to modify the menu container.
e.g. to add a header or footer, search field etc.

We're currently using this in a project, so any comments gratefully received even if you choose not to accept the PR.

I haven't added any documentation, but can do if there's any interest in this solution.