### PR TITLE
Change isOptionDisabled to have the same inputs as isOptionSelected

### DIFF
--- a/docs/pages/upgradeGuide/index.js
+++ b/docs/pages/upgradeGuide/index.js
@@ -127,7 +127,7 @@ with your options:
   formatOptionLabel={(option: {}, context: {} ) => Node}
   getOptionLabel={(option: {}) => string}
   getOptionValue={(option: {}) => string}
-  isOptionDisabled={(option: {}) => boolean}
+  isOptionDisabled={(option: {}, value: [{}]) => boolean}
   isOptionSelected?={(option: {}, value: [{}]) => boolean}
 />
 ~~~

--- a/src/Select.js
+++ b/src/Select.js
@@ -118,7 +118,7 @@ export type Props = {
   /* Is the select in a state of loading (async) */
   isLoading: boolean,
   /* Override the built-in logic to detect whether an option is disabled */
-  isOptionDisabled: typeof isOptionDisabled | false,
+  isOptionDisabled: (OptionType, OptionsType) => boolean | false,
   /* Override the built-in logic to detect whether an option is selected */
   isOptionSelected?: (OptionType, OptionsType) => boolean,
   /* Support multiple selected options */
@@ -655,9 +655,9 @@ export default class Select extends Component<Props, State> {
 
     return isClearable;
   }
-  isOptionDisabled(option: OptionType): boolean {
+  isOptionDisabled(option: OptionType, selectValue: OptionsType): boolean {
     return typeof this.props.isOptionDisabled === 'function'
-      ? this.props.isOptionDisabled(option)
+      ? this.props.isOptionDisabled(option, selectValue)
       : false;
   }
   isOptionSelected(option: OptionType, selectValue: OptionsType): boolean {
@@ -988,7 +988,7 @@ export default class Select extends Component<Props, State> {
     const { hideSelectedOptions, isMulti, inputValue = '', options } = props;
 
     const toOption = (option, id) => {
-      const isDisabled = this.isOptionDisabled(option);
+      const isDisabled = this.isOptionDisabled(option, selectValue);
       const isSelected = this.isOptionSelected(option, selectValue);
       const label = this.getOptionLabel(option);
       const value = this.getOptionValue(option);


### PR DESCRIPTION
As we pass the selected values to isOptionSelected, it makes sense to pass them to isOptionDisabled as well. Allows for much more dynamic select lists.

#### Some context

In the code for the following image I have auto selecting checkboxes, I'd like to also auto disable them using very similar logic which requires `isOptionDisabled` to be passed the list of selected options.
Code snippets after the image.

![screencast 2018-06-08 20-35-45](https://user-images.githubusercontent.com/1085899/41156173-bb6423ca-6b5b-11e8-9a05-2b78e207dc34.gif)
my data structure simulates groups by concatenating ids, something like this:
```js
items={[
  ...
  { label: 'fr 1', value: 'sh1,sh2' },
  { label: 'Shop 1', value: 'sh1' },
  { label: 'Shop 2', value: 'sh2' }
  ...
]}
```

Then my select implementation goes something like this:
```jsx
<Select
  isOptionSelected={(option, options) => {
    for (let i = 0; i < options.length; i += 1) {
      if (
        options[i].value === option.value ||
        options[i].value.indexOf(option.value) >= 0
      )
        return true;
    }
    return false;
  }}
  options={...}
/>
```