### PR TITLE
Bumps flow-bin to version 0.68

### DIFF
--- a/docs/App/PageNav.js
+++ b/docs/App/PageNav.js
@@ -2,7 +2,7 @@
 // @jsx glam
 
 import glam from 'glam';
-import React, { Component, type Element } from 'react';
+import React, { Component, type ElementRef } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import type { RouterProps } from '../types';
@@ -33,7 +33,7 @@ const NavSection = () => {
 type NavState = { links: Array<Object>, activeId: string | null };
 
 class PageNav extends Component<RouterProps, NavState> {
-  scrollSpy: Element<*>;
+  scrollSpy: ElementRef<typeof ScrollSpy>;
   state = { activeId: null, links: [] };
   componentDidMount() {
     const { match } = this.props;

--- a/docs/App/Sticky.js
+++ b/docs/App/Sticky.js
@@ -22,8 +22,8 @@ type State = {
 };
 
 export default class Sticky extends Component<Props, State> {
-  innerEl: Element;
-  outerEl: Element;
+  innerEl: ElementRef<'div'>;
+  outerEl: ElementRef<'div'>;
   state = {
     height: 'auto',
     isFixed: false,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "^7.3.0",
     "extract-react-types": "^0.8.1",
     "extract-react-types-loader": "^0.1.0",
-    "flow-bin": "^0.67.1",
+    "flow-bin": "^0.68.0",
     "flow-copy-source": "^1.3.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^2.30.1",

--- a/src/Select.js
+++ b/src/Select.js
@@ -583,11 +583,12 @@ export default class Select extends Component<Props, State> {
     if (!this.state.isFocused) {
       this.openAfterFocus = true;
       this.focusInput();
-    } else if (!this.state.menuIsOpen) {
+    } else if (!this.props.menuIsOpen) {
       this.openMenu('first');
     } else {
       this.onMenuClose();
     }
+    // $FlowFixMe HTMLElement type does not have tagName property
     if (event.target.tagName !== 'INPUT') {
       event.preventDefault();
     }
@@ -599,9 +600,7 @@ export default class Select extends Component<Props, State> {
     }
     if (this.props.isDisabled) return;
     const { isMulti, menuIsOpen } = this.props;
-    if (!this.focused) {
-      this.focusInput();
-    }
+    this.focusInput();
     if (menuIsOpen) {
       this.inputIsHiddenAfterUpdate = !isMulti;
       this.onMenuClose();


### PR DESCRIPTION
I have been looking at upgrading Atlaskit to Flow version 0.68. To get there, react-select needs to be compatible with 0.68. Upgrade was fairly straightforward. I'll highlight some of the most important changes.