### PR TITLE
[V2] Fix FlowTypes in Menu and utils

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -36,7 +36,7 @@ import type {
 type MenuState = { placement: 'bottom' | 'top' | null, maxHeight: number };
 type PlacementArgs = {
   maxHeight: number,
-  menuEl: HTMLElement,
+  menuEl: ElementRef<*>,
   minHeight: number,
   placement: 'bottom' | 'top' | 'auto',
   shouldScroll: boolean,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 // @flow
 
 import raf from 'raf';
+import { type ElementRef } from 'react';
 import type { InputActionMeta, OptionsType, ValueType } from './types';
 
 // ==============================
@@ -110,7 +111,7 @@ export function scrollTo(el: Element, top: number): void {
 // Get Scroll Parent
 // ------------------------------
 
-export function getScrollParent(element: Element): Element {
+export function getScrollParent(element: ElementRef<*>): Element {
   let style = getComputedStyle(element);
   const excludeStaticParent = style.position === 'absolute';
   const overflowRx = /(auto|scroll)/;


### PR DESCRIPTION
Use elementRef instead of HTMLElement and Element in getMenuPlacement and getScrollParent. 