### PR TITLE
change color used to highlight changed sections on the components page

### DIFF
--- a/docs/examples/CustomControl.js
+++ b/docs/examples/CustomControl.js
@@ -5,7 +5,7 @@ import { colourOptions } from '../data';
 const controlStyles = {
   borderRadius: '1px solid black',
   padding: '5px',
-  background: '#2684FF',
+  background: colourOptions[2].color,
   color: 'white'
 };
 

--- a/docs/examples/CustomDropdownIndicator.js
+++ b/docs/examples/CustomDropdownIndicator.js
@@ -9,7 +9,7 @@ const DropdownIndicator = (props) => {
   return (
     <components.DropdownIndicator {...props}>
       <EmojiIcon
-        primaryColor="#2684FF"
+        primaryColor={colourOptions[2].color}
       />
     </components.DropdownIndicator>
   );

--- a/docs/examples/CustomGroup.js
+++ b/docs/examples/CustomGroup.js
@@ -4,7 +4,7 @@ import Select, { components } from '../../src';
 import { colourOptions, groupedOptions } from '../data';
 
 const groupStyles = {
-  border: '2px dotted #2684FF',
+  border: `2px dotted ${colourOptions[2].color}`,
   borderRadius: '5px',
   background: '#f2fcff'
 };

--- a/docs/examples/CustomGroupHeading.js
+++ b/docs/examples/CustomGroupHeading.js
@@ -6,9 +6,9 @@ import EditorPanelIcon from '@atlaskit/icon/glyph/editor/panel';
 import Tooltip from '@atlaskit/tooltip';
 
 const groupStyles = {
-  border: '2px dotted #2684FF',
+  border: `2px dotted ${colourOptions[2].color}`,
   color: 'white',
-  background: '#2684FF',
+  background: colourOptions[2].color,
   padding: '5px 0px',
   display: 'flex',
 };

--- a/docs/examples/CustomIndicatorSeparator.js
+++ b/docs/examples/CustomIndicatorSeparator.js
@@ -6,7 +6,7 @@ import { colourOptions } from '../data';
 
 const indicatorSeparatorStyle = {
   alignSelf: 'stretch',
-  backgroundColor: '#2684FF',
+  backgroundColor: colourOptions[2].color,
   marginBottom: 8,
   marginTop: 8,
   width: 1,

--- a/docs/examples/CustomIndicatorsContainer.js
+++ b/docs/examples/CustomIndicatorsContainer.js
@@ -6,7 +6,7 @@ import { colourOptions } from '../data';
 
 const IndicatorsContainer = (props) => {
   return (
-    <div style={{ background: '#2684FF' }}>
+    <div style={{ background: colourOptions[2].color }}>
       <components.IndicatorsContainer {...props}/>
     </div>
   );

--- a/docs/examples/CustomInput.js
+++ b/docs/examples/CustomInput.js
@@ -10,7 +10,7 @@ const Input = (props) => {
     return <components.Input {...props}/>;
   }
   return (
-    <div style={{ border: '1px dotted #2684FF' }}>
+    <div style={{ border: `1px dotted ${colourOptions[2].color}` }}>
       <Tooltip content={'Custom Input'}>
         <components.Input {...props}/>
       </Tooltip>

--- a/docs/examples/CustomLoadingMessage.js
+++ b/docs/examples/CustomLoadingMessage.js
@@ -42,7 +42,7 @@ export default class CustomLoadingIndicator extends Component<*, State> {
         cacheOptions
         defaultOptions
         loadOptions={promiseOptions}
-        styles={{ loadingMessage: (base) => ({ ...base, backgroundColor: '#2684FF', color: 'white' }) }}
+        styles={{ loadingMessage: (base) => ({ ...base, backgroundColor: colourOptions[2].color, color: 'white' }) }}
         components={{ LoadingMessage }}
       />
     );

--- a/docs/examples/CustomMenuList.js
+++ b/docs/examples/CustomMenuList.js
@@ -5,7 +5,7 @@ import { colourOptions, groupedOptions } from '../data';
 
 const menuHeaderStyle = {
   padding: '8px 12px',
-  background: '#2684FF',
+  background: colourOptions[2].color,
   color: 'white',
 };
 

--- a/docs/examples/CustomMultiValueContainer.js
+++ b/docs/examples/CustomMultiValueContainer.js
@@ -17,7 +17,7 @@ export default () => (
   <Select
     closeMenuOnSelect={false}
     components={{ MultiValueContainer }}
-    styles={{ multiValue: (base) => ({ ...base, border: '2px dotted #2684FF' }) }}
+    styles={{ multiValue: (base) => ({ ...base, border: `2px dotted ${colourOptions[2].color}` }) }}
     defaultValue={[colourOptions[4], colourOptions[5]]}
     isMulti
     options={colourOptions}

--- a/docs/examples/CustomMultiValueLabel.js
+++ b/docs/examples/CustomMultiValueLabel.js
@@ -17,7 +17,7 @@ export default () => (
   <Select
     closeMenuOnSelect={false}
     components={{ MultiValueLabel }}
-    styles={{ multiValueLabel: (base) => ({ ...base, backgroundColor: '#2684FF', color: 'white' }) }}
+    styles={{ multiValueLabel: (base) => ({ ...base, backgroundColor: colourOptions[2].color, color: 'white' }) }}
     defaultValue={[colourOptions[4], colourOptions[5]]}
     isMulti
     options={colourOptions}

--- a/docs/examples/CustomMultiValueRemove.js
+++ b/docs/examples/CustomMultiValueRemove.js
@@ -10,7 +10,7 @@ const MultiValueRemove = (props) => {
   return (
     <Tooltip content={'Customise your multi-value remove component!'} truncateText>
       <components.MultiValueRemove {...props}>
-        <EmojiIcon primaryColor="#2684FF"/>
+        <EmojiIcon primaryColor={colourOptions[2].color}/>
       </components.MultiValueRemove>
     </Tooltip>
   );
@@ -20,7 +20,7 @@ export default () => (
   <Select
     closeMenuOnSelect={false}
     components={{ MultiValueRemove }}
-    styles={{ multiValueRemove: (base) => ({ ...base, border: '1px dotted #2684FF', height: '100%' }) }}
+    styles={{ multiValueRemove: (base) => ({ ...base, border: `1px dotted ${colourOptions[2].color}`, height: '100%' }) }}
     defaultValue={[colourOptions[4], colourOptions[5]]}
     isMulti
     options={colourOptions}

--- a/docs/examples/CustomNoOptionsMessage.js
+++ b/docs/examples/CustomNoOptionsMessage.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import Tooltip from '@atlaskit/tooltip';
 import Select, { components } from '../../src';
+import { colourOptions } from '../data';
 const msgStyles = {
-  background: '#2684FF',
+  background: colourOptions[2].color,
   color: 'white'
 };
 

--- a/docs/examples/CustomOption.js
+++ b/docs/examples/CustomOption.js
@@ -15,7 +15,7 @@ export default () => (
   <Select
     closeMenuOnSelect={false}
     components={{ Option }}
-    styles={{ option: (base) => ({ ...base, border: '1px dotted #2684FF', height: '100%' }) }}
+    styles={{ option: (base) => ({ ...base, border: `1px dotted ${colourOptions[2].color}`, height: '100%' }) }}
     defaultValue={colourOptions[4]}
     options={colourOptions}
   />

--- a/docs/examples/CustomPlaceholder.js
+++ b/docs/examples/CustomPlaceholder.js
@@ -13,7 +13,7 @@ export default () => (
     closeMenuOnSelect={false}
     components={{ Placeholder }}
     placeholder={'custom placeholder component'}
-    styles={{ placeholder: (base) => ({ ...base, fontSize: '1em', color:'#2684FF', fontWeight: 400 }) }}
+    styles={{ placeholder: (base) => ({ ...base, fontSize: '1em', color:colourOptions[2].color, fontWeight: 400 }) }}
     options={colourOptions}
   />
 );

--- a/docs/examples/CustomSelectContainer.js
+++ b/docs/examples/CustomSelectContainer.js
@@ -18,7 +18,7 @@ export default () => (
     closeMenuOnSelect={false}
     components={{ SelectContainer }}
 
-    styles={{ container: (base) => ({ ...base, backgroundColor:'#2684FF', padding: 5 }) }}
+    styles={{ container: (base) => ({ ...base, backgroundColor:colourOptions[2].color, padding: 5 }) }}
     options={colourOptions}
   />
 );

--- a/docs/examples/CustomSingleValue.js
+++ b/docs/examples/CustomSingleValue.js
@@ -18,7 +18,7 @@ export default class CustomControl extends Component<*, State> {
       <Select
         defaultValue={colourOptions[0]}
         isClearable
-        styles={{ singleValue: (base) => ({ ...base, padding: 5, borderRadius: 5, background: '#2684FF', color: 'white', display: 'flex' }) }}
+        styles={{ singleValue: (base) => ({ ...base, padding: 5, borderRadius: 5, background: colourOptions[2].color, color: 'white', display: 'flex' }) }}
         components={{ SingleValue }}
         isSearchable
         name="color"

--- a/docs/examples/CustomValueContainer.js
+++ b/docs/examples/CustomValueContainer.js
@@ -20,7 +20,7 @@ export default class CustomControl extends Component<*, State> {
         isClearable
         styles={{
           singleValue: (base) => ({ ...base, color: 'white' }),
-          valueContainer: (base) => ({ ...base, background: '#2684FF', color: 'white', width: '100%' }),
+          valueContainer: (base) => ({ ...base, background: colourOptions[2].color, color: 'white', width: '100%' }),
         }}
         components={{ ValueContainer }}
         isSearchable


### PR DESCRIPTION
Small change so that the color used in `/components` to indicate the changed section is not the same as the focus outline