### PR TITLE
[V2] update async docs

### DIFF
--- a/docs/pages/async/Docs.js
+++ b/docs/pages/async/Docs.js
@@ -1,0 +1,99 @@
+// @flow
+
+import React from 'react';
+import { Props } from '@atlaskit/docs';
+import md from '../../markdown/renderer';
+import ExampleWrapper from '../../ExampleWrapper';
+import {
+  AsyncCallbacks,
+  AsyncMulti,
+  AsyncPromises,
+} from '../../examples';
+
+export default md`
+# Async
+
+~~~jsx
+import Async from 'react-select/lib/Async';
+~~~
+
+Use the Async component to load options asynchronously as the user searches.
+
+---
+## Usage
+
+We can load options asynchronously by **returning the Promise** from loadOptions function prop or by **calling the callback argument with options** that is passed to loadOptions function prop.
+
+First argument passed to the loadOptions function prop is the search string(**inputValue**) user has typed in Async select. Second argument is the callback we can call with options
+to load, we can ignore the second argument if returning a Promise from loadOptions prop funciton.
+
+${(
+  <ExampleWrapper
+    label="With Callbacks"
+    urlPath="docs/examples/AsyncCallbacks.js"
+    raw={require('!!raw-loader!../../examples/AsyncCallbacks.js')}
+  >
+    <AsyncCallbacks />
+  </ExampleWrapper>
+)}
+
+TL;DR:
+
+~~~jsx
+<Async
+  loadOptions={makeCallAndloadOptions}
+/>
+
+// In your component
+makeCallAndloadOptions = (searchString, callback) => {
+  fetch('myremoteURL')
+    .then(options => options.filter(option => option.label.indexOf(searchString) > -1 ))
+    .then(filteredOptions => callback(filteredOptions));
+}
+~~~
+
+---
+
+${(
+  <ExampleWrapper
+    label="With Promises"
+    urlPath="docs/examples/AsyncPromises.js"
+    raw={require('!!raw-loader!../../examples/AsyncPromises.js')}
+  >
+    <AsyncPromises />
+  </ExampleWrapper>
+)}
+
+TL;DR:
+
+~~~jsx
+<Async
+  loadOptions={makeCallAndloadOptions}
+/>
+
+// In your component
+makeCallAndloadOptions = searchString => 
+  new Promise(resolve => {
+    fetch('myremoteURL')
+    .then(options => options.filter(option => option.label.indexOf(searchString) > -1 ))
+    .then(filteredOptions => resolve(filteredOptions));
+  })
+~~~
+
+${(
+  <ExampleWrapper
+    label="Async MultiSelect"
+    urlPath="docs/examples/AsyncMulti.js"
+    raw={require('!!raw-loader!../../examples/AsyncMulti.js')}
+  >
+    <AsyncMulti/>
+  </ExampleWrapper>
+)}
+
+## API
+
+These props are included with in both the Async and AsyncCreatable select.
+
+${<Props shouldCollapseProps heading="" props={require('!!extract-react-types-loader!../../PropTypes/Async')} />}
+`;
+

--- a/docs/pages/async/index.js
+++ b/docs/pages/async/index.js
@@ -2,68 +2,19 @@
 
 import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
-import ExampleWrapper from '../../ExampleWrapper';
-import md from '../../markdown/renderer';
-import {
-  AsyncCallbacks,
-  AsyncMulti,
-  AsyncPromises,
-} from '../../examples';
-
+import Docs from './Docs';
 
 export default function Async() {
   return (
-  <Fragment>
-    <Helmet>
-      <title>Async - React Select</title>
-      <meta
-        name="description"
-        content="The react-select Async Component."
-      />
-    </Helmet>
-    {md`
-    # Async
-    Use the Async component to load options from a remote source as the user types.
-
-    ~~~jsx
-    import Async from 'react-select/lib/Async';
-    ~~~
-
-    ## Loading Asynchronously
-
-    The loadOptions prop allows users to either resolve from a callback...
-
-    ${(
-      <ExampleWrapper
-        label="Callbacks"
-        urlPath="docs/examples/AsyncCallbacks.js"
-        raw={require('!!raw-loader!../../examples/AsyncCallbacks.js')}
-      >
-        <AsyncCallbacks />
-      </ExampleWrapper>
-    )}
-
-    or resolve from a returned promise....
-
-    ${(
-      <ExampleWrapper
-        label="Promises"
-        urlPath="docs/examples/AsyncPromises.js"
-        raw={require('!!raw-loader!../../examples/AsyncPromises.js')}
-      >
-        <AsyncPromises />
-      </ExampleWrapper>
-    )}
-
-    ${(
-      <ExampleWrapper
-        label="Async MultiSelect"
-        urlPath="docs/examples/AsyncMulti.js"
-        raw={require('!!raw-loader!../../examples/AsyncMulti.js')}
-      >
-        <AsyncMulti/>
-      </ExampleWrapper>
-    )}
-  `}
-</Fragment>);
+    <Fragment>
+      <Helmet>
+        <title>Async - React Select</title>
+        <meta
+          name="description"
+          content="The react-select Async Component."
+        />
+      </Helmet>
+      {Docs}
+    </Fragment>
+  );
 };


### PR DESCRIPTION
Working on docs for async component.

I am inclined towards the given kind of format, ( though there could be better heading for TL;DR ).

- Having a separate markdown than rest of head data will enable us to add an edit button which takes us directly to the markdown content. ( and keeps it simple, though it maybe because I have habit of looking at this doc format. ).

- TL;DR - gives minimum code( not working ) to understand loadOptions. Devs can read code faster than text  🤔)

cc. @JedWatson , @gwyneplaine , @Noviny , @jossmac , @treshugart 

