### PR TITLE
[v2] Re-render when defaultOptions changes

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -69,6 +69,14 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
       if (nextProps.cacheOptions !== this.props.cacheOptions) {
         this.optionsCache = {};
       }
+      if (nextProps.defaultOptions !== this.props.defaultOptions) {
+        this.setState({
+          defaultOptions: Array.isArray(nextProps.defaultOptions)
+            ? nextProps.defaultOptions
+            : undefined,
+        });
+      }
+
     }
     componentWillUnmount() {
       this.mounted = false;


### PR DESCRIPTION
WIP.

Discussed with @JedWatson - needs tests probably.

Current workaround is to set a key on the select item which forces it to rerender (`key={this.props.defaultOptions}`).