### PR TITLE
Adds a Select prop that prevents unselecting previously-selected item

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -482,13 +482,13 @@ class Select extends React.Component {
 					break;
 				}
 				event.preventDefault();
-				this.selectFocusedOption();
+				this.selectFocusedOption(!this.props.unselectOnEnter);
 				break;
 			case 13: // enter
 				event.preventDefault();
 				event.stopPropagation();
 				if (this.state.isOpen) {
-					this.selectFocusedOption();
+					this.selectFocusedOption(!this.props.unselectOnEnter);
 				} else {
 					this.focusNextOption();
 				}
@@ -610,7 +610,7 @@ class Select extends React.Component {
 		}
 	}
 
-	selectValue (value) {
+	selectValue (value, preventUnselecting) {
 		// NOTE: we actually add/set the value in a callback to make sure the
 		// input value is empty to avoid styling issues in Chrome
 		if (this.props.closeOnSelect) {
@@ -624,7 +624,7 @@ class Select extends React.Component {
 				isOpen: !this.props.closeOnSelect,
 			}, () => {
 				const valueArray = this.getValueArray(this.props.value);
-				if (valueArray.some(i => i[this.props.valueKey] === value[this.props.valueKey])) {
+				if (valueArray.some(i => i[this.props.valueKey] === value[this.props.valueKey]) && !preventUnselecting) {
 					this.removeValue(value);
 				} else {
 					this.addValue(value);
@@ -645,6 +645,7 @@ class Select extends React.Component {
 		let valueArray = this.getValueArray(this.props.value);
 		const visibleOptions = this._visibleOptions.filter(val => !val.disabled);
 		const lastValueIndex = visibleOptions.indexOf(value);
+		valueArray = valueArray.filter(i => i[this.props.valueKey] !== value[this.props.valueKey]);
 		this.setValue(valueArray.concat(value));
 		if (visibleOptions.length - 1 === lastValueIndex) {
 			// the last option was selected; focus the second-last one
@@ -792,9 +793,9 @@ class Select extends React.Component {
 		return this._focusedOption;
 	}
 
-	selectFocusedOption () {
+	selectFocusedOption (preventUnselecting) {
 		if (this._focusedOption) {
-			return this.selectValue(this._focusedOption);
+			return this.selectValue(this._focusedOption, preventUnselecting);
 		}
 	}
 
@@ -1260,6 +1261,7 @@ Select.propTypes = {
 	tabIndex: stringOrNumber,             // optional tab index of the control
 	tabSelectsValue: PropTypes.bool,      // whether to treat tabbing out while focused to be value selection
 	trimFilter: PropTypes.bool,           // whether to trim whitespace around filter value
+	unselectOnEnter: PropTypes.bool,      // whether enter/tab will unselect the focused option on multi selects
 	value: PropTypes.any,                 // initial field value
 	valueComponent: PropTypes.func,       // value component to render
 	valueKey: PropTypes.string,           // path of the label value in option objects
@@ -1308,7 +1310,8 @@ Select.defaultProps = {
 	searchable: true,
 	simpleValue: false,
 	tabSelectsValue: true,
- 	trimFilter: true,
+	trimFilter: true,
+	unselectOnEnter: true,
 	valueComponent: Value,
 	valueKey: 'value',
 };

--- a/test/Select-test.js
+++ b/test/Select-test.js
@@ -4344,7 +4344,7 @@ describe('Select', () => {
 			});
 		});
 
-		describe('with multiselect', () => {
+		describe.only('with multiselect', () => {
 
 			beforeEach(() => {
 
@@ -4359,6 +4359,7 @@ describe('Select', () => {
 					value: ['three', 'two'],
 					multi: true,
 					closeOnSelect: false,
+					searchable: true,
 				}, {
 					wireUpOnChangeToValue: true
 				});
@@ -4406,6 +4407,35 @@ describe('Select', () => {
 						expect(ReactDOM.findDOMNode(instance), 'queried for first', '#' + activeId, 'to have text', 'label four');
 					});
 
+			});
+
+			it('unselects previously-selected menu options that are focused on enter by default', () => {
+				wrapper.setPropsForChild({
+					removeSelected: false,
+				});
+				onChange.reset();
+				typeSearchText('three');
+				pressEnterToAccept();
+
+				// 'three' was selected and focused,
+				// therefore after `enter`, the `four` option should not be selected
+
+				expect(onChange, 'was called with', [{ label: 'label two', value: 'two' }]);
+			});
+
+			it('does not unselect previously-selected menu options that are focused on enter when `unselectOnEnter` prop is `false`', () => {
+				wrapper.setPropsForChild({
+					removeSelected: false,
+					unselectOnEnter: false,
+				});
+				onChange.reset();
+				typeSearchText('three');
+				pressEnterToAccept();
+
+				// 'three' was selected and focused, but `unselectOnEnter` prop is `false`
+				// therefore after `enter`, the `three` option should still be selected
+
+				expect(onChange, 'was called with', [{ label: 'label two', value: 'two' }, { label: 'label three', value: 'three' }]);
 			});
 
 			it('expands the drop down when the enter key is pressed', () => {


### PR DESCRIPTION
We're using react-select to allow the user to pick multiple people from a list of contacts, and we're setting the `removeSelected` prop to be false so that the user can see which contacts they've already picked both in the input and in the menu. So far, most everything is working well.

However, during user testing we noticed that users found it unintuitive that hitting tab or enter after filtering the list down would actually unselect an option if it was previously selected. 

After getting a couple more eyes on it around the office, we agree that it's a little weird to hit "enter" and then have things disappear, given that enter is generally a positive input rather than a negative. We think that a better interaction is to either do nothing, or to maintain the previously-selected option but to also move it to be the newest item in the input list (as if they had just selected it for the first time).

This pull request exposes a boolean prop, `unselectOnEnter`, which toggles on the latter behavior described above when set to false (it defaults to true to maintain existing behavior by default). Note that this behavior is only invoked when using enter/tab to select a value; clicking on a selected option will still unselect it even if `unselectOnEnter` is set to false.

Please let me know if there's anything else I can do to assist with this pull request. Thanks for all your hard work!