### PR TITLE
Export indicator icons for use in customizations

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -15,6 +15,8 @@ import {
   DropdownIndicator,
   LoadingIndicator,
   IndicatorSeparator,
+  DownChevron,
+  CrossIcon,
 } from './indicators';
 
 import Control, { type ControlProps } from './Control';
@@ -46,6 +48,8 @@ export type SelectComponents = {
   ClearIndicator: IndicatorComponentType,
   Control: ComponentType<ControlProps>,
   DropdownIndicator: IndicatorComponentType,
+  DownChevron: ComponentType<any>,
+  CrossIcon: ComponentType<any>,
   Group: ComponentType<GroupProps>,
   GroupHeading: ComponentType<any>,
   IndicatorsContainer: ComponentType<IndicatorContainerProps>,
@@ -74,6 +78,8 @@ export const components: SelectComponents = {
   ClearIndicator: ClearIndicator,
   Control: Control,
   DropdownIndicator: DropdownIndicator,
+  DownChevron: DownChevron,
+  CrossIcon: CrossIcon,
   Group: Group,
   GroupHeading: GroupHeading,
   IndicatorsContainer: IndicatorsContainer,


### PR DESCRIPTION
Enables things such as changing the size of the indicator icon, like so:

```javascript
// @flow

import React from 'react';
import Select, { components } from 'react-select';

const DropdownIndicator = (props) => {
  return (
    <components.DropdownIndicator {...props}>
      <components.DownChevron size="2rem" />
    </components.DropdownIndicator>
  );
};

export default () => (
  <Select
    components={{ DropdownIndicator }}
    options={[...]}
  />
);
```

**eg:** 
<img width="218" alt="screen shot 2018-04-20 at 10 39 57 pm" src="https://user-images.githubusercontent.com/612020/39051375-cc699308-44eb-11e8-92de-4bf0e17812d3.png">
