### PR TITLE
Fix #1667: Do not output invalid empty 'aria-owns' attr

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -876,7 +876,7 @@ class Select extends React.Component {
 			'aria-haspopup': '' + isOpen,
 			'aria-label': this.props['aria-label'],
 			'aria-labelledby': this.props['aria-labelledby'],
-			'aria-owns': ariaOwns,
+			...(ariaOwns ? { 'aria-owns': ariaOwns } : {}),
 			className: className,
 			onBlur: this.handleInputBlur,
 			onChange: this.handleInputChange,
@@ -903,7 +903,7 @@ class Select extends React.Component {
 				<div
 					{...divProps}
 					aria-expanded={isOpen}
-					aria-owns={ariaOwns}
+					{...(ariaOwns ? { 'aria-owns': ariaOwns } : {})}
 					aria-activedescendant={isOpen ? `${this._instancePrefix}-option-${focusedOptionIndex}` : `${this._instancePrefix}-value`}
 					aria-disabled={'' + this.props.disabled}
 					aria-label={this.props['aria-label']}


### PR DESCRIPTION
Fixes #1667 

`aria-owns=""` is not a valid attribute. I noticed this when using the [aXe accessibility checker](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/). 

![image](https://user-images.githubusercontent.com/3307404/36788586-c3b5d062-1c8e-11e8-86e0-89acc33199da.png)
