### PR TITLE
Prevent focus of next option in multi selects that don't remove options

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -646,12 +646,15 @@ class Select extends React.Component {
 		const visibleOptions = this._visibleOptions.filter(val => !val.disabled);
 		const lastValueIndex = visibleOptions.indexOf(value);
 		this.setValue(valueArray.concat(value));
-		if (visibleOptions.length - 1 === lastValueIndex) {
-			// the last option was selected; focus the second-last one
-			this.focusOption(visibleOptions[lastValueIndex - 1]);
-		} else if (visibleOptions.length > lastValueIndex) {
-			// focus the option below the selected one
-			this.focusOption(visibleOptions[lastValueIndex + 1]);
+
+		if (this.props.removeSelected !== false) {
+			if (visibleOptions.length - 1 === lastValueIndex) {
+				// the last option was selected; focus the second-last one
+				this.focusOption(visibleOptions[lastValueIndex - 1]);
+			} else if (visibleOptions.length > lastValueIndex) {
+				// focus the option below the selected one
+				this.focusOption(visibleOptions[lastValueIndex + 1]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi everyone, fantastic work on this library! I think I've found a weird edge case on multi selects that this PR fixes.

## Issue:
When you have a multi select with:
 - `closeOnSelect`: false
- `removeSelected`: false

If you click an item, it adds focus to the next item. In the screenshot added, I've clicked "vanilla", which highlights it as selected and also adds focus to "strawberry". When I move my mouse, focus will be returned to "vanilla". This creates a poor UX of flashes as `"is-focused"` is attached and removed from items as a user selects multiple options. This small PR fixes that.

![image](https://user-images.githubusercontent.com/4015939/38436741-5cdee4d0-39cd-11e8-96c0-e795512ef068.png)

## Issue Demo:
The issue can be tested on the demo page http://jedwatson.github.io/react-select/. 

To replicate: de-select "remove selected options", and select "stay open when option selected". Then click an option and you will see the next option gets focused. Move your mouse and you will see it loses focus. You will see as you click a few options it creates a poor UX, while with this change applied it functions nicer.
