### PR TITLE
[v2] fix group component in experimental

### DIFF
--- a/docs/examples/Experimental.js
+++ b/docs/examples/Experimental.js
@@ -105,10 +105,16 @@ const daysContainerStyles = {
 };
 
 const Group = props => {
-  const { Heading, getStyles, children, label, innerProps } = props;
+  const { Heading, getStyles, children, label, innerProps, headingProps, cx } = props;
   return (
     <Div aria-label={label} css={getStyles('group', props)} {...innerProps}>
-      <Heading getStyles={getStyles}>{label}</Heading>
+      <Heading
+        getStyles={getStyles}
+        cx={cx}
+        {...headingProps}
+      >
+        {label}
+      </Heading>
       <Div css={daysHeaderStyles}>
         {days.map((day, i) => (
           <Span key={`${i}-${day}`} css={daysHeaderItemStyles}>


### PR DESCRIPTION
Fixed bug where custom group component in Experimental.js (calendar example) wasn't passing cx down to the heading component.