### PR TITLE
[V2] Add isDisabled class to Option

### DIFF
--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -59,11 +59,11 @@ export const css = ({ isDisabled, isFocused, isSelected }: State) => ({
 });
 
 const Option = (props: OptionProps) => {
-  const { children, cx, getStyles, isFocused, isSelected, innerProps } = props;
+  const { children, cx, getStyles, isDisabled, isFocused, isSelected, innerProps } = props;
 
   return (
     <Div
-      className={cx('option', { isFocused, isSelected })}
+      className={cx('option', { isDisabled, isFocused, isSelected })}
       css={getStyles('option', props)}
       {...innerProps}
     >


### PR DESCRIPTION
Previously, `Option` would be rendered with just the `isFocused` and `isSelected` classname variants, i.e. without the `isDisabled` variant. This makes styling disabled options practically speaking impossible using CSS and `<Selected className>`.

This adds the `isDisabled` classname variant to `Option`.