### PR TITLE
[v2] Add labelProps prop to MultiValue, as an analogue to removeProps

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1247,6 +1247,11 @@ export default class Select extends Component<Props, State> {
             isFocused={isFocused}
             isDisabled={isDisabled}
             key={this.getOptionValue(opt)}
+            labelProps={{
+              onClick: () => undefined,
+              onTouchEnd: () => undefined,
+              onMouseDown: () => undefined
+            }}
             removeProps={{
               onClick: () => this.removeValue(opt),
               onTouchEnd: () => this.removeValue(opt),

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -11,6 +11,7 @@ type LabelProps = { cropWithEllipsis: boolean };
 export type ValueProps = LabelProps & {
   children: Node,
   components: any,
+  data: any,
   innerProps: any,
   isFocused: boolean,
   isDisabled: boolean,
@@ -65,6 +66,7 @@ export type MultiValueLabelProps = CommonProps & {
     onClick: any => void,
     onMouseDown: any => void,
   },
+  data: any
 };
 export class MultiValueLabel extends Component<MultiValueLabelProps> {
   static defaultProps = {}
@@ -82,6 +84,7 @@ export type MultiValueRemoveProps = CommonProps & {
     onClick: any => void,
     onMouseDown: any => void,
   },
+  data: any
 };
 export class MultiValueRemove extends Component<MultiValueRemoveProps> {
   static defaultProps = {
@@ -103,6 +106,7 @@ class MultiValue extends Component<MultiValueProps> {
       className,
       components,
       cx,
+      data,
       getStyles,
       innerProps,
       isDisabled,
@@ -133,10 +137,10 @@ class MultiValue extends Component<MultiValueProps> {
         className={cn.container}
         {...innerProps}
         >
-        <Label className={cn.label} {...labelProps}>
+        <Label className={cn.label} data={data} {...labelProps}>
           {children}
         </Label>
-        <Remove className={cn.remove} {...removeProps} />
+        <Remove className={cn.remove} data={data} {...removeProps} />
       </Container>
     );
   }

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -14,6 +14,11 @@ export type ValueProps = LabelProps & {
   innerProps: any,
   isFocused: boolean,
   isDisabled: boolean,
+  labelProps: {
+    onTouchEnd: any => void,
+    onClick: any => void,
+    onMouseDown: any => void,
+  },
   removeProps: {
     onTouchEnd: any => void,
     onClick: any => void,
@@ -52,7 +57,23 @@ export const multiValueRemoveCSS = ({ isFocused }: MultiValueProps) => ({
 });
 
 export const MultiValueContainer = Div;
-export const MultiValueLabel = Div;
+export type MultiValueLabelProps = CommonProps & {
+  children: Node,
+  innerProps: any,
+  labelProps: {
+    onTouchEnd: any => void,
+    onClick: any => void,
+    onMouseDown: any => void,
+  },
+};
+export class MultiValueLabel extends Component<MultiValueLabelProps> {
+  static defaultProps = {}
+  render() {
+    const { children, ...props } = this.props;
+    return <Div {...props}>{children}</Div>;
+  }
+}
+
 export type MultiValueRemoveProps = CommonProps & {
   children: Node,
   innerProps: any,
@@ -85,6 +106,7 @@ class MultiValue extends Component<MultiValueProps> {
       getStyles,
       innerProps,
       isDisabled,
+      labelProps,
       removeProps,
     } = this.props;
     const cn = {
@@ -111,7 +133,7 @@ class MultiValue extends Component<MultiValueProps> {
         className={cn.container}
         {...innerProps}
         >
-        <Label className={cn.label}>
+        <Label className={cn.label} {...labelProps}>
           {children}
         </Label>
         <Remove className={cn.remove} {...removeProps} />


### PR DESCRIPTION
... to allow adding behaviors to the label as well. This also opens an avenue for users to implement the now-removed `onValueClick` functionality, which I really kinda need.

Behavior and actual props being passed are identical to removeProps.