### PR TITLE
[v2] Stylable components with className / styled-components

### DIFF
--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -51,10 +51,10 @@ export const css = ({ isDisabled, isFocused }: State) => ({
 });
 
 const Control = (props: ControlProps) => {
-  const { children, cx, getStyles, isDisabled, isFocused, innerProps } = props;
+  const { children, cx, className, getStyles, isDisabled, isFocused, innerProps } = props;
   return (
     <Div
-      className={cx('control', { isDisabled, isFocused })}
+      className={(className ? `${className} ` : '') + cx('control', { isDisabled, isFocused })}
       css={getStyles('control', props)}
       {...innerProps}
     >

--- a/src/types.js
+++ b/src/types.js
@@ -46,6 +46,7 @@ export type CommonProps = {
     property as the first argument, and the current props as the second argument.
     See the `styles` object for the properties available.
   */
+  className: string | void,
   getStyles: (string, any) => {},
   getValue: () => ValueType,
   hasValue: boolean,


### PR DESCRIPTION
Enables styling via Styled-Components

For example, this enables:

```javascript
import styled, { css } from 'styled-components';
import Select, { components } from 'react-select';

// Setting up sc theme somewhere:
const theme = {
  flexContainer: () => css`
    display: flex;
    flex: 1 0 auto;
    /* other common flex setup rules here */
  `,
};

// ... then in our component
const Control = styled(components.Control)`
  ${props => props.theme.flexContainer()};
`;

export default () => (
  <Select
    components={{ Control }}
    {...}
  />
);
```

Currently, there's no way to do this. The closest is access to the `theme` prop from the styles object:

```javascript
import { withTheme } from 'styled-components';
import Select, { components } from 'react-select';

// ...

export default withTheme(({ theme }) => {
  const styles = {
    control: styles => ({
      ...styles,
      flex: theme.flexContainer(), // DOES NOT WORK
    }),
  };

  return (
    <Select
      styles={styles}
      {...}
    />
  );
});
```
_or_

```javascript
import Select, { components } from 'react-select';

const styles = {
  control: (styles, { theme }) => ({
    ...styles,
    flex: theme.flexContainer(), // DOES NOT WORK
  }),
};

export default () => {
  return (
    <Select
      styles={styles}
      {...}
    />
  );
}
```

Neither support the case where you have a chunk of CSS stored as a string which you want to apply.

And that's not to mention when you have external CSS with existing classnames, etc, that you'd like to apply.


NOTE: Not sure if this is the best way to go about it as the specificity gets all screwy - when I tested this example, the specificity of the styled component class was lower (appeared earlier injected into the `<head>` than the react select classes). A workaround for this could be to [use the `&&` styled components selector](https://github.com/styled-components/styled-components/issues/1253#issuecomment-337871693):

```javascript
const Control = styled(components.Control)`
  && {
    ${props => props.theme.flexContainer()};
  }
`;
```

---

This is just an idea, if it's given the 👍 , I can add it to the other components in react-select too.