### PR TITLE
[V2] Add meta to onChange when isMulti

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -486,7 +486,7 @@ export default class Select extends Component<Props, State> {
       focusedValue: null,
     });
   }
-  setValue = (newValue: ValueType, action: ActionTypes = 'set-value') => {
+  setValue = (newValue: ValueType, action: ActionTypes = 'set-value', option?: OptionType) => {
     const { closeMenuOnSelect, isMulti, onChange } = this.props;
     this.onInputChange('', { action: 'set-value' });
     if (closeMenuOnSelect) {
@@ -495,7 +495,7 @@ export default class Select extends Component<Props, State> {
     }
     // when the select value should change, we should reset focusedValue
     this.clearFocusValueOnUpdate = true;
-    onChange(newValue, { action });
+    onChange(newValue, { action, option });
   };
   selectOption = (newValue: OptionType) => {
     const { blurInputOnSelect, isMulti } = this.props;
@@ -506,10 +506,11 @@ export default class Select extends Component<Props, State> {
         const candidate = this.getOptionValue(newValue);
         this.setValue(
           selectValue.filter(i => this.getOptionValue(i) !== candidate),
-          'deselect-option'
+          'deselect-option',
+          newValue
         );
       } else {
-        this.setValue([...selectValue, newValue], 'select-option');
+        this.setValue([...selectValue, newValue], 'select-option', newValue);
       }
     } else {
       this.setValue(newValue, 'select-option');

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -424,6 +424,7 @@ cases(
     expectedSelectedOption,
     optionsSelected,
     focusedOption,
+    expectedActionMetaOption,
   }) => {
     let onChangeSpy = jest.fn();
     props = { ...props, onChange: onChangeSpy };
@@ -438,6 +439,7 @@ cases(
     selectWrapper.update();
     expect(onChangeSpy).toHaveBeenCalledWith(expectedSelectedOption, {
       action: 'select-option',
+      option: expectedActionMetaOption
     });
   },
   {
@@ -494,6 +496,7 @@ cases(
       event: ['click'],
       optionsSelected: { label: '2', value: 'two' },
       expectedSelectedOption: [{ label: '2', value: 'two' }],
+      expectedActionMetaOption: { label: '2', value: 'two' },
     },
     'multi select > option with number value > option is clicked > should call onChange() prop with selected option': {
       props: {
@@ -505,6 +508,7 @@ cases(
       event: ['click'],
       optionsSelected: { label: '0', value: 0 },
       expectedSelectedOption: [{ label: '0', value: 0 }],
+      expectedActionMetaOption: { label: '0', value: 0 },
     },
     'multi select > option with boolean value > option is clicked > should call onChange() prop with selected option': {
       props: {
@@ -516,6 +520,7 @@ cases(
       event: ['click'],
       optionsSelected: { label: 'true', value: true },
       expectedSelectedOption: [{ label: 'true', value: true }],
+      expectedActionMetaOption: { label: 'true', value: true },
     },
     'multi select > tab key is pressed while focusing option > should call onChange() prop with selected option': {
       props: {
@@ -529,6 +534,7 @@ cases(
       optionsSelected: { label: '1', value: 'one' },
       focusedOption: { label: '1', value: 'one' },
       expectedSelectedOption: [{ label: '1', value: 'one' }],
+      expectedActionMetaOption: { label: '1', value: 'one' },
     },
     'multi select > enter key is pressed while focusing option > should call onChange() prop with selected option': {
       props: {
@@ -541,6 +547,7 @@ cases(
       optionsSelected: { label: '3', value: 'three' },
       focusedOption: { label: '3', value: 'three' },
       expectedSelectedOption: [{ label: '3', value: 'three' }],
+      expectedActionMetaOption: { label: '3', value: 'three' },
     },
     'multi select > space key is pressed while focusing option > should call onChange() prop with selected option': {
       props: {
@@ -553,6 +560,107 @@ cases(
       optionsSelected: { label: '1', value: 'one' },
       focusedOption: { label: '1', value: 'one' },
       expectedSelectedOption: [{ label: '1', value: 'one' }],
+      expectedActionMetaOption: { label: '1', value: 'one' },
+    },
+  }
+);
+
+cases(
+  'calls onChange on de-selecting an option in multi select',
+  ({
+    props = { ...BASIC_PROPS },
+    event,
+    expectedSelectedOption,
+    expectedMetaOption,
+    optionsSelected,
+    focusedOption,
+  }) => {
+    let onChangeSpy = jest.fn();
+    props = { ...props, onChange: onChangeSpy, menuIsOpen: true, hideSelectedOptions: false, isMulti: true, menuIsOpen: true };
+    let selectWrapper = mount(<Select {...props} />);
+
+    let selectOption = selectWrapper
+      .find('div.react-select__option')
+      .findWhere(n => n.props().children === optionsSelected.label);
+    selectWrapper.setState({ focusedOption });
+
+    selectOption.simulate(...event);
+    selectWrapper.update();
+    expect(onChangeSpy).toHaveBeenCalledWith(expectedSelectedOption, {
+      action: 'deselect-option',
+      option: expectedMetaOption
+    });
+  },
+  {
+    'option is clicked > should call onChange() prop with correct selected options and meta': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS,
+        value: [{ label: '2', value: 'two' }]
+      },
+      event: ['click'],
+      optionsSelected: { label: '2', value: 'two' },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: '2', value: 'two' }
+    },
+    'option with number value > option is clicked > should call onChange() prop with selected option': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS_NUMBER_VALUE,
+        value: [{ label: '0', value: 0 }]
+      },
+      event: ['click'],
+      optionsSelected: { label: '0', value: 0 },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: '0', value: 0 }
+    },
+    'option with boolean value > option is clicked > should call onChange() prop with selected option': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS_BOOLEAN_VALUE,
+        value: [{ label: 'true', value: true }]
+      },
+      event: ['click'],
+      optionsSelected: { label: 'true', value: true },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: 'true', value: true }
+    },
+    'tab key is pressed while focusing option > should call onChange() prop with selected option': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS,
+        value: [{ label: '1', value: 'one' }]
+      },
+      event: ['keyDown', { keyCode: 9, key: 'Tab' }],
+      menuIsOpen: true,
+      optionsSelected: { label: '1', value: 'one' },
+      focusedOption: { label: '1', value: 'one' },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: '1', value: 'one' },
+    },
+    'enter key is pressed while focusing option > should call onChange() prop with selected option': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS,
+        value: { label: '3', value: 'three' }
+      },
+      event: ['keyDown', { keyCode: 13, key: 'Enter' }],
+      optionsSelected: { label: '3', value: 'three' },
+      focusedOption: { label: '3', value: 'three' },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: '3', value: 'three' },
+    },
+    'space key is pressed while focusing option > should call onChange() prop with selected option': {
+      props: {
+        ...BASIC_PROPS,
+        options: OPTIONS,
+        value: [{ label: '1', value: 'one' }]
+      },
+      event: ['keyDown', { keyCode: 32, key: ' ' }],
+      optionsSelected: { label: '1', value: 'one' },
+      focusedOption: { label: '1', value: 'one' },
+      expectedSelectedOption: [],
+      expectedMetaOption: { label: '1', value: 'one' },
     },
   }
 );
@@ -1840,8 +1948,10 @@ test('multi select >  calls onChange when option is selected and isSearchable is
     .find('div.react-select__option')
     .at(0)
     .simulate('click', { button: 0 });
-  expect(onChangeSpy).toHaveBeenCalledWith([{ label: '0', value: 'zero' }], {
+  const selectedOption = { label: '0', value: 'zero' };
+  expect(onChangeSpy).toHaveBeenCalledWith([selectedOption], {
     action: 'select-option',
+    option: selectedOption
   });
 });
 


### PR DESCRIPTION
In the case of using isMulti and especially with `hideSelectedOptions = false` (for deselect) the action meta should include the option that is being selected/deselected.

This is kind of an extension of https://github.com/JedWatson/react-select/pull/2637. Only applies to `isMulti`.