### PR TITLE
[v2] Allow Creatable option first

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -29,6 +29,9 @@ export type CreatableProps = {
      created, and `onChange` will **not** be called. Use this when you need more
      control over what happens when new options are created. */
   onCreateOption?: string => void,
+  /* Renders the label for the "create new..." option first in the options list
+     when it is true. */
+  createOptionLabelFirst: boolean,
 };
 
 export type Props = SelectProps & CreatableProps;
@@ -62,6 +65,7 @@ const builtins = {
 
 export const defaultProps = {
   allowCreateWhileLoading: false,
+  createOptionLabelFirst: false,
   ...builtins,
 };
 
@@ -85,6 +89,7 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
     componentWillReceiveProps(nextProps: Props) {
       const {
         allowCreateWhileLoading,
+        createOptionLabelFirst,
         formatCreateLabel,
         getNewOptionData,
         inputValue,
@@ -103,7 +108,7 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
         newOption: newOption,
         options:
           (allowCreateWhileLoading || !isLoading) && newOption
-            ? [...options, newOption]
+            ? (createOptionLabelFirst ? [newOption, ...options] : [...options, newOption])
             : options,
       });
     }

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -19,6 +19,7 @@ exports[`defaults - snapshot 1`] = `
     <Creatable
       allowCreateWhileLoading={false}
       cacheOptions={false}
+      createOptionLabelFirst={false}
       defaultInputValue=""
       defaultMenuIsOpen={false}
       defaultOptions={false}
@@ -45,6 +46,7 @@ exports[`defaults - snapshot 1`] = `
         captureMenuScroll={false}
         closeMenuOnSelect={true}
         components={Object {}}
+        createOptionLabelFirst={false}
         defaultInputValue=""
         defaultMenuIsOpen={false}
         defaultOptions={false}
@@ -117,6 +119,7 @@ exports[`defaults - snapshot 1`] = `
               "captureMenuScroll": false,
               "closeMenuOnSelect": true,
               "components": Object {},
+              "createOptionLabelFirst": false,
               "defaultInputValue": "",
               "defaultMenuIsOpen": false,
               "defaultOptions": false,
@@ -215,6 +218,7 @@ exports[`defaults - snapshot 1`] = `
                     "captureMenuScroll": false,
                     "closeMenuOnSelect": true,
                     "components": Object {},
+                    "createOptionLabelFirst": false,
                     "defaultInputValue": "",
                     "defaultMenuIsOpen": false,
                     "defaultOptions": false,
@@ -295,6 +299,7 @@ exports[`defaults - snapshot 1`] = `
                           "captureMenuScroll": false,
                           "closeMenuOnSelect": true,
                           "components": Object {},
+                          "createOptionLabelFirst": false,
                           "defaultInputValue": "",
                           "defaultMenuIsOpen": false,
                           "defaultOptions": false,
@@ -370,6 +375,7 @@ exports[`defaults - snapshot 1`] = `
                                 "captureMenuScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {},
+                                "createOptionLabelFirst": false,
                                 "defaultInputValue": "",
                                 "defaultMenuIsOpen": false,
                                 "defaultOptions": false,
@@ -572,6 +578,7 @@ exports[`defaults - snapshot 1`] = `
                           "captureMenuScroll": false,
                           "closeMenuOnSelect": true,
                           "components": Object {},
+                          "createOptionLabelFirst": false,
                           "defaultInputValue": "",
                           "defaultMenuIsOpen": false,
                           "defaultOptions": false,
@@ -652,6 +659,7 @@ exports[`defaults - snapshot 1`] = `
                                 "captureMenuScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {},
+                                "createOptionLabelFirst": false,
                                 "defaultInputValue": "",
                                 "defaultMenuIsOpen": false,
                                 "defaultOptions": false,
@@ -733,6 +741,7 @@ exports[`defaults - snapshot 1`] = `
                                 "captureMenuScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {},
+                                "createOptionLabelFirst": false,
                                 "defaultInputValue": "",
                                 "defaultMenuIsOpen": false,
                                 "defaultOptions": false,

--- a/src/__tests__/__snapshots__/Creatable.test.js.snap
+++ b/src/__tests__/__snapshots__/Creatable.test.js.snap
@@ -3,6 +3,7 @@
 exports[`defaults - snapshot 1`] = `
 <Creatable
   allowCreateWhileLoading={false}
+  createOptionLabelFirst={false}
   defaultInputValue=""
   defaultMenuIsOpen={false}
   defaultValue={null}


### PR DESCRIPTION
There are cases, like if you want to submit `" "` as a new option, where you need to scroll down to the `Create " "` option to select this

Allowing to set the `Create new...` option first (like it was before v2) makes it easier to handle it