### PR TITLE
[V2] update components prop types

### DIFF
--- a/docs/examples/CustomDropdownIndicator.js
+++ b/docs/examples/CustomDropdownIndicator.js
@@ -6,7 +6,7 @@ import Select, { components } from '../../src';
 import { colourOptions } from '../data';
 
 const DropdownIndicator = (props) => {
-  return (
+  return components.DropdownIndicator && (
     <components.DropdownIndicator {...props}>
       <EmojiIcon
         primaryColor={colourOptions[2].color}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -45,17 +45,17 @@ import SingleValue, { type SingleValueProps } from './SingleValue';
 type IndicatorComponentType = ComponentType<IndicatorProps>;
 
 export type SelectComponents = {
-  ClearIndicator: IndicatorComponentType,
+  ClearIndicator: IndicatorComponentType | null,
   Control: ComponentType<ControlProps>,
-  DropdownIndicator: IndicatorComponentType,
+  DropdownIndicator: IndicatorComponentType | null,
   DownChevron: ComponentType<any>,
   CrossIcon: ComponentType<any>,
   Group: ComponentType<GroupProps>,
   GroupHeading: ComponentType<any>,
   IndicatorsContainer: ComponentType<IndicatorContainerProps>,
-  IndicatorSeparator: IndicatorComponentType,
+  IndicatorSeparator: IndicatorComponentType | null,
   Input: ComponentType<InputProps>,
-  LoadingIndicator: ComponentType<LoadingIconProps>,
+  LoadingIndicator: ComponentType<LoadingIconProps> | null,
   Menu: ComponentType<MenuProps>,
   MenuList: ComponentType<MenuListComponentProps>,
   MenuPortal: ComponentType<MenuPortalProps>,


### PR DESCRIPTION
Indicator components can be explicitly set to `null` if the user doesn't want to render (e.g. separator). There were all necessary checks for indicator components so adding `| null` to the type was not an issue.