### PR TITLE
Fix disabled and focused classNames in Control

### DIFF
--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -58,8 +58,8 @@ const Control = (props: ControlProps) => {
       ref={innerRef}
       className={cx(emotionCSS(getStyles('control', props)), {
         'control': true,
-        'control-is-disabled': isDisabled,
-        'control-is-focused': isFocused
+        'control--is-disabled': isDisabled,
+        'control--is-focused': isFocused
       }, className)}
       {...rest}
     >


### PR DESCRIPTION
Fix for #2713 

Due to BEM methodology, modifiers should be with double dash