### PR TITLE
[v2] Passing props to MenuPortal's getStyles

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -487,7 +487,7 @@ export class MenuPortal extends Component<MenuPortalProps, MenuPortalState> {
     // same wrapper element whether fixed or portalled
     const menuWrapper = (
       <div
-        className={css(getStyles('menuPortal', state))}
+        className={css(getStyles('menuPortal', state, this.props))}
       >
         {children}
       </div>

--- a/src/types.js
+++ b/src/types.js
@@ -47,7 +47,7 @@ export type CommonProps = {
     property as the first argument, and the current props as the second argument.
     See the `styles` object for the properties available.
   */
-  getStyles: (string, any) => {},
+  getStyles: (string, any, any) => {},
   getValue: () => ValueType,
   hasValue: boolean,
   isMulti: boolean,


### PR DESCRIPTION
I'm using app-level context to determine current z-index (select can be opened in different "layers" of app, like modals, popups, etc.). I'm passing current z-index as custom prop to Select and need to have an access to it from menuPortal's `getStyles()`. Furthermore there is an access to `selectProps` from all `getStyles()` functions, except `menuPortal`, so i think that this will made styling api more consistent. 