### PR TITLE
[V2] Fix inputHeight

### DIFF
--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -81,7 +81,7 @@ describe('New Select', function() {
           .get(selector.toggleMenuSingle)
           .click({ force: true })
           .get(selector.singleSelectSingleInput)
-          .should('not.be.visible');
+          .should('be.disabled');
       });
       it('Should display group in the menu ' + view, function() {
         cy

--- a/docs/Tests.js
+++ b/docs/Tests.js
@@ -8,12 +8,11 @@ import { H1, Note } from './styled-components';
 import { colourOptions, groupedOptions } from './data';
 
 import * as animatedComponents from '../src/animated';
-import * as defaultComponents from '../src/components';
 
 type SuiteProps = {
   selectComponent: ComponentType<any>,
   idSuffix: string,
-}
+};
 type SuiteState = {
   isDisabled: boolean,
   isFixed: boolean,
@@ -22,13 +21,12 @@ type SuiteState = {
   portalPlacement: MenuPlacement,
 };
 
-const AnimatedSelect = (props) => (
+const AnimatedSelect = props => (
   <Select
     {...props}
     components={{
-      ...defaultComponents,
       ...animatedComponents,
-      ...props.components
+      ...props.components,
     }}
   />
 );
@@ -70,7 +68,7 @@ class TestSuite extends Component<SuiteProps, SuiteState> {
             autoFocus
             defaultValue={colourOptions[0]}
             styles={{
-              menuPortal: (base) => ({ ...base, zIndex: 999 }),
+              menuPortal: base => ({ ...base, zIndex: 999 }),
             }}
             isDisabled={this.state.isDisabled}
             isLoading={this.state.isLoading}
@@ -84,7 +82,7 @@ class TestSuite extends Component<SuiteProps, SuiteState> {
             id={`cypress-${idSuffix}__disabled-checkbox`}
           />
           Disabled
-          </Note>
+        </Note>
         <Note Tag="label" style={{ marginLeft: '1em' }}>
           <input
             type="checkbox"
@@ -92,11 +90,14 @@ class TestSuite extends Component<SuiteProps, SuiteState> {
             id={`cypress-${idSuffix}__loading-checkbox`}
           />
           Loading
-          </Note>
+        </Note>
 
         <h4>Grouped</h4>
         <div id={`cypress-${idSuffix}-grouped`}>
-          <SelectComp defaultValue={colourOptions[1]} options={groupedOptions} />
+          <SelectComp
+            defaultValue={colourOptions[1]}
+            options={groupedOptions}
+          />
         </div>
 
         <h4>Portalled</h4>
@@ -174,7 +175,14 @@ class TestSuite extends Component<SuiteProps, SuiteState> {
 
 export default function Tests() {
   return (
-    <div style={{ margin: 'auto', maxWidth: 440, padding: 20, position: 'relative' }}>
+    <div
+      style={{
+        margin: 'auto',
+        maxWidth: 440,
+        padding: 20,
+        position: 'relative',
+      }}
+    >
       <H1>Test Page for Cypress</H1>
       <h2>Single Select</h2>
       <TestSuite selectComponent={Select} idSuffix="single" />

--- a/src/Select.js
+++ b/src/Select.js
@@ -242,7 +242,6 @@ export default class Select extends Component<Props, State> {
   focusedOptionRef: ?HTMLElement;
   hasGroups: boolean = false;
   input: ?ElRef;
-  inputHeight: ?number = 20;
   inputIsHiddenAfterUpdate: ?boolean;
   instancePrefix: string = '';
   menuRef: ?ElRef;
@@ -333,11 +332,6 @@ export default class Select extends Component<Props, State> {
 
   onInputRef = (ref: ElRef) => {
     this.input = ref;
-
-    // cache the input height to use when the select is disabled
-    if (ref) {
-      this.inputHeight = ref.clientHeight;
-    }
   };
   onControlRef = (ref: ElementRef<*>) => {
     this.controlRef = ref;
@@ -997,7 +991,6 @@ export default class Select extends Component<Props, State> {
         getStyles={this.getStyles}
         id={id}
         innerRef={this.onInputRef}
-        inputHeight={this.inputHeight}
         isDisabled={isDisabled}
         isHidden={inputIsHidden}
         onBlur={this.onInputBlur}

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -514,7 +514,6 @@ exports[`defaults - snapshot 1`] = `
                                 getStyles={[Function]}
                                 id="react-select-2-input"
                                 innerRef={[Function]}
-                                inputHeight={20}
                                 isDisabled={false}
                                 isHidden={false}
                                 onBlur={[Function]}

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -532,6 +532,7 @@ exports[`defaults - snapshot 1`] = `
                                       "margin": 2,
                                       "paddingBottom": 2,
                                       "paddingTop": 2,
+                                      "visibility": "visible",
                                     }
                                   }
                                 >
@@ -542,12 +543,13 @@ exports[`defaults - snapshot 1`] = `
                                         "margin": 2,
                                         "paddingBottom": 2,
                                         "paddingTop": 2,
+                                        "visibility": "visible",
                                       }
                                     }
                                     render={[Function]}
                                   >
                                     <div
-                                      className="css-16n6ap7"
+                                      className="css-cko0rn"
                                     >
                                       <AutosizeInput
                                         aria-autocomplete="list"
@@ -558,6 +560,7 @@ exports[`defaults - snapshot 1`] = `
                                         autoComplete="off"
                                         autoCorrect="off"
                                         className="react-select__input"
+                                        disabled={false}
                                         id="react-select-2-input"
                                         injectStyles={true}
                                         inputRef={[Function]}
@@ -597,6 +600,7 @@ exports[`defaults - snapshot 1`] = `
                                             autoCapitalize="none"
                                             autoComplete="off"
                                             autoCorrect="off"
+                                            disabled={false}
                                             id="react-select-2-input"
                                             onBlur={[Function]}
                                             onChange={[Function]}

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -573,6 +573,7 @@ exports[`defaults - snapshot 1`] = `
                                         "margin": 2,
                                         "paddingBottom": 2,
                                         "paddingTop": 2,
+                                        "visibility": "visible",
                                       }
                                     }
                                   >
@@ -583,12 +584,13 @@ exports[`defaults - snapshot 1`] = `
                                           "margin": 2,
                                           "paddingBottom": 2,
                                           "paddingTop": 2,
+                                          "visibility": "visible",
                                         }
                                       }
                                       render={[Function]}
                                     >
                                       <div
-                                        className="css-16n6ap7"
+                                        className="css-cko0rn"
                                       >
                                         <AutosizeInput
                                           aria-autocomplete="list"
@@ -599,6 +601,7 @@ exports[`defaults - snapshot 1`] = `
                                           autoComplete="off"
                                           autoCorrect="off"
                                           className="react-select__input"
+                                          disabled={false}
                                           id="react-select-2-input"
                                           injectStyles={true}
                                           inputRef={[Function]}
@@ -638,6 +641,7 @@ exports[`defaults - snapshot 1`] = `
                                               autoCapitalize="none"
                                               autoComplete="off"
                                               autoCorrect="off"
+                                              disabled={false}
                                               id="react-select-2-input"
                                               onBlur={[Function]}
                                               onChange={[Function]}

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -555,7 +555,6 @@ exports[`defaults - snapshot 1`] = `
                                   getStyles={[Function]}
                                   id="react-select-2-input"
                                   innerRef={[Function]}
-                                  inputHeight={20}
                                   isDisabled={false}
                                   isHidden={false}
                                   onBlur={[Function]}

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -234,7 +234,6 @@ exports[`snapshot - defaults 1`] = `
         getStyles={[Function]}
         id="react-select-2-input"
         innerRef={[Function]}
-        inputHeight={20}
         isDisabled={false}
         isHidden={false}
         onBlur={[Function]}

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -15,14 +15,13 @@ export type InputProps = PropsWithStyles & {
   isHidden: boolean,
   /** Whether the input is disabled */
   isDisabled?: boolean,
-  /** The input height, used for rendering disabled inputs. */
-  inputHeight?: ?number,
 };
 
-export const css = () => ({
+export const css = ({ isDisabled }: InputProps) => ({
   margin: spacing.baseUnit / 2,
   paddingBottom: spacing.baseUnit / 2,
   paddingTop: spacing.baseUnit / 2,
+  visibility: isDisabled ? 'hidden' : 'visible',
 });
 const inputStyle = isHidden => ({
   background: 0,
@@ -33,18 +32,21 @@ const inputStyle = isHidden => ({
   padding: 0,
 });
 
-const Input = ({ getStyles, innerRef, isHidden, isDisabled, inputHeight, ...props }: InputProps) =>
-  isDisabled ? (
-    // maintain baseline alignment when the input is removed for disabled state
-    <div style={{ height: inputHeight }} />
-  ) : (
-    <Div css={getStyles('input', props)}>
-      <AutosizeInput
-        className={className('input')}
-        inputRef={innerRef}
-        inputStyle={inputStyle(isHidden)}
-        {...props}
-      />
-    </Div>
-  );
+const Input = ({
+  getStyles,
+  innerRef,
+  isHidden,
+  isDisabled,
+  ...props
+}: InputProps) => (
+  <Div css={getStyles('input', props)}>
+    <AutosizeInput
+      className={className('input')}
+      inputRef={innerRef}
+      inputStyle={inputStyle(isHidden)}
+      disabled={isDisabled}
+      {...props}
+    />
+  </Div>
+);
 export default Input;


### PR DESCRIPTION
Previously, the `inputHeight` would be undefined when `<Select isDisabled>` is mounted - it would only have worked if the select was mounted in the enabled state, then switched to disabled.

Using a disabled input has the same effect and completely removes the need to track inputHeight.