### PR TITLE
Fix #1620

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -877,7 +877,6 @@ class Select extends React.Component {
 			'aria-label': this.props['aria-label'],
 			'aria-labelledby': this.props['aria-labelledby'],
 			'aria-owns': ariaOwns,
-			className: className,
 			onBlur: this.handleInputBlur,
 			onChange: this.handleInputChange,
 			onFocus: this.handleInputFocus,
@@ -921,7 +920,7 @@ class Select extends React.Component {
 
 		if (this.props.autosize) {
 			return (
-				<AutosizeInput id={this.props.id} {...inputProps} minWidth="5" />
+				<AutosizeInput id={this.props.id} {...inputProps} className={className} minWidth="5" />
 			);
 		}
 		return (

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -3570,7 +3570,7 @@ describe('Select', () => {
 			});
 
 			it('calls the renderer with props', () => {
-				expect(inputRenderer, 'was called with', { value: '', className: 'Select-input' });
+				expect(inputRenderer, 'was called with', { value: '' });
 			});
 		});
 


### PR DESCRIPTION
Hi!

I am facing with incorrect behavior of caret (it gets incorrect position relative to the first letter of placeholder) with this set of props:

1. autosize: false
2. inputRenderer: not defined
3. disabled: false
4. searchable: true

It caused because react-select renders input and it's wrapper with the same class for these rules (See #1620).

I tried to fix it via removing className from inputProps and pass it manually to `<AutosizeInput />`