### PR TITLE
remove use of Fragment in Select.js

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, Fragment, type ElementRef, type Node } from 'react';
+import React, { Component, type ElementRef, type Node } from 'react';
 
 import { createFilter } from './filters';
 import { DummyInput, ScrollBlock, ScrollCaptor } from './internal/index';
@@ -1270,7 +1270,7 @@ export default class Select extends Component<Props, State> {
     }
 
     const menuElement = (
-      <Fragment>
+      <span>
         {menuShouldBlockScroll ? <ScrollBlock /> : null}
         <Menu
           {...commonProps}
@@ -1305,7 +1305,7 @@ export default class Select extends Component<Props, State> {
             </MenuList>
           </ScrollCaptor>
         </Menu>
-      </Fragment>
+      </span>
     );
 
     // positioning behaviour is almost identical for portalled and fixed,


### PR DESCRIPTION
as above, we want to be supporting 15.3.2 - 16.0.0, Fragments are 16.0.0 only and should not be used in our source code. 