### PR TITLE
Add use cases for clear with tab, click and  touched and dragged

### DIFF
--- a/cypress/fixtures/selectors.json
+++ b/cypress/fixtures/selectors.json
@@ -1,6 +1,8 @@
 {
   "clearValues": ".react-select__clear-indicator",
   "disabledCheckbox": "#cypress-single__disabled-checkbox",
+  "firstMultiValueRemove":
+    "#cypress-multi .react-select__multi-value__remove:first",
   "groupColor": "#cypress-single-grouped .react-select__group",
   "menuGrouped": "#react-select-3--listbox",
   "menuMulti": "#react-select-4--listbox",
@@ -9,8 +11,9 @@
   "multiSelectDefaultValues": "#cypress-multi .react-select__multi-value",
   "multiSelectInput": "#react-select-4--input",
   "noOptionsValue": ".react-select__menu-notice--no-options",
-  "firstMultiValueRemove":
-    "#cypress-multi .react-select__multi-value__remove:first",
+  "placeHolderGrouped": "#cypress-single-grouped .react-select__placeholder",
+  "placeHolderMulti": "#cypress-multi .react-select__placeholder",
+  "placeHolderSingle": "#cypress-single .react-select__placeholder",
   "singleGroupedInputValue":
     "#cypress-single-grouped .react-select__single-value",
   "singleInputValue": ".react-select__single-value",

--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -1,6 +1,6 @@
 const selector = require('../fixtures/selectors.json');
 
-const viewport = ['macbook-15'];
+const viewport = ['macbook-15', 'iphone-6'];
 
 describe('New Select', function() {
   before(function() {
@@ -93,6 +93,34 @@ describe('New Select', function() {
           .should('be.visible')
           .and('have.attr', 'aria-expanded', 'true');
       });
+      it('Should not display the options menu when touched and dragged ' + view, function() {
+          cy
+            .get(selector.toggleMenuSingle)
+            .click()
+            .click()
+            .get(selector.menuSingle)
+            .should('not.be.visible')
+            // to be sure it says focus and the menu is closed
+            .get(selector.singleSelectSingleInput)
+            .trigger('mousedown')
+            .get(selector.menuSingle)
+            .should('not.be.visible');
+      });
+      it('Should not display menu when clearing using backspace - assuming autofocus' + view, function() {
+        cy
+            .get(selector.singleSelectGroupedInput)
+            .click({ force: true })
+            .get(selector.toggleMenuGrouped)
+            .click()
+            .get(selector.singleSelectGroupedInput)
+            // to be sure it says focus and the menu is closed
+            .type('{backspace}', { force: true })
+            .type('{backspace}', { force: true })
+            .get(selector.placeHolderGrouped)
+            .should('contain', 'Select...')
+            .get(selector.menuGrouped)
+            .should('not.be.visible');
+      });
     });
   });
 
@@ -111,8 +139,8 @@ describe('New Select', function() {
             .get(selector.multiSelectDefaultValues)
             .then(function($defaultValue) {
               expect($defaultValue).to.have.length(2);
-              expect($defaultValue.eq(0)).to.contain('Blue');
-              expect($defaultValue.eq(1)).to.contain('Green');
+              expect($defaultValue.eq(0)).to.contain('Purple');
+              expect($defaultValue.eq(1)).to.contain('Red');
             });
 
           cy
@@ -121,12 +149,28 @@ describe('New Select', function() {
             .get(selector.multiSelectDefaultValues)
             .then(function($defaultValue) {
               expect($defaultValue).to.have.length(1);
-              expect($defaultValue.eq(0)).to.contain('Green');
+              expect($defaultValue.eq(0)).to.contain('Red');
             })
             .get(selector.menuMulti)
             .should('not.be.visible');
         }
       );
+      it(
+        'Should be able to remove values on keyboard actions ' + view, function() {
+          cy
+            .get(selector.multiSelectInput)
+            .click()
+            .type('{backspace}', { force: true })
+            .get(selector.multiSelectDefaultValues)
+            .then(function($defaultValue) {
+              expect($defaultValue).to.have.length(1);
+              expect($defaultValue.eq(0)).to.contain('Purple');
+            })
+            .get(selector.multiSelectInput)
+            .type('{backspace}', { force: true })
+            .get(selector.placeHolderMulti)
+            .should('contain', 'Select...');
+        });
       it(
         'Should select different options using - click and enter ' + view,
         function() {


### PR DESCRIPTION
@gwyneplaine , adding cases for : 

- should display the options menu when tapped
- should not display the options menu when touched and dragged
- remove any selection - add smoketest for removal on keyboard action.
- on tapping `clear` use iphone viewport to validate tap event
- on tapping and dragging `clear`
- click on Clear button, menu shall remain closed








