### PR TITLE
[v2] making group options work with CreatableSelect

### DIFF
--- a/docs/examples/CreatableGrouped.js
+++ b/docs/examples/CreatableGrouped.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import CreatableSelect from '../../src/Creatable';
+import { colourOptions, groupedOptions } from '../data';
+
+const groupStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+};
+const groupBadgeStyles = {
+  backgroundColor: '#EBECF0',
+  borderRadius: '2em',
+  color: '#172B4D',
+  display: 'inline-block',
+  fontSize: 12,
+  fontWeight: 'normal',
+  lineHeight: '1',
+  minWidth: 1,
+  padding: '0.16666666666667em 0.5em',
+  textAlign: 'center',
+};
+
+const formatGroupLabel = data => (
+  <div style={groupStyles}>
+    <span>{data.label}</span>
+    <span style={groupBadgeStyles}>{data.options.length}</span>
+  </div>
+);
+
+export default () => (
+  <CreatableSelect
+    defaultValue={colourOptions[1]}
+    options={groupedOptions}
+    formatGroupLabel={formatGroupLabel}
+  />
+);

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -13,6 +13,7 @@ export { default as CreatableInputOnly } from './CreatableInputOnly';
 export { default as CreateFilter } from './CreateFilter';
 export { default as CreatableMulti } from './CreatableMulti';
 export { default as CreatableSingle } from './CreatableSingle';
+export { default as CreatableGrouped } from './CreatableGrouped';
 export { default as CustomClearIndicator } from './CustomClearIndicator';
 export { default as CustomDropdownIndicator } from './CustomDropdownIndicator';
 export { default as CustomLoadingIndicator } from './CustomLoadingIndicator';

--- a/docs/pages/creatable/index.js
+++ b/docs/pages/creatable/index.js
@@ -11,6 +11,7 @@ import {
   CreatableInputOnly,
   CreatableMulti,
   CreatableSingle,
+  CreatableGrouped,
 } from '../../examples';
 
 export default function Creatable() {
@@ -49,6 +50,16 @@ export default function Creatable() {
           raw={require('!!raw-loader!../../examples/CreatableMulti.js')}
         >
           <CreatableMulti />
+        </ExampleWrapper>
+      )}
+
+      ${(
+        <ExampleWrapper
+          label="Creatable Grouped Example"
+          urlPath="docs/examples/CreatableGrouped.js"
+          raw={require('!!raw-loader!../../examples/CreatableGrouped.js')}
+        >
+          <CreatableGrouped />
         </ExampleWrapper>
       )}
 

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -54,8 +54,6 @@ const compareOption = (
 const isOptionGroup = (option: OptionType | GroupType) => option.options;
 
 const builtins = {
-  getOptionLabel,
-  getOptionValue,
   formatCreateLabel: (inputValue: string) => `Create "${inputValue}"`,
   isValidNewOption: (
     inputValue: string,
@@ -117,7 +115,13 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
       } = nextProps;
       const options = nextProps.options || [];
       let { newOption } = this.state;
-      if (isValidNewOption(inputValue, cleanValue(value), options, nextProps.getOptionLabel, nextProps.getOptionValue)) {
+      if (isValidNewOption(
+        inputValue,
+        cleanValue(value),
+        options,
+        this.select ? this.select.props.getOptionLabel : getOptionLabel,
+        this.select ? this.select.props.getOptionValue : getOptionValue,
+      )) {
         newOption = getNewOptionData(inputValue, formatCreateLabel(inputValue));
       } else {
         newOption = undefined;


### PR DESCRIPTION
Dear Jed and other Maintainers,

Hereby a pull request to support group options also with CreatableSelect.
Without this PR, the isValidNewOption builtin will fail with group options, because it does not compare the underlying options array in the group. Secondly, the compareOption method didn't use the GetOptionLabel and GetOptionValue builtins for any custom option types. 

The main changes are in Creatable.js.
The isValidNewOption is now called with option label/value builtins as parameters in the componentWillReceiveProps event. In the PR, the isValidNewOption will now check if the option is a group before comparing it for similarity to any existing option. In the compareOption function, the builtins GetOptionLabel and GetOptionValue builtins will be applied to extract label and value.

For illustration purposes, I've also added an example 'CreatableGrouped', and added it to the Creatable document page.

In any case, thanks for the wonderfull component. I've switched from a different multiselect component to this one, and I really like it.

Cheers,
  Derk