### PR TITLE
[v2] Add brief class name explanation to Styles docs

### DIFF
--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -104,6 +104,32 @@ export default function Styles() {
           <StyledMulti />
         </ExampleWrapper>
       )}
+
+    ## Using classNames
+
+    If you provide the \`className\` prop to react-select, all inner elements will
+    be given a className based on the one you have provided.
+
+    For example, given \`className="react-select"\`, the DOM would roughtly look
+    like this:
+
+    ~~~html
+    <div class="react-select">
+      <div class="react-select__control">
+        <div class="react-select__value-container">...</div>
+        <div class="react-select__indicators">...</div>
+      </div>
+      <div class="react-select__menu">
+        <div class="react-select__menu-list">
+          <div class="react-select__option">...</div>
+        </div>
+      </div>
+    </div>
+    ~~~
+
+    While we encourage you to use the new Styles API, it's good to know that you
+    still have the option of adding class names to the components to style via CSS.
+
     `}
     </Fragment>
   );


### PR DESCRIPTION
IMO this is an important addition, especially for anyone upgrading. Moving styles from your project's
CSS into JS can be pretty painful in an already existing codebase. Also, if the rest of your project
is using CSS/Sass/etc then having the styles for a single component like this in JS can be hard to maintain
or abstract.

I think it's important that users know they have either option and if they wanna jump down either rabbit hole
they can.

Just my two cents...