### PR TITLE
Pressing ENTER should propagate when a closed Select has focus

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -485,13 +485,13 @@ class Select extends React.Component {
 				this.selectFocusedOption();
 				break;
 			case 13: // enter
+				if (!this.state.isOpen) {
+					break;
+				}
+
 				event.preventDefault();
 				event.stopPropagation();
-				if (this.state.isOpen) {
-					this.selectFocusedOption();
-				} else {
-					this.focusNextOption();
-				}
+				this.selectFocusedOption();
 				break;
 			case 27: // escape
 				event.preventDefault();

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -4408,16 +4408,6 @@ describe('Select', () => {
 
 			});
 
-			it('expands the drop down when the enter key is pressed', () => {
-
-				return expect(wrapper,
-						'with event', 'keyDown', KEY_ENTER, 'on', <div className="Select-control" />,
-						'queried for', <input role="combobox" />)
-						.then(input => {
-							expect(instance.state.focusedOption, 'to equal', { value: 'one', label: 'label one' });
-						});
-
-			});
 		});
 	});
 


### PR DESCRIPTION
I'm opening this PR to start a conversation rather than to get what's here merged necessarily. There appears to be competing motivations for better accessibility support vs native `<select>` compatibility. I think the pendulum has swung too far away from native compatibility with a recent change. In v1.2.1 if I have this:

```jsx
<form onSubmit={props.handleSubmit}>
  <Select />
</form>
```

I should be able to press ENTER when the Select menu is closed to submit the form. This is how it worked in v1.0.0, but #1428 changed the behavior to open the menu instead. I don't know what an appropriate compromise should be for accessibility, but not allowing ENTER to propagate runs counter to a lot of people's expectations, I think. It seems that this should be fine, because they can press virtually any other key on the keyboard to open the menu, but I'm not an expert so I was hoping to discuss.

Related issues: #2217 and #518

I created a build branch with these changes applied so if you want to try out these changes in an app before this PR gets merged, you can change your react-select dependency to:
```json
"react-select": "git://github.com/MrLeebo/react-select.git#build",
```