### PR TITLE
[V2] add newValue to set-value actionMeta in onInputChange

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -488,7 +488,7 @@ export default class Select extends Component<Props, State> {
   }
   setValue = (newValue: ValueType, action: ActionTypes = 'set-value') => {
     const { closeMenuOnSelect, isMulti, onChange } = this.props;
-    this.onInputChange('', { action: 'set-value' });
+    this.onInputChange('', { action: 'set-value', newValue });
     if (closeMenuOnSelect) {
       this.inputIsHiddenAfterUpdate = !isMulti;
       this.onMenuClose();

--- a/src/types.js
+++ b/src/types.js
@@ -76,9 +76,9 @@ export type InputActionTypes =
   | 'input-blur'
   | 'menu-close';
 
-export type InputActionMeta = {|
+export type InputActionMeta = {
   action: InputActionTypes,
-|};
+};
 
 export type MenuPlacement = 'auto' | 'bottom' | 'top';
 export type MenuPosition = 'absolute' | 'fixed';


### PR DESCRIPTION
Solution to support a use case where in the use of Async Select you may want to call loadOptions after the select value has been changed via user interaction. Please see an example of this case here 
https://codesandbox.io/s/18wmw5mk1j

added a `newValue` property to our InputActionMeta, when setValue is called, `onInputChange('', { action: 'set-value', newValue });`. I like this approach, but I’m also weary of overloading our actionMeta with conditional attributes like this. 