### PR TITLE
Add src code to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register",
     "precommit": "lint-staged && yarn run test"
   },
-  "files": ["dist", "less", "lib", "scss"],
+  "files": ["dist", "less", "lib", "scss", "src"],
   "keywords": [
     "combobox",
     "form",


### PR DESCRIPTION
I'm working on reducing the bundle in my project.
We are very serious about optimizing the size of the final gang for some reason the client.

At the moment I only use one import
```js
import Select from 'react-select';
```
But in the end all the code gets to the gang, half of which remains there dead part.

But I would like to import only the necessary parts as for example made in `lodash-es, date-fns, react-router, ramda, recompose`
Example:
```js
import { Select } from  'react-select';
// or
import Select from 'react-select/es/Select';
```