### PR TITLE
Issue #1084 - Accessibility for VoiceOver, add autoComplete prop to Select.js

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -15,6 +15,7 @@ import NumericSelect from './components/NumericSelect';
 import BooleanSelect from './components/BooleanSelect';
 import Virtualized from './components/Virtualized';
 import States from './components/States';
+import AutoCompleteStates from './components/AutoCompleteStates';
 
 ReactDOM.render(
 	<div>
@@ -31,6 +32,7 @@ ReactDOM.render(
 			hint="Enter a value that's NOT in the list, then hit return"
 			label="Custom tag creation"
 		/>
+		<AutoCompleteStates label="AutoCompleteStates" />
 	</div>,
 	document.getElementById('example')
 );

--- a/examples/src/components/AutoCompleteStates.js
+++ b/examples/src/components/AutoCompleteStates.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+
+const STATES = require('../data/states');
+
+var AutoCompleteStates = createClass({
+	displayName: 'AutoCompleteStates',
+	propTypes: {
+		label: PropTypes.string,
+		searchable: PropTypes.bool,
+	},
+	getDefaultProps () {
+		return {
+			label: 'States:',
+			searchable: true,
+		};
+	},
+	getInitialState () {
+		return {
+			country: 'AU',
+			disabled: false,
+			searchable: this.props.searchable,
+			selectValue: 'new-south-wales',
+			clearable: true,
+			rtl: false,
+		};
+	},
+	clearValue (e) {
+		this.select.setInputValue('');
+	},
+	switchCountry (e) {
+		var newCountry = e.target.value;
+		this.setState({
+			country: newCountry,
+			selectValue: null,
+		});
+	},
+	updateValue (newValue) {
+		this.setState({
+			selectValue: newValue,
+		});
+	},
+	focusStateSelect () {
+		this.refs.stateSelect.focus();
+	},
+	toggleCheckbox (e) {
+		let newState = {};
+		newState[e.target.name] = e.target.checked;
+		this.setState(newState);
+	},
+	render () {
+		var options = STATES[this.state.country];
+		return (
+			<div className="section">
+				<h3 className="section-heading">{this.props.label} <a href="https://github.com/JedWatson/react-select/tree/master/examples/src/components/AutoCompleteStates.js">(Source)</a></h3>
+				<Select
+					id="state-select"
+					ref={(ref) => { this.select = ref; }}
+					onBlurResetsInput={false}
+					onSelectResetsInput={false}
+					autoComplete={true}
+					autoFocus
+					options={options}
+					simpleValue
+					clearable={this.state.clearable}
+					name="selected-state"
+					disabled={this.state.disabled}
+					value={this.state.selectValue}
+					onChange={this.updateValue}
+					rtl={this.state.rtl}
+					searchable={this.state.searchable}
+				/>
+				<div
+	                aria-label={`${this.state.selectValue}`}
+	                aria-live="polite">
+                </div>
+				<button style={{ marginTop: '15px' }} type="button" onClick={this.focusStateSelect}>Focus Select</button>
+				<button style={{ marginTop: '15px' }} type="button" onClick={this.clearValue}>Clear Value</button>
+
+				<div className="checkbox-list">
+
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" name="searchable" checked={this.state.searchable} onChange={this.toggleCheckbox}/>
+						<span className="checkbox-label">Searchable</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" name="disabled" checked={this.state.disabled} onChange={this.toggleCheckbox}/>
+						<span className="checkbox-label">Disabled</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" name="clearable" checked={this.state.clearable} onChange={this.toggleCheckbox}/>
+						<span className="checkbox-label">Clearable</span>
+					</label>
+					<label className="checkbox">
+						<input type="checkbox" className="checkbox-control" name="rtl" checked={this.state.rtl} onChange={this.toggleCheckbox}/>
+						<span className="checkbox-label">rtl</span>
+					</label>
+				</div>
+				<div className="checkbox-list">
+					<label className="checkbox">
+						<input type="radio" className="checkbox-control" checked={this.state.country === 'AU'} value="AU" onChange={this.switchCountry}/>
+						<span className="checkbox-label">Australia</span>
+					</label>
+					<label className="checkbox">
+						<input type="radio" className="checkbox-control" checked={this.state.country === 'US'} value="US" onChange={this.switchCountry}/>
+						<span className="checkbox-label">United States</span>
+					</label>
+				</div>
+			</div>
+		);
+	}
+});
+
+
+module.exports = AutoCompleteStates;

--- a/examples/src/components/AutoCompleteStates.js
+++ b/examples/src/components/AutoCompleteStates.js
@@ -60,7 +60,7 @@ var AutoCompleteStates = createClass({
 					ref={(ref) => { this.select = ref; }}
 					onBlurResetsInput={false}
 					onSelectResetsInput={false}
-					autoComplete={true}
+					autoComplete
 					autoFocus
 					options={options}
 					simpleValue
@@ -73,9 +73,9 @@ var AutoCompleteStates = createClass({
 					searchable={this.state.searchable}
 				/>
 				<div
-	                aria-label={`${this.state.selectValue}`}
-	                aria-live="polite">
-                </div>
+					aria-label={`${this.state.selectValue}`}
+					aria-live="polite"
+				 />
 				<button style={{ marginTop: '15px' }} type="button" onClick={this.focusStateSelect}>Focus Select</button>
 				<button style={{ marginTop: '15px' }} type="button" onClick={this.clearValue}>Clear Value</button>
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -610,10 +610,11 @@ class Select extends React.Component {
 		}
 	}
 
-	selectValue (value) {
+	selectValue (value, keepOpen) {
 		// NOTE: we actually add/set the value in a callback to make sure the
 		// input value is empty to avoid styling issues in Chrome
-		if (this.props.closeOnSelect) {
+		const closeOnSelect = keepOpen ? false: this.props.closeOnSelect;
+		if (closeOnSelect) {
 			this.hasScrolledToOption = false;
 		}
 		const updatedValue = this.props.onSelectResetsInput ? '' : this.state.inputValue;
@@ -621,7 +622,7 @@ class Select extends React.Component {
 			this.setState({
 				focusedIndex: null,
 				inputValue: this.handleInputValueChange(updatedValue),
-				isOpen: !this.props.closeOnSelect,
+				isOpen: !closeOnSelect,
 			}, () => {
 				const valueArray = this.getValueArray(this.props.value);
 				if (valueArray.some(i => i[this.props.valueKey] === value[this.props.valueKey])) {
@@ -633,7 +634,7 @@ class Select extends React.Component {
 		} else {
 			this.setState({
 				inputValue: this.handleInputValueChange(updatedValue),
-				isOpen: !this.props.closeOnSelect,
+				isOpen: !closeOnSelect,
 				isPseudoFocused: this.state.isFocused,
 			}, () => {
 				this.setValue(value);
@@ -785,6 +786,10 @@ class Select extends React.Component {
 		this.setState({
 			focusedIndex: options[focusedIndex].index,
 			focusedOption: options[focusedIndex].option
+		}, () => {
+			if (this.props.autoComplete && (dir === 'previous' || dir === 'next')){
+				this.selectFocusedOption(true);
+			}			
 		});
 	}
 
@@ -792,9 +797,9 @@ class Select extends React.Component {
 		return this._focusedOption;
 	}
 
-	selectFocusedOption () {
+	selectFocusedOption (keepOpen) {
 		if (this._focusedOption) {
-			return this.selectValue(this._focusedOption);
+			return this.selectValue(this._focusedOption, keepOpen);
 		}
 	}
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -613,7 +613,7 @@ class Select extends React.Component {
 	selectValue (value, keepOpen) {
 		// NOTE: we actually add/set the value in a callback to make sure the
 		// input value is empty to avoid styling issues in Chrome
-		const closeOnSelect = keepOpen ? false: this.props.closeOnSelect;
+		const closeOnSelect = keepOpen === true ? false : this.props.closeOnSelect;
 		if (closeOnSelect) {
 			this.hasScrolledToOption = false;
 		}
@@ -1199,7 +1199,7 @@ Select.propTypes = {
 	'aria-labelledby': PropTypes.string,  // html id of an element that should be used as the label (for assistive tech)
 	arrowRenderer: PropTypes.func,        // create the drop-down caret element
 	autoBlur: PropTypes.bool,             // automatically blur the component when an option is selected
-	autoComplete: PropTypes.bool,		  // automatically select the focused value when using the up and down keys
+	autoComplete: PropTypes.bool,         // automatically select the focused value when using the up and down keys
 	autoFocus: PropTypes.bool,            // autofocus the component on mount
 	autofocus: PropTypes.bool,            // deprecated; use autoFocus instead
 	autosize: PropTypes.bool,             // whether to enable autosizing or not
@@ -1217,7 +1217,7 @@ Select.propTypes = {
 	escapeClearsValue: PropTypes.bool,    // whether escape clears the value when the menu is closed
 	filterOption: PropTypes.func,         // method to filter a single option (option, filterString)
 	filterOptions: PropTypes.any,         // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
-	id: PropTypes.string, 				        // html id to set on the input element for accessibility or tests
+	id: PropTypes.string,                 // html id to set on the input element for accessibility or tests
 	ignoreAccents: PropTypes.bool,        // whether to strip diacritics when filtering
 	ignoreCase: PropTypes.bool,           // whether to perform case-insensitive filtering
 	inputProps: PropTypes.object,         // custom attributes for the Input
@@ -1258,7 +1258,7 @@ Select.propTypes = {
 	removeSelected: PropTypes.bool,       // whether the selected option is removed from the dropdown on multi selects
 	required: PropTypes.bool,             // applies HTML5 required attribute when needed
 	resetValue: PropTypes.any,            // value to use when you clear the control
-	rtl: PropTypes.bool, 									// set to true in order to use react-select in right-to-left direction
+	rtl: PropTypes.bool,                  // set to true in order to use react-select in right-to-left direction
 	scrollMenuIntoView: PropTypes.bool,   // boolean to enable the viewport to shift so that the full menu fully visible when engaged
 	searchable: PropTypes.bool,           // whether to enable searching feature or not
 	simpleValue: PropTypes.bool,          // pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false

--- a/src/Select.js
+++ b/src/Select.js
@@ -1199,6 +1199,7 @@ Select.propTypes = {
 	'aria-labelledby': PropTypes.string,  // html id of an element that should be used as the label (for assistive tech)
 	arrowRenderer: PropTypes.func,        // create the drop-down caret element
 	autoBlur: PropTypes.bool,             // automatically blur the component when an option is selected
+	autoComplete: PropTypes.bool,		  // automatically select the focused value when using the up and down keys
 	autoFocus: PropTypes.bool,            // autofocus the component on mount
 	autofocus: PropTypes.bool,            // deprecated; use autoFocus instead
 	autosize: PropTypes.bool,             // whether to enable autosizing or not
@@ -1274,6 +1275,7 @@ Select.propTypes = {
 
 Select.defaultProps = {
 	arrowRenderer: defaultArrowRenderer,
+	autoComplete: false,
 	autosize: true,
 	backspaceRemoves: true,
 	backspaceToRemoveMessage: 'Press backspace to remove {label}',

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -4495,6 +4495,33 @@ describe('Select', () => {
 			warn.restore();
 		});
 	});
+	describe('with autocomplete', () => {
+		it('should update the input value', () => {
+			wrapper = createControl({
+				autoComplete: true,
+				options: defaultOptions,
+			});
+			return expect(wrapper,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />)
+					.then(input => {
+						expect(onChange, 'was called');
+					});
+		});
+	});
+	describe('without autocomplete', () => {
+		it('should not update the input value', () => {
+			wrapper = createControl({
+				options: defaultOptions,
+			});
+			return expect(wrapper,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />,
+					'with event', 'keyDown', ARROW_DOWN, 'on', <div className="Select-control" />)
+					.then(input => {
+						expect(onChange, 'was not called');
+					});
+		});
+	});	
 	describe('rtl', () => {
 		describe('className', () => {
 			it('assigns the className Select--rtl to the outer-most element', () => {


### PR DESCRIPTION
I've added a new prop in Select.js named autoComplete. It allows the up and down arrows to act as the enter button when navigating, except it doesn't close the menu. 

Like I did in the example AutoCompleteStates.js, you can add a div with aria-label={selectValue}. This will allow the screen reader to notice the change and read it out to the user when navigating with arrow keys.