### PR TITLE
[V2] remove wildcard from lib ignore path in flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [ignore]
-.*/lib/.*
+./lib/.*
 .*/node_modules/cypress/.*
 .*/node_modules/@atlaskit/tooltip/dist/cjs/components/Marshal.js.flow
 


### PR DESCRIPTION
We want to be ignoring only our lib files, not lib files in other directories (i.e. node_modules).
Ignoring lib files of our dependencies can cause potential dependency type resolution issues. 