### PR TITLE
Fixes long labels

### DIFF
--- a/scss/multi.scss
+++ b/scss/multi.scss
@@ -40,7 +40,7 @@
 	// common
 	.Select-value-icon,
 	.Select-value-label {
-		display: inline-block;
+		display: table-cell;
 		vertical-align: middle;
 	}
 


### PR DESCRIPTION
- Fixes issue "Styling issue with very long labels #402"
- I should also mention leaving 'vertical-align: middle' vertically centers the 'x' for long labels. If this is not desired, simply remove that property.
![screen shot 2018-03-15 at 3 42 59 pm](https://user-images.githubusercontent.com/2279954/37492618-a8a2afea-2867-11e8-838a-6a5474e4415b.png)
