### PR TITLE
[V2] fix for #2688

### DIFF
--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { type Node, type ComponentType } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 
 import { spacing } from '../theme';
 import type { CommonProps } from '../types';
@@ -44,7 +44,7 @@ const Group = (props: GroupProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('group', props)),
+        css(getStyles('group', props)),
         { 'group': true },
         className,
       )}
@@ -75,7 +75,7 @@ export const GroupHeading = (props: any) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('groupHeading', props)),
+        css(getStyles('groupHeading', props)),
         { 'group-heading': true },
         className
       )}

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -17,7 +17,7 @@ export type InputProps = PropsWithStyles & {
   className?: string,
 };
 
-export const css = ({ isDisabled }: InputProps) => ({
+export const inputCSS = ({ isDisabled }: InputProps) => ({
   margin: spacing.baseUnit / 2,
   paddingBottom: spacing.baseUnit / 2,
   paddingTop: spacing.baseUnit / 2,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -5,7 +5,7 @@ import React, {
   type ElementRef,
   type Node,
 } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 
@@ -287,7 +287,7 @@ export class Menu extends Component<MenuProps, MenuState> {
     return (
       <div
         className={cx(
-          emotionCss(getStyles('menu', this.getState())),
+          css(getStyles('menu', this.getState())),
           {
             'menu': true,
           },
@@ -343,7 +343,7 @@ export const MenuList = (props: MenuListComponentProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('menuList', props)),
+        css(getStyles('menuList', props)),
         {
           'menu-list': true,
           'menu-list--is-multi': isMulti
@@ -382,7 +382,7 @@ export const NoOptionsMessage = (props: NoticeProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('noOptionsMessage', props)),
+        css(getStyles('noOptionsMessage', props)),
         {
           'menu-notice': true,
           'menu-notice--no-options': true,
@@ -404,7 +404,7 @@ export const LoadingMessage = (props: NoticeProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('loadingMessage', props)),
+        css(getStyles('loadingMessage', props)),
         {
           'menu-notice': true,
           'menu-notice--loading': true,
@@ -494,7 +494,7 @@ export class MenuPortal extends Component<MenuPortalProps, MenuPortalState> {
     // same wrapper element whether fixed or portalled
     const menuWrapper = (
       <div
-        className={emotionCss(getStyles('menuPortal', state))}
+        className={css(getStyles('menuPortal', state))}
       >
         {children}
       </div>

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component, type Node } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 
 import { borderRadius, colors, spacing } from '../theme';
 import { CrossIcon } from './indicators';
@@ -87,18 +87,18 @@ class MultiValue extends Component<MultiValueProps> {
     } = this.props;
     const cn = {
       container: cx(
-        emotionCss(getStyles('multiValue', this.props)),
+        css(getStyles('multiValue', this.props)),
         {
           'multi-value': true,
           'multi-value--is-disabled': isDisabled
         }, className),
       label: cx(
-        emotionCss(getStyles('multiValueLabel', this.props)),
+        css(getStyles('multiValueLabel', this.props)),
         {
           'multi-value__label': true,
         }, className),
       remove: cx(
-        emotionCss(getStyles('multiValueRemove', this.props),), {
+        css(getStyles('multiValueRemove', this.props),), {
           'multi-value__remove': true,
         }, className),
     };

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 
 import { colors, spacing } from '../theme';
 import type { CommonProps, PropsWithStyles, InnerRef } from '../types';
@@ -37,7 +37,7 @@ export type OptionProps = PropsWithStyles &
     type: 'option',
   };
 
-export const css = ({ isDisabled, isFocused, isSelected }: State) => ({
+export const optionCSS = ({ isDisabled, isFocused, isSelected }: State) => ({
   backgroundColor: isSelected
     ? colors.primary
     : isFocused ? colors.primary25 : 'transparent',
@@ -65,7 +65,7 @@ const Option = (props: OptionProps) => {
     <div
       ref={innerRef}
       className={cx(
-        emotionCss(getStyles('option', props)),
+        css(getStyles('option', props)),
         {
           'option': true,
           'option--is-disabled': isDisabled,

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { type Node } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 
 import { colors, spacing } from '../theme';
 import type { CommonProps } from '../types';
@@ -12,7 +12,7 @@ export type PlaceholderProps = CommonProps & {
   innerProps: { [string]: any },
 };
 
-export const css = () => ({
+export const placeholderCSS = () => ({
   color: colors.neutral50,
   marginLeft: spacing.baseUnit / 2,
   marginRight: spacing.baseUnit / 2,
@@ -26,7 +26,7 @@ const Placeholder = (props: PlaceholderProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('placeholder', props)),
+        css(getStyles('placeholder', props)),
         {
           'placeholder': true,
         },

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component, type Node } from 'react';
-import { css as emotionCss } from 'emotion';
+import { css } from 'emotion';
 import { spacing } from '../theme';
 import type { CommonProps, KeyboardEventHandler } from '../types';
 
@@ -32,7 +32,7 @@ export const SelectContainer = (props: ContainerProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('container', props)),
+        css(getStyles('container', props)),
         {
           '--is-disabled': isDisabled,
           '--is-rtl': isRtl
@@ -74,7 +74,7 @@ export class ValueContainer extends Component<ValueContainerProps> {
     return (
       <div
         className={cx(
-          emotionCss(getStyles('valueContainer', this.props)),
+          css(getStyles('valueContainer', this.props)),
           {
             'value-container': true,
             'value-container--is-multi': isMulti,
@@ -114,7 +114,7 @@ export const IndicatorsContainer = (props: IndicatorContainerProps) => {
   return (
     <div
       className={cx(
-        emotionCss(getStyles('indicatorsContainer', props)),
+        css(getStyles('indicatorsContainer', props)),
         {
           'indicators': true,
         },

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { type ElementType } from 'react';
-import { injectGlobal, css as emotionCss } from 'emotion';
+import { injectGlobal, css } from 'emotion';
 
 import { A11yText } from '../primitives';
 import { colors, spacing } from '../theme';
@@ -15,7 +15,7 @@ const Svg = ({ size, ...props }: { size: number }) => (
     height={size}
     width={size}
     viewBox="0 0 20 20"
-    className={emotionCss({
+    className={css({
       display: 'inline-block',
       fill: 'currentColor',
       lineHeight: 1,
@@ -70,7 +70,7 @@ export const DropdownIndicator = (props: IndicatorProps) => {
     <div
       {...innerProps}
       className={cx(
-        emotionCss(getStyles('dropdownIndicator', props)),
+        css(getStyles('dropdownIndicator', props)),
         {
           'indicator': true,
           'dropdown-indicator': true,
@@ -90,7 +90,7 @@ export const ClearIndicator = (props: IndicatorProps) => {
     <div
       {...innerProps}
       className={cx(
-        emotionCss(getStyles('clearIndicator', props)),
+        css(getStyles('clearIndicator', props)),
         {
           'indicator': true,
           'clear-indicator': true,
@@ -122,7 +122,7 @@ export const IndicatorSeparator = (props: IndicatorProps) => {
     <span
       {...innerProps}
       className={cx(
-        emotionCss(getStyles('indicatorSeparator', props)),
+        css(getStyles('indicatorSeparator', props)),
         { 'indicator-separator': true },
         className
       )}
@@ -158,7 +158,7 @@ export const loadingIndicatorCSS = ({
 type DotProps = { color: string, delay: number, offset: boolean };
 const LoadingDot = ({ color, delay, offset }: DotProps) => (
   <span
-    css={{
+    className={css({
       animationDuration: '1s',
       animationDelay: `${delay}ms`,
       animationIterationCount: 'infinite',
@@ -171,7 +171,7 @@ const LoadingDot = ({ color, delay, offset }: DotProps) => (
       height: '1em',
       verticalAlign: 'top',
       width: '1em',
-    }}
+    })}
   />
 );
 
@@ -193,7 +193,7 @@ export const LoadingIndicator = (props: LoadingIconProps) => {
     <div
       {...innerProps}
       className={cx(
-        emotionCss(getStyles('loadingIndicator', props)),
+        css(getStyles('loadingIndicator', props)),
         {
           'indicator': true,
           'loading-indicator': true,

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -158,7 +158,7 @@ export const loadingIndicatorCSS = ({
 type DotProps = { color: string, delay: number, offset: boolean };
 const LoadingDot = ({ color, delay, offset }: DotProps) => (
   <span
-    className={css({
+    css={{
       animationDuration: '1s',
       animationDelay: `${delay}ms`,
       animationIterationCount: 'infinite',
@@ -171,7 +171,7 @@ const LoadingDot = ({ color, delay, offset }: DotProps) => (
       height: '1em',
       verticalAlign: 'top',
       width: '1em',
-    })}
+    }}
   />
 );
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -13,9 +13,9 @@ import {
   loadingIndicatorCSS,
   indicatorSeparatorCSS,
 } from './components/indicators';
-import { css as inputCSS } from './components/Input';
-import { css as placeholderCSS } from './components/Placeholder';
-import { css as optionCSS } from './components/Option';
+import { inputCSS } from './components/Input';
+import { placeholderCSS } from './components/Placeholder';
+import { optionCSS } from './components/Option';
 import {
   menuCSS,
   menuListCSS,


### PR DESCRIPTION
Changing the namespace using the import { css as Blah } syntax in the indicators file, meant that babel-plugin-emotion was internally transpiling the css prop using the incorrect namespace.

This has now been addressed, we now normalise calls to emotion's css function in all cases where we use it. styling functions that clash with this naming (in Input, Option and Placeholder) have been renamed inputCSS, optionCSS, placeholderCSS respectively. 