### PR TITLE
[V2| WIP] Jesstelford forced width

### DIFF
--- a/docs/Tests.js
+++ b/docs/Tests.js
@@ -94,7 +94,8 @@ class TestSuite extends Component<SuiteProps, SuiteState> {
         </Note>
 
         <h4>Grouped</h4>
-        <div id={`cypress-${idSuffix}-grouped`}>
+        this is some text beforehand
+        <div id={`cypress-${idSuffix}-grouped`} style={{ display: 'inline-block' }}>
           <SelectComp
             className="react-select"
             defaultValue={colourOptions[1]}

--- a/src/Select.js
+++ b/src/Select.js
@@ -1039,48 +1039,54 @@ export default class Select extends Component<Props, State> {
       MultiValueRemove,
       SingleValue,
       Placeholder,
+      ValueSpacer,
     } = this.components;
     const { commonProps } = this;
-    const { isDisabled, isMulti, inputValue, placeholder } = this.props;
+    const { isDisabled, isMulti, inputValue, placeholder, options } = this.props;
     const { selectValue } = this.state;
 
     if (!this.hasValue()) {
       return inputValue ? null : (
-        <Placeholder {...commonProps} key="placeholder" isDisabled={isDisabled}>
-          {placeholder}
-        </Placeholder>
+        <ValueSpacer key="placeholder" values={{ placeholder, options }}>
+          <Placeholder {...commonProps} isDisabled={isDisabled}>
+            {placeholder}
+          </Placeholder>
+        </ValueSpacer>
       );
     }
     if (isMulti) {
       return selectValue.map(opt => (
-        <MultiValue
-          {...commonProps}
-          components={{
-            Container: MultiValueContainer,
-            Label: MultiValueLabel,
-            Remove: MultiValueRemove,
-          }}
-          isDisabled={isDisabled}
-          key={this.getOptionValue(opt)}
-          removeProps={{
-            onClick: () => this.removeValue(opt),
-            onMouseDown: e => {
-              e.preventDefault();
-              e.stopPropagation();
-            },
-          }}
-          data={opt}
-        >
-          {this.formatOptionLabel(opt, 'value')}
-        </MultiValue>
+        <ValueSpacer key={this.getOptionValue(opt)} values={{ placeholder, options }}>
+          <MultiValue
+            {...commonProps}
+            components={{
+              Container: MultiValueContainer,
+              Label: MultiValueLabel,
+              Remove: MultiValueRemove,
+            }}
+            isDisabled={isDisabled}
+            removeProps={{
+              onClick: () => this.removeValue(opt),
+              onMouseDown: e => {
+                e.preventDefault();
+                e.stopPropagation();
+              },
+            }}
+            data={opt}
+          >
+            {this.formatOptionLabel(opt, 'value')}
+          </MultiValue>
+        </ValueSpacer>
       ));
     }
     if (inputValue) return null;
     const singleValue = selectValue[0];
     return (
-      <SingleValue {...commonProps} data={singleValue} isDisabled={isDisabled}>
-        {this.formatOptionLabel(singleValue, 'value')}
-      </SingleValue>
+      <ValueSpacer values={{ placeholder, options }}>
+        <SingleValue {...commonProps} data={singleValue} isDisabled={isDisabled}>
+          {this.formatOptionLabel(singleValue, 'value')}
+        </SingleValue>
+      </ValueSpacer>
     );
   }
   renderClearIndicator() {

--- a/src/Select.js
+++ b/src/Select.js
@@ -583,7 +583,7 @@ export default class Select extends Component<Props, State> {
       ? this.props.filterOption(option, inputValue)
       : true;
   }
-  formatOptionLabel(data: OptionType, context: FormatOptionLabelContext): Node {
+  formatOptionLabel = (data: OptionType, context: FormatOptionLabelContext): Node  => {
     if (typeof this.props.formatOptionLabel === 'function') {
       const { inputValue } = this.props;
       const { selectValue } = this.state;
@@ -1047,7 +1047,15 @@ export default class Select extends Component<Props, State> {
 
     if (!this.hasValue()) {
       return inputValue ? null : (
-        <ValueSpacer key="placeholder" values={{ placeholder, options }}>
+        <ValueSpacer
+          placeholder={placeholder}
+          options={options}
+          getOptionLabel={getOptionLabel}
+          formatOptionLabel={this.formatOptionLabel}
+          components={this.components}
+          isDisabled={isDisabled}
+          {...commonProps}
+        >
           <Placeholder {...commonProps} isDisabled={isDisabled}>
             {placeholder}
           </Placeholder>
@@ -1056,33 +1064,39 @@ export default class Select extends Component<Props, State> {
     }
     if (isMulti) {
       return selectValue.map(opt => (
-        <ValueSpacer key={this.getOptionValue(opt)} values={{ placeholder, options }}>
-          <MultiValue
-            {...commonProps}
-            components={{
-              Container: MultiValueContainer,
-              Label: MultiValueLabel,
-              Remove: MultiValueRemove,
-            }}
-            isDisabled={isDisabled}
-            removeProps={{
-              onClick: () => this.removeValue(opt),
-              onMouseDown: e => {
-                e.preventDefault();
-                e.stopPropagation();
-              },
-            }}
-            data={opt}
-          >
-            {this.formatOptionLabel(opt, 'value')}
-          </MultiValue>
-        </ValueSpacer>
+        <MultiValue
+          {...commonProps}
+          components={{
+            Container: MultiValueContainer,
+            Label: MultiValueLabel,
+            Remove: MultiValueRemove,
+          }}
+          isDisabled={isDisabled}
+          removeProps={{
+            onClick: () => this.removeValue(opt),
+            onMouseDown: e => {
+              e.preventDefault();
+              e.stopPropagation();
+            },
+          }}
+          data={opt}
+        >
+          {this.formatOptionLabel(opt, 'value')}
+        </MultiValue>
       ));
     }
     if (inputValue) return null;
     const singleValue = selectValue[0];
     return (
-      <ValueSpacer values={{ placeholder, options }}>
+      <ValueSpacer
+        placeholder={placeholder}
+        options={options}
+        getOptionLabel={getOptionLabel}
+        formatOptionLabel={this.formatOptionLabel}
+        components={this.components}
+        isDisabled={isDisabled}
+        {...commonProps}
+      >
         <SingleValue {...commonProps} data={singleValue} isDisabled={isDisabled}>
           {this.formatOptionLabel(singleValue, 'value')}
         </SingleValue>

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -10,13 +10,17 @@ export type PlaceholderProps = CommonProps & {
   children: Node,
   /** props passed to the wrapping element for the group. */
   innerProps: { [string]: any },
-};
+} & State;
 
-export const css = () => ({
+export type State = {
+  cssPosition: 'relative' | 'absolute',
+}
+
+export const css = ({ cssPosition }: State) => ({
   color: colors.neutral50,
   marginLeft: spacing.baseUnit / 2,
   marginRight: spacing.baseUnit / 2,
-  position: 'absolute',
+  position: cssPosition || 'absolute',
   top: '50%',
   transform: 'translateY(-50%)',
 });

--- a/src/components/SingleValue.js
+++ b/src/components/SingleValue.js
@@ -8,6 +8,8 @@ import type { CommonProps } from '../types';
 type State = {
   /** Whether this is disabled */
   isDisabled: boolean,
+  /** the css position value of the component **/
+  cssPosition: 'relative' | 'absolute',
 };
 type ValueProps = {
   /** The children to be rendered. */
@@ -19,13 +21,13 @@ type ValueProps = {
 };
 export type SingleValueProps = CommonProps & ValueProps & State;
 
-export const css = ({ isDisabled }: State) => ({
+export const css = ({ isDisabled, cssPosition }: State) => ({
   color: isDisabled ? colors.neutral40 : colors.text,
   marginLeft: spacing.baseUnit / 2,
   marginRight: spacing.baseUnit / 2,
   maxWidth: `calc(100% - ${spacing.baseUnit * 2}px)`,
   overflow: 'hidden',
-  position: 'absolute',
+  position: cssPosition || 'absolute',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   top: '50%',

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -3,9 +3,8 @@ import React, { Component, type Node, type ElementRef } from 'react';
 
 import { Div } from '../primitives';
 import { spacing } from '../theme';
-import Placeholder from './placeholder';
-import SingleValue from './SingleValue';
-import type { CommonProps, KeyboardEventHandler } from '../types';
+import type { CommonProps, KeyboardEventHandler, OptionsType, OptionType } from '../types';
+import type { SelectComponents } from '../components';
 
 // ==============================
 // Root Container
@@ -144,27 +143,113 @@ export const IndicatorsContainer = (props: IndicatorContainerProps) => {
 
 export type ValueSpacerProps = CommonProps & {
   /** Set when the value container should hold multiple values. This is important for styling. */
-  values: any,
+  placeholder?: string,
+  options?: OptionsType,
+  children: Node,
+  getOptionLabel: Function,
+  formatOptionLabel: Function,
+  isDisabled: boolean,
+  components: SelectComponents
 };
 export const valueSpacerCSS = () => ({
   display: 'flex ',
   flexDirection: 'column',
   alignItems: 'flex-start',
+  margin: 0,
+  padding: 0,
+  height: 0,
+  visibility: 'hidden',
 });
-export const ValueSpacer = (props: ValueSpacerProps) => {
-  const { children, values } = props;
-  return (
-    <Div
-      css={getStyles('value-spacer', props)}
-      {...innerProps}
-    >
-      <div style={{ margin: 0, padding: 0, height: 0, visibility: 'hidden' }}>
-        {values.placeholder && <Placeholder>{values.placeholder}</Placeholder>}
-        {values.options && values.options.length && values.options.map(
-          option => <SingleValue>{option}</SingleValue>
-        )}
+
+export class ValueSpacer extends Component<ValueSpacerProps>{
+  longestOption: OptionType | null;
+  componentWillMount () {
+    this.longestOption = this.getLongestOption(this.props.options);
+  }
+
+  componentWillUnmount () {
+    this.longestOption = null;
+  }
+
+  componentDidUpdate (prevProps: ValueSpacerProps) {
+    if (prevProps.options !== this.props.options) {
+      this.longestOption = this.getLongestOption(this.props.options);
+    }
+  }
+
+  flattenOptions = (options: OptionsType) => {
+    return options.reduce((acc, current) => {
+      if (Array.isArray(current.options)) return [...acc, ...current.options];
+      return [...acc, current];
+    }, []);
+  }
+
+  getLongestOption = (options: OptionsType) => {
+    const { getOptionLabel } = this.props;
+    const sortedOptionsList = this.flattenOptions(options).sort((a, b) => getOptionLabel(a).length - getOptionLabel(b).length);
+    return sortedOptionsList[sortedOptionsList.length - 1];
+  }
+
+  render () {
+    const {
+      children,
+      isDisabled,
+      formatOptionLabel,
+      placeholder,
+      components,
+      ...commonProps
+    } = this.props;
+
+    // $FlowFixMe
+    const { getStyles } = commonProps;
+    const { Placeholder, SingleValue } = components;
+    return (
+      <div>
+        <Div
+          css={getStyles('valueSpacer', this.props)}
+        >
+          {placeholder &&
+            <Placeholder
+              {...commonProps}
+              cssPosition="relative"
+              isDisabled={isDisabled}
+            >
+              {placeholder}
+            </Placeholder>}
+          {this.longestOption &&
+            <SingleValue
+              data={this.longestOption}
+              cssPosition="relative"
+              style={{
+                position: 'relative'
+              }}
+              isDisabled={isDisabled}
+              {...commonProps}
+            >
+              {formatOptionLabel(this.longestOption, 'value')}
+            </SingleValue>
+          }
+        </Div>
+        {children}
       </div>
-      {children}
-    </Div>
-  );
-};
+    );
+  };
+}
+
+// export const ValueSpacer = (props: ValueSpacerProps) => {
+//   const { children, values } = props;
+//   return (
+//     <Div
+//       css={getStyles('value-spacer', props)}
+//       {...innerProps}
+//     >
+//       <div style={{ margin: 0, padding: 0, height: 0, visibility: 'hidden' }}>
+//         {values.placeholder && <Placeholder>{values.placeholder}</Placeholder>}
+//         {values.options && values.options.length && values.options.map(
+//           option => <SingleValue>{option}</SingleValue>
+//         )}
+//       </div>
+//       {children}
+//     </Div>
+//   );
+// };

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -3,6 +3,8 @@ import React, { Component, type Node, type ElementRef } from 'react';
 
 import { Div } from '../primitives';
 import { spacing } from '../theme';
+import Placeholder from './placeholder';
+import SingleValue from './SingleValue';
 import type { CommonProps, KeyboardEventHandler } from '../types';
 
 // ==============================
@@ -131,6 +133,37 @@ export const IndicatorsContainer = (props: IndicatorContainerProps) => {
       className={cx('indicators')}
       css={getStyles('indicatorsContainer', props)}
     >
+      {children}
+    </Div>
+  );
+};
+
+// ==============================
+// Value Spacer
+// ==============================
+
+export type ValueSpacerProps = CommonProps & {
+  /** Set when the value container should hold multiple values. This is important for styling. */
+  values: any,
+};
+export const valueSpacerCSS = () => ({
+  display: 'flex ',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+});
+export const ValueSpacer = (props: ValueSpacerProps) => {
+  const { children, values } = props;
+  return (
+    <Div
+      css={getStyles('value-spacer', props)}
+      {...innerProps}
+    >
+      <div style={{ margin: 0, padding: 0, height: 0, visibility: 'hidden' }}>
+        {values.placeholder && <Placeholder>{values.placeholder}</Placeholder>}
+        {values.options && values.options.length && values.options.map(
+          option => <SingleValue>{option}</SingleValue>
+        )}
+      </div>
       {children}
     </Div>
   );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,9 +4,11 @@ import {
   type IndicatorContainerProps,
   type ContainerProps,
   type ValueContainerProps,
+  type ValueSpacerProps,
   IndicatorsContainer,
   SelectContainer,
   ValueContainer,
+  ValueSpacer,
 } from './containers';
 import {
   type IndicatorProps,
@@ -41,7 +43,6 @@ import MultiValue, {
 import Option, { type OptionProps } from './Option';
 import Placeholder, { type PlaceholderProps } from './Placeholder';
 import SingleValue, { type SingleValueProps } from './SingleValue';
-import ValueSpacer, { type ValueSpacerProps } from './ValueSpacer';
 
 type IndicatorComponentType = ComponentType<IndicatorProps>;
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,6 +41,7 @@ import MultiValue, {
 import Option, { type OptionProps } from './Option';
 import Placeholder, { type PlaceholderProps } from './Placeholder';
 import SingleValue, { type SingleValueProps } from './SingleValue';
+import ValueSpacer, { type ValueSpacerProps } from './ValueSpacer';
 
 type IndicatorComponentType = ComponentType<IndicatorProps>;
 
@@ -69,6 +70,7 @@ export type SelectComponents = {
   Placeholder: ComponentType<PlaceholderProps>,
   SelectContainer: ComponentType<ContainerProps>,
   SingleValue: ComponentType<SingleValueProps>,
+  ValueSpacer: ComponentType<ValueSpacerProps>,
   ValueContainer: ComponentType<ValueContainerProps>,
 };
 
@@ -99,6 +101,7 @@ export const components: SelectComponents = {
   Placeholder: Placeholder,
   SelectContainer: SelectContainer,
   SingleValue: SingleValue,
+  ValueSpacer: ValueSpacer,
   ValueContainer: ValueContainer,
 };
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -4,6 +4,7 @@ import {
   containerCSS,
   indicatorsContainerCSS,
   valueContainerCSS,
+  valueSpacerCSS,
 } from './components/containers';
 import { css as controlCSS } from './components/Control';
 import { groupCSS, groupHeadingCSS } from './components/Group';
@@ -55,6 +56,7 @@ export type Styles = {
   placeholder?: Props => {},
   singleValue?: Props => {},
   valueContainer: Props => {},
+  valueSpacer?: Props => {},
 };
 export type StylesConfig = $Shape<Styles>;
 export type GetStyles = (string, Props) => {};
@@ -82,6 +84,7 @@ export const defaultStyles: Styles = {
   placeholder: placeholderCSS,
   singleValue: singleValueCSS,
   valueContainer: valueContainerCSS,
+  valueSpacer: valueSpacerCSS,
 };
 
 // Merge Utility


### PR DESCRIPTION
An expansion on @jesstelford #2545 notably:
- We no longer map over and render each hidden component
- We now call 'getLongestOption' which iterates over the passed in options array to retrieve the 'longest' option, according to an evaluation of what's currently passed in as 'getOptionLabel'. This does mean that our longest option is now an approximation, but I think this is an adequate trade off compared to rendering the entire options list. 
- getLongestOption flattens the options array so that we're also accounting for option groups. 
- We also pass in the Placeholder and SingleValue components from the components object, as opposed to directly importing them into the file. This allows us to use the placeholder and singlevalue components passed in by the user.


Theoretically this should be an performance optimisation for longer (long) lists. Will add a performance benchmark soon
