### PR TITLE
Prefer more descriptive esm word instead of es

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "2.0.0-beta.6",
   "description": "A Select control built with and for ReactJS",
   "main": "lib/index.js",
-  "jsnext:main": "dist/react-select.es.js",
-  "module": "dist/react-select.es.js",
+  "module": "dist/react-select.esm.js",
   "author": "Jed Watson",
   "license": "MIT",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ export default [
     external: [...external, 'raf'],
     plugins: [babel(babelOptions())],
   },
+
   {
     input: 'src/index.umd.js',
     output: {
@@ -54,6 +55,7 @@ export default [
     external,
     plugins: [babel(babelOptions()), resolve(), commonjs()],
   },
+
   {
     input: 'src/index.umd.js',
     output: {


### PR DESCRIPTION
es has different meanings. Some call it es5+ syntax or just es6.
There is a precedent of using `es` for untranspiled code in
[materia-ui](https://unpkg.com/@material-ui/core@1.0.0/es/).

In this diff I propose to rename `es` to `esm` as a shorthand for
ES Modules.

`jsnext:main` is deprecated in rollup community (it came from rollup and
dead in it) and shouldn't be used anymore. `module` is enabled by
default like in webpack.