### PR TITLE
Always clear focusedOption when opening the menu

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -278,6 +278,7 @@ class Select extends React.Component {
 				this.setState({
 					isOpen: true,
 					isPseudoFocused: false,
+					focusedOption: null,
 				});
 			}
 
@@ -293,6 +294,7 @@ class Select extends React.Component {
 			this.focus();
 			return this.setState({
 				isOpen: !this.state.isOpen,
+				focusedOption: null,
 			});
 		}
 

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -4645,7 +4645,7 @@ describe('Select', () => {
 			expect(preventDefault, 'was called once');
 			expect(focusStub, 'was called once');
 			expect(setStateStub, 'was called once');
-			expect(setStateStub, 'was called with', { isOpen: !isOpen });
+			expect(setStateStub, 'was called with', { isOpen: !isOpen, focusedOption: null });
 		});
 
 		it('for tagName="INPUT", isFocused=false should call only focus', () => {
@@ -4687,7 +4687,7 @@ describe('Select', () => {
 			expect(preventDefault, 'was not called');
 			expect(focusStub, 'was not called');
 			expect(setStateStub, 'was called once');
-			expect(setStateStub, 'was called with', { isOpen: true, isPseudoFocused: false });
+			expect(setStateStub, 'was called with', { isOpen: true, isPseudoFocused: false, focusedOption: null });
 		});
 
 		it('for tagName="INPUT", isFocused=true, isOpen=true should return', () => {


### PR DESCRIPTION
When closing and reopening the menu, the last option to be moused-over will remain focused:
![oldselectbehavior](https://user-images.githubusercontent.com/1316184/41739693-d8f9570e-7563-11e8-81c6-a5842daa622b.gif)

While this could be intended behavior it seems more like a bug, especially since the same does not happen if `searchable` is set to `true`:
![searchselectbehavior](https://user-images.githubusercontent.com/1316184/41739695-de02532c-7563-11e8-8c34-4d1fe295e4b0.gif)

This PR changes the behavior to always clear the last focused option when opening the menu.