### PR TITLE
Remain focused on option after selecting it

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -646,6 +646,7 @@ class Select extends React.Component {
 		const visibleOptions = this._visibleOptions.filter(val => !val.disabled);
 		const lastValueIndex = visibleOptions.indexOf(value);
 		this.setValue(valueArray.concat(value));
+		if(!this.props.closeOnSelect) { return; }
 		if (visibleOptions.length - 1 === lastValueIndex) {
 			// the last option was selected; focus the second-last one
 			this.focusOption(visibleOptions[lastValueIndex - 1]);

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -2333,6 +2333,17 @@ describe('Select', () => {
 			]);
 		});
 
+		it('does not change the focused item after selecting it', () => {
+			clickArrowToOpen();
+
+			var items = ReactDOM.findDOMNode(instance).querySelectorAll('.Select-option');
+
+			// Click the option "Two" to select it
+			expect(items[1], 'to have text', 'Two');
+			TestUtils.Simulate.mouseDown(items[1]);
+			expect(items[1].classList.contains('is-focused'), 'to be true');
+		});
+
 		it('removes a selected value if chosen again', () => {
 
 			clickArrowToOpen();


### PR DESCRIPTION
Currently, selecting an option in multi select with `removeSelected=false` and `closeOnSelect=false` causes the focused option to jump which looks odd, especially when using a mouse. This ensures it stays correctly selected.

Fixes #2169 (see issue for more details + demo)