### PR TITLE
Fix spelling of "IndicatorSeparator"

### DIFF
--- a/docs/pages/props/index.js
+++ b/docs/pages/props/index.js
@@ -168,7 +168,7 @@ export default function Api() {
       />
     )}
 
-    ### IndicatorsSeparator
+    ### IndicatorSeparator
 
     ${(
       <Props


### PR DESCRIPTION
The `IndicatorSeparator` component doesn't pluralize the word `Indicator`.