### PR TITLE
[V2] Fix: advanced menu placement logic

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -408,7 +408,6 @@ export type MenuPortalProps = PropsWithStyles & {
   appendTo: HTMLElement,
   children: Node, // ideally Menu<MenuProps>
   controlElement: HTMLElement,
-  maxMenuHeight: number,
   menuPlacement: MenuPlacement,
   menuPosition: MenuPosition,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -211,6 +211,13 @@ export function getBoundingClientObj(element: HTMLElement) {
     width: rect.width,
   };
 }
+export type RectType = {
+  left: number,
+  right: number,
+  bottom: number,
+  height: number,
+  width: number,
+};
 
 // ==============================
 // String to Key (kebabify)


### PR DESCRIPTION
Resolves cases where:
- position is `absolute` (portal) and placement is `top`
- position is `fixed` and placement is `bottom`, must flip