### PR TITLE
Fix creatable fn "shouldKeyDownEventCreateNewOption"

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -133,7 +133,7 @@ class CreatableSelect extends React.Component {
 		if (
 			focusedOption &&
 			focusedOption === this._createPlaceholderOption &&
-			shouldKeyDownEventCreateNewOption({ keyCode: event.keyCode })
+			shouldKeyDownEventCreateNewOption(event)
 		) {
 			this.createNewOption();
 


### PR DESCRIPTION
Pass the entire event to `shouldKeyDownEventCreateNewOption`; necessary for things like `KeyboardEvent.shiftKey`.

Ref #2494