### PR TITLE
update to v0.3 of codesandboxer

### DIFF
--- a/docs/ExampleWrapper.js
+++ b/docs/ExampleWrapper.js
@@ -2,50 +2,18 @@
 
 import glam from 'glam';
 import React, { Component } from 'react';
-import CodeSandboxer, { replaceImports } from 'react-codesandboxer';
-
+import CodeSandboxer from 'react-codesandboxer';
+import pkg from '../package.json';
 import { colors } from '../src/theme';
 
 const user = 'JedWatson';
 const branch = 'v2';
 
 const sourceUrl = `https://github.com/${user}/react-select/tree/${branch}`;
-const rawUrl = `https://raw.githubusercontent.com/${user}/react-select/${branch}`;
-const rawPKGJSON = rawUrl + '/package.json';
-
-const rawDataUrl = rawUrl + '/docs/data.js';
-const rawComponentsUrl = rawUrl + '/docs/styled-components.js';
-const promise = urlPath =>
-  fetch(rawUrl + urlPath)
-    .then(a => a.text())
-    .then(a =>
-      replaceImports(a, [
-        ['../../../src/*', 'react-select/lib/'],
-        ['../../../src', 'react-select'],
-        ['../../data', './data'],
-        ['../../styled-components', './styled-components'],
-      ])
-    );
 
 export default class ExampleWrapper extends Component {
   static defaultProps = { isEditable: true };
-  configPromise = () =>
-    Promise.all([
-      fetch(rawDataUrl).then(a => a.text()),
-      fetch(rawComponentsUrl)
-        .then(a => a.text())
-        .then(a => replaceImports(a, [['../src/*', 'react-select/lib/']])),
-    ]).then(([data, components]) => ({
-      providedDeps: { glam: '^5.0.1' },
-      providedFiles: {
-        'data.js': {
-          content: data,
-        },
-        'styled-components.js': {
-          content: components,
-        },
-      },
-    }));
+
   render() {
     return (
       <div>
@@ -54,7 +22,7 @@ export default class ExampleWrapper extends Component {
           <Actions>
             <Action
               icon="source"
-              href={sourceUrl + this.props.urlPath}
+              href={`${sourceUrl}/${this.props.urlPath}`}
               tag="a"
               target="_blank"
             >
@@ -62,13 +30,28 @@ export default class ExampleWrapper extends Component {
             </Action>
             {this.props.isEditable ? (
               <CodeSandboxer
-                config={this.configPromise}
-                example={promise(this.props.urlPath)}
-                pkgJSON={fetch(rawPKGJSON).then(a => a.json())}
+                examplePath={this.props.urlPath}
+                pkgJSON={pkg}
+                gitInfo={{
+                  account: 'JedWatson',
+                  repository: 'react-select',
+                  branch: 'v2',
+                  host: 'github',
+                }}
+                importReplacements={[
+                  ['src/*', 'react-select/lib/'],
+                  ['src', 'react-select'],
+                ]}
+                dependencies={{
+                  [pkg.name]: pkg.version,
+                }}
               >
-                <Action icon="new-window" type="submit">
-                  Edit in CodeSandbox
-                </Action>
+                {/* isLoading can now be implemented */}
+                {() => (
+                  <Action icon="new-window" type="submit">
+                    Edit in CodeSandbox
+                  </Action>
+                )}
               </CodeSandboxer>
             ) : null}
           </Actions>

--- a/docs/home/examples/AnimatedMulti.js
+++ b/docs/home/examples/AnimatedMulti.js
@@ -11,7 +11,7 @@ export default function AnimatedMulti() {
   return (
     <ExampleWrapper
       label="Animation"
-      urlPath="/docs/home/examples/AnimatedMulti.js"
+      urlPath="docs/home/examples/AnimatedMulti.js"
     >
       <div id="cypress-multi-animated">
         <Select

--- a/docs/home/examples/AsyncCallbacks.js
+++ b/docs/home/examples/AsyncCallbacks.js
@@ -30,7 +30,7 @@ export default class WithCallbacks extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Callbacks"
-        urlPath="/docs/home/examples/AsyncCallbacks.js"
+        urlPath="docs/home/examples/AsyncCallbacks.js"
       >
         <pre>inputValue: "{this.state.inputValue}"</pre>
         <AsyncSelect

--- a/docs/home/examples/AsyncPromises.js
+++ b/docs/home/examples/AsyncPromises.js
@@ -31,7 +31,7 @@ export default class WithPromises extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Promises"
-        urlPath="/docs/home/examples/AsyncPromises.js"
+        urlPath="docs/home/examples/AsyncPromises.js"
       >
         <AsyncSelect cacheOptions defaultOptions loadOptions={promiseOptions} />
       </ExampleWrapper>

--- a/docs/home/examples/BasicGrouped.js
+++ b/docs/home/examples/BasicGrouped.js
@@ -30,7 +30,7 @@ const formatGroupLabel = data => (
 );
 
 export default () => (
-  <ExampleWrapper label="Grouped" urlPath="/docs/home/examples/BasicGrouped.js">
+  <ExampleWrapper label="Grouped" urlPath="docs/home/examples/BasicGrouped.js">
     <Select
       defaultValue={colourOptions[1]}
       options={groupedOptions}

--- a/docs/home/examples/BasicMulti.js
+++ b/docs/home/examples/BasicMulti.js
@@ -5,7 +5,7 @@ import { colourOptions } from '../../data';
 import ExampleWrapper from '../../ExampleWrapper';
 
 export default () => (
-  <ExampleWrapper label="Multi" urlPath="/docs/home/examples/BasicMulti.js">
+  <ExampleWrapper label="Multi" urlPath="docs/home/examples/BasicMulti.js">
     <Select
       defaultValue={[colourOptions[2], colourOptions[3]]}
       isMulti

--- a/docs/home/examples/BasicSingle.js
+++ b/docs/home/examples/BasicSingle.js
@@ -45,7 +45,7 @@ export default class SingleSelect extends Component<*, State> {
       <Fragment>
         <ExampleWrapper
           label="Single"
-          urlPath="/docs/home/examples/BasicSingle.js"
+          urlPath="docs/home/examples/BasicSingle.js"
         >
           <Select
             defaultValue={colourOptions[0]}

--- a/docs/home/examples/CreatableAdvanced.js
+++ b/docs/home/examples/CreatableAdvanced.js
@@ -53,7 +53,7 @@ export default class CreatableAdvanced extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Advanced Example"
-        urlPath="/docs/home/examples/CreatableAdvanced.js"
+        urlPath="docs/home/examples/CreatableAdvanced.js"
       >
         <CreatableSelect
           isClearable

--- a/docs/home/examples/CreatableInputOnly.js
+++ b/docs/home/examples/CreatableInputOnly.js
@@ -48,7 +48,7 @@ export default class CreatableInputOnly extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Multi-select text input"
-        urlPath="/docs/home/examples/CreatableInputOnly.js"
+        urlPath="docs/home/examples/CreatableInputOnly.js"
       >
         <CreatableSelect
           components={components}

--- a/docs/home/examples/CreatableMulti.js
+++ b/docs/home/examples/CreatableMulti.js
@@ -15,7 +15,7 @@ export default class CreatableMulti extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Creatable Multiselect Example"
-        urlPath="/docs/home/examples/CreatableMulti.js"
+        urlPath="docs/home/examples/CreatableMulti.js"
       >
         <CreatableSelect
           isMulti

--- a/docs/home/examples/CreatableSingle.js
+++ b/docs/home/examples/CreatableSingle.js
@@ -15,7 +15,7 @@ export default class CreatableSingle extends Component<*, State> {
     return (
       <ExampleWrapper
         label="Creatable Example"
-        urlPath="/docs/home/examples/CreatableSingle.js"
+        urlPath="docs/home/examples/CreatableSingle.js"
       >
         <CreatableSelect
           isClearable

--- a/docs/home/examples/Experimental.js
+++ b/docs/home/examples/Experimental.js
@@ -209,7 +209,7 @@ export default class App extends Component<*, *> {
         <ExampleWrapper
           isEditable={false}
           label="DatePicker"
-          urlPath="/docs/home/examples/Experimental.js"
+          urlPath="docs/home/examples/Experimental.js"
         >
           <DatePicker value={value} onChange={this.handleChange} />
         </ExampleWrapper>

--- a/docs/home/examples/StyledMulti.js
+++ b/docs/home/examples/StyledMulti.js
@@ -46,7 +46,7 @@ const colourStyles = {
 export default () => (
   <ExampleWrapper
     label="Multi Select"
-    urlPath="/docs/home/examples/StyledMulti.js"
+    urlPath="docs/home/examples/StyledMulti.js"
   >
     <Select
       closeMenuOnSelect={false}

--- a/docs/home/examples/StyledSingle.js
+++ b/docs/home/examples/StyledSingle.js
@@ -43,7 +43,7 @@ const colourStyles = {
 };
 
 export default () => (
-  <ExampleWrapper label="Single" urlPath="/docs/home/examples/StyledSingle.js">
+  <ExampleWrapper label="Single" urlPath="docs/home/examples/StyledSingle.js">
     <Select
       defaultValue={colourOptions[2]}
       label="Single select"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nyc": "^11.1.0",
     "raf-schd": "^2.1.0",
     "react": "^16.2.0",
-    "react-codesandboxer": "^0.2.1",
+    "react-codesandboxer": "^0.3.0",
     "react-dom": "^16.2.0",
     "react-markings": "^1.2.0",
     "react-router-dom": "^4.2.2",


### PR DESCRIPTION
Released v0.3 of `react-codesandboxer`, and updated exampleWrapper to use the newer version.

This was a fairly major API rewrite, but should be a much more stable base to build on. Easiest upgrade after that is to get a 'loading' svg, so we can show this to people while they are waiting to fetch files.

Biggest wins:
codesandboxer handles all file fetching itself, pushing nothing back onto you.
Now can fetch any number of files from github, and send them to codesandbox.
Has security around only fetching a file once.
Resolves all relative imports.