### PR TITLE
[V2] Flowtype upgrade to v0.72.0

### DIFF
--- a/docs/pages/upgradeGuide/props.js
+++ b/docs/pages/upgradeGuide/props.js
@@ -252,7 +252,7 @@ class PropChanges extends Component<
   { selectedOptions: Array<string>, filterValue: string }
 > {
   state = {
-    selectedOptions: allOptions.map(opt => opt.value),
+    selectedOptions: (allOptions.map(opt => opt.value): Array<string>),
     filterValue: filterOptions[0].value,
   };
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^4.6.1",
     "eslint-plugin-react": "^7.3.0",
     "extract-react-types-loader": "^0.1.2",
-    "flow-bin": "^0.68.0",
+    "flow-bin": "^0.72.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const globals = {
   'react-input-autosize': 'AutosizeInput',
   react: 'React',
 };
+// $FlowFixMe This should be inferred by Flow and manual casting does not work inside of this config.
 const external = Object.keys(globals);
 const babelOptions = () => {
   let result = {

--- a/src/Select.js
+++ b/src/Select.js
@@ -23,6 +23,7 @@ import {
 
 import {
   defaultComponents,
+  type PlaceholderOrValue,
   type SelectComponents,
   type SelectComponentsConfig,
 } from './components/index';
@@ -1141,7 +1142,7 @@ export default class Select extends Component<Props, State> {
       />
     );
   }
-  renderPlaceholderOrValue() {
+  renderPlaceholderOrValue(): ?PlaceholderOrValue {
     const {
       MultiValue,
       MultiValueContainer,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,8 @@
 // @flow
-import type { ComponentType } from 'react';
+import {
+  type ComponentType,
+  type Element,
+} from 'react';
 import {
   type IndicatorContainerProps,
   type ContainerProps,
@@ -41,6 +44,11 @@ import MultiValue, {
 import Option, { type OptionProps } from './Option';
 import Placeholder, { type PlaceholderProps } from './Placeholder';
 import SingleValue, { type SingleValueProps } from './SingleValue';
+
+export type PlaceholderOrValue =
+  | Element<ComponentType<PlaceholderProps>>
+  | Element<ComponentType<SingleValueProps>>
+  | Array<Element<ComponentType<MultiValueProps>>>
 
 type IndicatorComponentType = ComponentType<IndicatorProps>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,9 +4056,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.68.0:
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
+flow-bin@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.72.0.tgz#12051180fb2db7ccb728fefe67c77e955e92a44d"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
When the consumer of react-select v2 already uses Flowtype v0.72.0 then react-select v2 beta-6 is reporting Flow errors. This is solved by upgrading Flowtype and fixing the necessary type issues.