### PR TITLE
[v2] Force min-width of select to widest option

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1038,48 +1038,54 @@ export default class Select extends Component<Props, State> {
       MultiValueRemove,
       SingleValue,
       Placeholder,
+      ValueSpacer,
     } = this.components;
     const { commonProps } = this;
-    const { isDisabled, isMulti, inputValue, placeholder } = this.props;
+    const { isDisabled, isMulti, inputValue, placeholder, options } = this.props;
     const { selectValue } = this.state;
 
     if (!this.hasValue()) {
       return inputValue ? null : (
-        <Placeholder {...commonProps} key="placeholder" isDisabled={isDisabled}>
-          {placeholder}
-        </Placeholder>
+        <ValueSpacer key="placeholder" values={{ placeholder, options }}>
+          <Placeholder {...commonProps} isDisabled={isDisabled}>
+            {placeholder}
+          </Placeholder>
+        </ValueSpacer>
       );
     }
     if (isMulti) {
       return selectValue.map(opt => (
-        <MultiValue
-          {...commonProps}
-          components={{
-            Container: MultiValueContainer,
-            Label: MultiValueLabel,
-            Remove: MultiValueRemove,
-          }}
-          isDisabled={isDisabled}
-          key={this.getOptionValue(opt)}
-          removeProps={{
-            onClick: () => this.removeValue(opt),
-            onMouseDown: e => {
-              e.preventDefault();
-              e.stopPropagation();
-            },
-          }}
-          data={opt}
-        >
-          {this.formatOptionLabel(opt, 'value')}
-        </MultiValue>
+        <ValueSpacer key={this.getOptionValue(opt)} values={{ placeholder, options }}>
+          <MultiValue
+            {...commonProps}
+            components={{
+              Container: MultiValueContainer,
+              Label: MultiValueLabel,
+              Remove: MultiValueRemove,
+            }}
+            isDisabled={isDisabled}
+            removeProps={{
+              onClick: () => this.removeValue(opt),
+              onMouseDown: e => {
+                e.preventDefault();
+                e.stopPropagation();
+              },
+            }}
+            data={opt}
+          >
+            {this.formatOptionLabel(opt, 'value')}
+          </MultiValue>
+        </ValueSpacer>
       ));
     }
     if (inputValue) return null;
     const singleValue = selectValue[0];
     return (
-      <SingleValue {...commonProps} data={singleValue} isDisabled={isDisabled}>
-        {this.formatOptionLabel(singleValue, 'value')}
-      </SingleValue>
+      <ValueSpacer values={{ placeholder, options }}>
+        <SingleValue {...commonProps} data={singleValue} isDisabled={isDisabled}>
+          {this.formatOptionLabel(singleValue, 'value')}
+        </SingleValue>
+      </ValueSpacer>
     );
   }
   renderClearIndicator() {

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -3,6 +3,8 @@ import React, { Component, type Node, type ElementRef } from 'react';
 
 import { Div } from '../primitives';
 import { spacing } from '../theme';
+import Placeholder from './placeholder';
+import SingleValue from './SingleValue';
 import type { CommonProps, KeyboardEventHandler } from '../types';
 
 // ==============================
@@ -131,6 +133,37 @@ export const IndicatorsContainer = (props: IndicatorContainerProps) => {
       className={cx('indicators')}
       css={getStyles('indicatorsContainer', props)}
     >
+      {children}
+    </Div>
+  );
+};
+
+// ==============================
+// Value Spacer
+// ==============================
+
+export type ValueSpacerProps = CommonProps & {
+  /** Set when the value container should hold multiple values. This is important for styling. */
+  values: any,
+};
+export const valueSpacerCSS = () => ({
+  display: 'flex ',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+});
+export const ValueSpacer = (props: ValueSpacerProps) => {
+  const { children, values } = props;
+  return (
+    <Div
+      css={getStyles('value-spacer', props)}
+      {...innerProps}
+    >
+      <div style={{ margin: 0, padding: 0, height: 0, visibility: 'hidden' }}>
+        {values.placeholder && <Placeholder>{values.placeholder}</Placeholder>}
+        {values.options && values.options.length && values.options.map(
+          option => <SingleValue>{option}</SingleValue>
+        )}
+      </div>
       {children}
     </Div>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,6 +41,7 @@ import MultiValue, {
 import Option, { type OptionProps } from './Option';
 import Placeholder, { type PlaceholderProps } from './Placeholder';
 import SingleValue, { type SingleValueProps } from './SingleValue';
+import ValueSpacer, { type ValueSpacerProps } from './ValueSpacer';
 
 type IndicatorComponentType = ComponentType<IndicatorProps>;
 
@@ -69,6 +70,7 @@ export type SelectComponents = {
   Placeholder: ComponentType<PlaceholderProps>,
   SelectContainer: ComponentType<ContainerProps>,
   SingleValue: ComponentType<SingleValueProps>,
+  ValueSpacer: ComponentType<ValueSpacerProps>,
   ValueContainer: ComponentType<ValueContainerProps>,
 };
 
@@ -99,6 +101,7 @@ export const components: SelectComponents = {
   Placeholder: Placeholder,
   SelectContainer: SelectContainer,
   SingleValue: SingleValue,
+  ValueSpacer: ValueSpacer,
   ValueContainer: ValueContainer,
 };
 


### PR DESCRIPTION
Avoids the issue of widths jumping around when selecting a wide value

**DO NOT MERGE**. This is a 100% WIP, and I haven't even tried to run the code.

I've left comments inline about specifics, but you can see from the gifs below the difference:

**Before / "fluid" width**
![react-select-fluid-width](https://user-images.githubusercontent.com/612020/39107276-99038954-4704-11e8-9eeb-4aca2ba45d8e.gif)

**After / fixed width**
![react-select-forced-width](https://user-images.githubusercontent.com/612020/39107284-a3f72474-4704-11e8-92a3-cdcf2e9871a0.gif)

