### PR TITLE
V2 revert ref to inner ref

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1327,7 +1327,7 @@ export default class Select extends Component<Props, State> {
       // for performance, the menu options in state aren't changed when the
       // focused option changes so we calculate additional props based on that
       const isFocused = focusedOption === props.data;
-      props.innerProps.ref = isFocused ? this.onFocusedOptionRef : undefined;
+      props.innerProps.innerRef = isFocused ? this.onFocusedOptionRef : undefined;
 
       return (
         <Option {...commonProps} {...props} isFocused={isFocused}>
@@ -1406,7 +1406,7 @@ export default class Select extends Component<Props, State> {
               innerProps={{
                 'aria-multiselectable': isMulti,
                 id: this.getElementId('listbox'),
-                ref: this.onMenuRef,
+                innerRef: this.onMenuRef,
                 role: 'listbox',
               }}
               isLoading={isLoading}
@@ -1496,7 +1496,7 @@ export default class Select extends Component<Props, State> {
         <Control
           {...commonProps}
           innerProps={{
-            ref: this.onControlRef,
+            innerRef: this.onControlRef,
             onMouseDown: this.onControlMouseDown,
             onTouchEnd: this.onControlTouchEnd,
           }}

--- a/src/__tests__/Async.test.js
+++ b/src/__tests__/Async.test.js
@@ -52,7 +52,7 @@ cases(
   'load options props with no default options',
   ({ props, expectloadOptionsLength }) => {
     let asyncSelectWrapper = mount(
-      <Async className="react-select" {...props} />
+      <Async className="react-select" classNamePrefix="react-select" {...props} />
     );
     let inputValueWrapper = asyncSelectWrapper.find(
       'div.react-select__input input'
@@ -87,7 +87,7 @@ cases(
 test.skip('to not call loadOptions again for same value when cacheOptions is true', () => {
   let loadOptionsSpy = jest.fn();
   let asyncSelectWrapper = mount(
-    <Async className="react-select" loadOptions={loadOptionsSpy} cacheOptions />
+    <Async className="react-select" classNamePrefix="react-select" loadOptions={loadOptionsSpy} cacheOptions />
   );
   let inputValueWrapper = asyncSelectWrapper.find(
     'div.react-select__input input'
@@ -125,7 +125,7 @@ test('in case of callbacks display the most recently-requested loaded options (i
     callbacks.push(callback);
   };
   let asyncSelectWrapper = mount(
-    <Async className="react-select" loadOptions={loadOptions} />
+    <Async className="react-select" classNamePrefix="react-select" loadOptions={loadOptions} />
   );
   let inputValueWrapper = asyncSelectWrapper.find(
     'div.react-select__input input'
@@ -151,6 +151,7 @@ test.skip('in case of callbacks should handle an error by setting options to an 
   let asyncSelectWrapper = mount(
     <Async
       className="react-select"
+      classNamePrefix="react-select"
       loadOptions={loadOptions}
       options={OPTIONS}
     />

--- a/src/__tests__/AsyncCreatable.test.js
+++ b/src/__tests__/AsyncCreatable.test.js
@@ -15,19 +15,19 @@ test('defaults - snapshot', () => {
 
 test('creates an inner Select', () => {
   const asyncCreatableWrapper = mount(
-    <AsyncCreatable className="react-select" />
+    <AsyncCreatable className="react-select" classNamePrefix="react-select"/>
   );
   expect(asyncCreatableWrapper.find(Select).exists()).toBeTruthy();
 });
 
 test('render decorated select with props passed', () => {
-  const asyncCreatableWrapper = mount(<AsyncCreatable className="foo" />);
+  const asyncCreatableWrapper = mount(<AsyncCreatable className="foo" classNamePrefix="foo" />);
   expect(asyncCreatableWrapper.find(Select).props().className).toBe('foo');
 });
 
 test('to show the create option in menu', () => {
   let asyncCreatableWrapper = mount(
-    <AsyncCreatable className="react-select" />
+    <AsyncCreatable className="react-select" classNamePrefix="react-select"/>
   );
   let inputValueWrapper = asyncCreatableWrapper.find(
     'div.react-select__input input'
@@ -48,7 +48,7 @@ test('to show loading and then create option in menu', () => {
     setTimeout(() => callback(OPTIONS), 200)
   );
   let asyncCreatableWrapper = mount(
-    <AsyncCreatable className="react-select" loadOptions={loadOptionsSpy} />
+    <AsyncCreatable className="react-select" classNamePrefix="react-select" loadOptions={loadOptionsSpy} />
   );
   let inputValueWrapper = asyncCreatableWrapper.find(
     'div.react-select__input input'

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -30,6 +30,7 @@ const {
 
 const BASIC_PROPS = {
   className: 'react-select',
+  classNamePrefix: 'react-select',
   onChange: jest.fn(),
   onInputChange: jest.fn(),
   onMenuClose: jest.fn(),
@@ -1178,6 +1179,7 @@ test('hitting tab on option should not call onChange if tabSelectsValue is false
   let selectWrapper = mount(
     <Select
       className="react-select"
+      classNamePrefix="react-select"
       menuIsOpen
       onChange={spy}
       onInputChange={jest.fn()}
@@ -1227,6 +1229,7 @@ test('multi select > to not hide the selected options from the menu if hideSelec
   let selectWrapper = mount(
     <Select
       className="react-select"
+      classNamePrefix="react-select"
       hideSelectedOptions={false}
       isMulti
       menuIsOpen

--- a/src/__tests__/StateManaged.test.js
+++ b/src/__tests__/StateManaged.test.js
@@ -12,6 +12,7 @@ const { Control, Menu } = components;
 
 const BASIC_PROPS = {
   className: 'react-select',
+  classNamePrefix: 'react-select',
   options: OPTIONS,
   name: 'test-input-name',
 };

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -162,9 +162,9 @@ exports[`defaults - snapshot 1`] = `
             hasValue={false}
             innerProps={
               Object {
+                "innerRef": [Function],
                 "onMouseDown": [Function],
                 "onTouchEnd": [Function],
-                "ref": [Function],
               }
             }
             isDisabled={false}

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -191,9 +191,9 @@ exports[`defaults - snapshot 1`] = `
               hasValue={false}
               innerProps={
                 Object {
+                  "innerRef": [Function],
                   "onMouseDown": [Function],
                   "onTouchEnd": [Function],
-                  "ref": [Function],
                 }
               }
               isDisabled={false}

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -76,9 +76,9 @@ exports[`snapshot - defaults 1`] = `
     hasValue={false}
     innerProps={
       Object {
+        "innerRef": [Function],
         "onMouseDown": [Function],
         "onTouchEnd": [Function],
-        "ref": [Function],
       }
     }
     isDisabled={false}

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -20,7 +20,7 @@ export type ControlProps = CommonProps &
     /** The mouse down event and the innerRef to pass down to the controller element. */
     innerProps: {
       onMouseDown: (SyntheticMouseEvent<HTMLElement>) => void,
-      ref: ElementRef<*>,
+      innerRef: ElementRef<*>,
     },
   };
 
@@ -52,14 +52,16 @@ export const css = ({ isDisabled, isFocused }: State) => ({
 
 const Control = (props: ControlProps) => {
   const { children, cx, getStyles, className, isDisabled, isFocused, innerProps } = props;
+  const { innerRef, ...rest } = innerProps;
   return (
     <div
+      ref={innerRef}
       className={cx(emotionCSS(getStyles('control', props)), {
         'control': true,
         'control-is-disabled': isDisabled,
         'control-is-focused': isFocused
       }, className)}
-      {...innerProps}
+      {...rest}
     >
       {children}
     </div>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -226,8 +226,11 @@ function alignToControl(placement) {
 }
 const coercePlacement = p => (p === 'auto' ? 'bottom' : p);
 
-export const menuCSS = ({ placement }: MenuState) => ({
+export const menuCSS = ({ placement, maxHeight }: MenuState) => ({
   [alignToControl(placement)]: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: maxHeight,
   backgroundColor: colors.neutral0,
   borderRadius: borderRadius,
   boxShadow: `0 0 0 1px ${colors.neutral10a}, 0 4px 11px ${colors.neutral10a}`,
@@ -329,8 +332,8 @@ export type MenuListProps = {
 export type MenuListComponentProps = CommonProps &
   MenuListProps &
   MenuListState;
-export const menuListCSS = ({ maxHeight }: MenuListComponentProps) => ({
-  maxHeight,
+export const menuListCSS = () => ({
+  flex: '0 1 100%',
   overflowY: 'auto',
   paddingBottom: spacing.baseUnit,
   paddingTop: spacing.baseUnit,
@@ -339,6 +342,7 @@ export const menuListCSS = ({ maxHeight }: MenuListComponentProps) => ({
 });
 export const MenuList = (props: MenuListComponentProps) => {
   const { children, className, cx, getStyles, isMulti, innerProps } = props;
+  const { innerRef, ...rest } = innerProps;
   return (
     <div
       className={cx(
@@ -349,7 +353,8 @@ export const MenuList = (props: MenuListComponentProps) => {
         },
         className
       )}
-      {...innerProps}
+      ref={innerRef}
+      {...rest}
     >
       {children}
     </div>

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -60,9 +60,10 @@ export const css = ({ isDisabled, isFocused, isSelected }: State) => ({
 
 const Option = (props: OptionProps) => {
   const { children, className, cx, getStyles, isDisabled, isFocused, isSelected, innerProps } = props;
-
+  const { innerRef, ...rest } = innerProps;
   return (
     <div
+      ref={innerRef}
       className={cx(
         emotionCss(getStyles('option', props)),
         {
@@ -73,7 +74,7 @@ const Option = (props: OptionProps) => {
         },
         className
       )}
-      {...innerProps}
+      {...rest}
     >
       {children}
     </div>


### PR DESCRIPTION
Reverting change of innerProps innerRef to ref for customisable components, as we need to maintain compatibility with StyledComponents, and this method of ref forwarding is potentially unsafe.