### PR TITLE
[v2] Fix Mobile MultiValue Remove ( Issue #2577 )

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1204,6 +1204,7 @@ export default class Select extends Component<Props, State> {
             key={this.getOptionValue(opt)}
             removeProps={{
               onClick: () => this.removeValue(opt),
+              onTouchEnd: () => this.removeValue(opt),
               onMouseDown: e => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -15,6 +15,7 @@ export type ValueProps = LabelProps & {
   isFocused: boolean,
   isDisabled: boolean,
   removeProps: {
+    onTouchEnd: any => void,
     onClick: any => void,
     onMouseDown: any => void,
   },
@@ -56,6 +57,7 @@ export type MultiValueRemoveProps = CommonProps & {
   children: Node,
   innerProps: any,
   removeProps: {
+    onTouchEnd: any => void,
     onClick: any => void,
     onMouseDown: any => void,
   },


### PR DESCRIPTION
Pipes the `onTouchEnd` events down to the MultiValueRemove component's props.

Fixes #2577 