### PR TITLE
[v2] make the children of multi-value-remove customisable

### DIFF
--- a/docs/examples/CustomMultiValueRemove.js
+++ b/docs/examples/CustomMultiValueRemove.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react';
+import EmojiIcon from '@atlaskit/icon/glyph/emoji';
 import Tooltip from '@atlaskit/tooltip';
 import Select, { components } from '../../src';
 import { colourOptions } from '../data';
@@ -8,7 +9,9 @@ import { colourOptions } from '../data';
 const MultiValueRemove = (props) => {
   return (
     <Tooltip content={'Customise your multi-value remove component!'} truncateText>
-      <components.MultiValueRemove {...props}/>
+      <components.MultiValueRemove {...props}>
+        <EmojiIcon primaryColor="#2684FF"/>
+      </components.MultiValueRemove>
     </Tooltip>
   );
 };

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Component, type Node } from 'react';
 
 import { borderRadius, colors, spacing } from '../theme';
 import { className } from '../utils';
@@ -52,7 +52,27 @@ export const multiValueRemoveCSS = () => ({
 
 export const MultiValueContainer = Div;
 export const MultiValueLabel = Div;
-export const MultiValueRemove = Div;
+export type MultiValueRemoveProps = PropsWithStyles & {
+  children: Node,
+  innerProps: any,
+  removeProps: {
+    onClick: any => void,
+    onMouseDown: any => void,
+  }
+};
+export class MultiValueRemove extends Component <MultiValueRemoveProps> {
+  static defaultProps = {
+    children: <CrossIcon size={14}/>
+  }
+  render () {
+    const { children, ...props } = this.props;
+    return (
+      <Div {...props}>
+        {children}
+      </Div>
+    );
+  }
+}
 
 const MultiValue = (props: MultiValueProps) => {
   const {
@@ -80,9 +100,7 @@ const MultiValue = (props: MultiValueProps) => {
       <Label className={cn.label} css={css.label}>
         {children}
       </Label>
-      <Remove className={cn.remove} css={css.remove} {...removeProps}>
-        <CrossIcon size={14} />
-      </Remove>
+      <Remove className={cn.remove} css={css.remove} {...removeProps}/>
     </Container>
   );
 };


### PR DESCRIPTION
Previously this was an internally declared child <CrossIcon/>
This change makes <CrossIcon/> a default value of the children prop of MultiValueRemove, allowing users to customise the child of the MultiValueRemove container. 