### PR TITLE
[v2] Allow configuring the Theme object

### DIFF
--- a/docs/examples/Theme.js
+++ b/docs/examples/Theme.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { flavourOptions } from '../data';
+import Select from '../../src';
+
+export default () => (
+  <Select
+    defaultValue={flavourOptions[2]}
+    label="Single select"
+    options={flavourOptions}
+    theme={(theme) => ({
+      ...theme,
+      borderRadius: 0,
+      colors: {
+      ...theme.colors,
+        text: 'orangered',
+        primary25: 'hotpink',
+        primary: 'black',
+      },
+    })}
+  />
+);

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -44,3 +44,4 @@ export { default as StyledSingle } from './StyledSingle';
 export { default as OnSelectResetsInput } from './OnSelectResetsInput';
 export { default as AsyncMulti } from './AsyncMulti';
 export { default as MenuPortal } from './MenuPortal';
+export { default as Theme } from './Theme';

--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
 import md from '../../markdown/renderer';
 import ExampleWrapper from '../../ExampleWrapper';
-import { StyledSingle, StyledMulti } from '../../examples';
+import { StyledSingle, StyledMulti, Theme } from '../../examples';
 
 export default function Styles() {
   return (
@@ -146,6 +146,22 @@ export default function Styles() {
 
     While we encourage you to use the new Styles API, it's good to know that you
     still have the option of adding class names to the components to style via CSS.
+
+    ## Overriding the theme
+
+    The default styles are derived from a theme object, which you can mutate like \`styles\`.
+
+    The \`theme\` object is available for the \`styles\` functions as well.
+
+    ${(
+      <ExampleWrapper
+        label="Customised theme"
+        urlPath="docs/examples/Theme.js"
+        raw={require('!!raw-loader!../../examples/Theme.js')}
+      >
+        <Theme />
+      </ExampleWrapper>
+    )}
 
     `}
     </Fragment>

--- a/src/Select.js
+++ b/src/Select.js
@@ -45,7 +45,9 @@ import {
   type SelectComponents,
   type SelectComponentsConfig,
 } from './components/index';
+
 import { defaultStyles, type StylesConfig } from './styles';
+import { defaultTheme } from './theme';
 
 import type {
   ActionMeta,
@@ -653,6 +655,10 @@ export default class Select extends Component<Props, State> {
   // Getters
   // ==============================
 
+  getTheme() {
+    return defaultTheme;
+  }
+
   getCommonProps() {
     const { clearValue, getStyles, setValue, selectOption, props } = this;
     const { classNamePrefix, isMulti, isRtl, options } = props;
@@ -674,6 +680,7 @@ export default class Select extends Component<Props, State> {
       selectOption,
       setValue,
       selectProps: props,
+      theme: this.getTheme(),
     };
   }
 
@@ -1318,7 +1325,7 @@ export default class Select extends Component<Props, State> {
       'aria-labelledby': this.props['aria-labelledby'],
     };
 
-    const { cx } = this.commonProps;
+    const { cx, theme } = this.commonProps;
 
     return (
       <Input
@@ -1336,6 +1343,7 @@ export default class Select extends Component<Props, State> {
         onFocus={this.onInputFocus}
         spellCheck="false"
         tabIndex={tabIndex}
+        theme={theme}
         type="text"
         value={inputValue}
         {...ariaAttributes}

--- a/src/Select.js
+++ b/src/Select.js
@@ -47,7 +47,7 @@ import {
 } from './components/index';
 
 import { defaultStyles, type StylesConfig } from './styles';
-import { defaultTheme } from './theme';
+import { defaultTheme, type ThemeConfig } from './theme';
 
 import type {
   ActionMeta,
@@ -213,6 +213,8 @@ export type Props = {
   screenReaderStatus: ({ count: number }) => string,
   /* Style modifier methods */
   styles: StylesConfig,
+  /* Theme modifier method */
+  theme?: ThemeConfig,
   /* Sets the tabIndex attribute on the input */
   tabIndex: string,
   /* Select the currently focused option when the user presses tab */
@@ -656,7 +658,22 @@ export default class Select extends Component<Props, State> {
   // ==============================
 
   getTheme() {
-    return defaultTheme;
+    // Use the default theme if there are no customizations.
+    if (!this.props.theme) {
+      return defaultTheme;
+    }
+    // If the theme prop is a function, assume the function
+    // knows how to merge the passed-in default theme with
+    // its own modifications.
+    if (typeof this.props.theme === 'function') {
+      return this.props.theme(defaultTheme);
+    }
+    // Otherwise, if a plain theme object was passed in,
+    // overlay it with the default theme.
+    return {
+      ...defaultTheme,
+      ...this.props.theme,
+    };
   }
 
   getCommonProps() {

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -2256,3 +2256,28 @@ test.skip('hitting spacebar should not select option if isSearchable is true (de
   selectWrapper.simulate('keyDown', { keyCode: 32, key: ' ' });
   expect(onChangeSpy).not.toHaveBeenCalled();
 });
+
+
+test('renders with custom theme', () => {
+  const primary = 'rgb(255, 164, 83)';
+  const selectWrapper = mount(
+    <Select
+      {...BASIC_PROPS}
+      value={OPTIONS[0]}
+      menuIsOpen
+      theme={(theme) => (
+        {
+          ... theme,
+          borderRadius: 180,
+          colors: {
+            ...theme.colors,
+            primary,
+          },
+        }
+      )} />
+  );
+  const menu = selectWrapper.find(Menu);
+  expect(window.getComputedStyle(menu.getDOMNode()).getPropertyValue('border-radius')).toEqual('180px');
+  const firstOption = selectWrapper.find(Option).first();
+  expect(window.getComputedStyle(firstOption.getDOMNode()).getPropertyValue('background-color')).toEqual(primary);
+});

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -135,6 +135,35 @@ exports[`defaults - snapshot 1`] = `
           }
         }
         setValue={[Function]}
+        theme={
+          Object {
+            "borderRadius": 4,
+            "colors": Object {
+              "danger": "#DE350B",
+              "dangerLight": "#FFBDAD",
+              "neutral0": "hsl(218, 0%, 100%)",
+              "neutral10": "hsl(218, 10%, 90%)",
+              "neutral20": "hsl(218, 15%, 80%)",
+              "neutral30": "hsl(218, 20%, 70%)",
+              "neutral40": "hsl(218, 25%, 60%)",
+              "neutral5": "hsl(218, 5%, 95%)",
+              "neutral50": "hsl(218, 30%, 50%)",
+              "neutral60": "hsl(218, 35%, 40%)",
+              "neutral70": "hsl(218, 40%, 30%)",
+              "neutral80": "hsl(218, 45%, 20%)",
+              "neutral90": "hsl(218, 50%, 10%)",
+              "primary": "#2684FF",
+              "primary25": "#DEEBFF",
+              "primary50": "#B2D4FF",
+              "primary75": "#4C9AFF",
+            },
+            "spacing": Object {
+              "baseUnit": 4,
+              "controlHeight": 38,
+              "menuGutter": 8,
+            },
+          }
+        }
       >
         <div
           className="css-10nd86i"
@@ -211,6 +240,35 @@ exports[`defaults - snapshot 1`] = `
               }
             }
             setValue={[Function]}
+            theme={
+              Object {
+                "borderRadius": 4,
+                "colors": Object {
+                  "danger": "#DE350B",
+                  "dangerLight": "#FFBDAD",
+                  "neutral0": "hsl(218, 0%, 100%)",
+                  "neutral10": "hsl(218, 10%, 90%)",
+                  "neutral20": "hsl(218, 15%, 80%)",
+                  "neutral30": "hsl(218, 20%, 70%)",
+                  "neutral40": "hsl(218, 25%, 60%)",
+                  "neutral5": "hsl(218, 5%, 95%)",
+                  "neutral50": "hsl(218, 30%, 50%)",
+                  "neutral60": "hsl(218, 35%, 40%)",
+                  "neutral70": "hsl(218, 40%, 30%)",
+                  "neutral80": "hsl(218, 45%, 20%)",
+                  "neutral90": "hsl(218, 50%, 10%)",
+                  "primary": "#2684FF",
+                  "primary25": "#DEEBFF",
+                  "primary50": "#B2D4FF",
+                  "primary75": "#4C9AFF",
+                },
+                "spacing": Object {
+                  "baseUnit": 4,
+                  "controlHeight": 38,
+                  "menuGutter": 8,
+                },
+              }
+            }
           >
             <div
               className="css-adi9xj"
@@ -280,6 +338,35 @@ exports[`defaults - snapshot 1`] = `
                   }
                 }
                 setValue={[Function]}
+                theme={
+                  Object {
+                    "borderRadius": 4,
+                    "colors": Object {
+                      "danger": "#DE350B",
+                      "dangerLight": "#FFBDAD",
+                      "neutral0": "hsl(218, 0%, 100%)",
+                      "neutral10": "hsl(218, 10%, 90%)",
+                      "neutral20": "hsl(218, 15%, 80%)",
+                      "neutral30": "hsl(218, 20%, 70%)",
+                      "neutral40": "hsl(218, 25%, 60%)",
+                      "neutral5": "hsl(218, 5%, 95%)",
+                      "neutral50": "hsl(218, 30%, 50%)",
+                      "neutral60": "hsl(218, 35%, 40%)",
+                      "neutral70": "hsl(218, 40%, 30%)",
+                      "neutral80": "hsl(218, 45%, 20%)",
+                      "neutral90": "hsl(218, 50%, 10%)",
+                      "primary": "#2684FF",
+                      "primary25": "#DEEBFF",
+                      "primary50": "#B2D4FF",
+                      "primary75": "#4C9AFF",
+                    },
+                    "spacing": Object {
+                      "baseUnit": 4,
+                      "controlHeight": 38,
+                      "menuGutter": 8,
+                    },
+                  }
+                }
               >
                 <div
                   className="css-1hwfws3"
@@ -348,6 +435,35 @@ exports[`defaults - snapshot 1`] = `
                       }
                     }
                     setValue={[Function]}
+                    theme={
+                      Object {
+                        "borderRadius": 4,
+                        "colors": Object {
+                          "danger": "#DE350B",
+                          "dangerLight": "#FFBDAD",
+                          "neutral0": "hsl(218, 0%, 100%)",
+                          "neutral10": "hsl(218, 10%, 90%)",
+                          "neutral20": "hsl(218, 15%, 80%)",
+                          "neutral30": "hsl(218, 20%, 70%)",
+                          "neutral40": "hsl(218, 25%, 60%)",
+                          "neutral5": "hsl(218, 5%, 95%)",
+                          "neutral50": "hsl(218, 30%, 50%)",
+                          "neutral60": "hsl(218, 35%, 40%)",
+                          "neutral70": "hsl(218, 40%, 30%)",
+                          "neutral80": "hsl(218, 45%, 20%)",
+                          "neutral90": "hsl(218, 50%, 10%)",
+                          "primary": "#2684FF",
+                          "primary25": "#DEEBFF",
+                          "primary50": "#B2D4FF",
+                          "primary75": "#4C9AFF",
+                        },
+                        "spacing": Object {
+                          "baseUnit": 4,
+                          "controlHeight": 38,
+                          "menuGutter": 8,
+                        },
+                      }
+                    }
                   >
                     <div
                       className="css-11zjhuz"
@@ -371,6 +487,35 @@ exports[`defaults - snapshot 1`] = `
                     onFocus={[Function]}
                     spellCheck="false"
                     tabIndex="0"
+                    theme={
+                      Object {
+                        "borderRadius": 4,
+                        "colors": Object {
+                          "danger": "#DE350B",
+                          "dangerLight": "#FFBDAD",
+                          "neutral0": "hsl(218, 0%, 100%)",
+                          "neutral10": "hsl(218, 10%, 90%)",
+                          "neutral20": "hsl(218, 15%, 80%)",
+                          "neutral30": "hsl(218, 20%, 70%)",
+                          "neutral40": "hsl(218, 25%, 60%)",
+                          "neutral5": "hsl(218, 5%, 95%)",
+                          "neutral50": "hsl(218, 30%, 50%)",
+                          "neutral60": "hsl(218, 35%, 40%)",
+                          "neutral70": "hsl(218, 40%, 30%)",
+                          "neutral80": "hsl(218, 45%, 20%)",
+                          "neutral90": "hsl(218, 50%, 10%)",
+                          "primary": "#2684FF",
+                          "primary25": "#DEEBFF",
+                          "primary50": "#B2D4FF",
+                          "primary75": "#4C9AFF",
+                        },
+                        "spacing": Object {
+                          "baseUnit": 4,
+                          "controlHeight": 38,
+                          "menuGutter": 8,
+                        },
+                      }
+                    }
                     type="text"
                     value=""
                   >
@@ -404,6 +549,35 @@ exports[`defaults - snapshot 1`] = `
                         onFocus={[Function]}
                         spellCheck="false"
                         tabIndex="0"
+                        theme={
+                          Object {
+                            "borderRadius": 4,
+                            "colors": Object {
+                              "danger": "#DE350B",
+                              "dangerLight": "#FFBDAD",
+                              "neutral0": "hsl(218, 0%, 100%)",
+                              "neutral10": "hsl(218, 10%, 90%)",
+                              "neutral20": "hsl(218, 15%, 80%)",
+                              "neutral30": "hsl(218, 20%, 70%)",
+                              "neutral40": "hsl(218, 25%, 60%)",
+                              "neutral5": "hsl(218, 5%, 95%)",
+                              "neutral50": "hsl(218, 30%, 50%)",
+                              "neutral60": "hsl(218, 35%, 40%)",
+                              "neutral70": "hsl(218, 40%, 30%)",
+                              "neutral80": "hsl(218, 45%, 20%)",
+                              "neutral90": "hsl(218, 50%, 10%)",
+                              "primary": "#2684FF",
+                              "primary25": "#DEEBFF",
+                              "primary50": "#B2D4FF",
+                              "primary75": "#4C9AFF",
+                            },
+                            "spacing": Object {
+                              "baseUnit": 4,
+                              "controlHeight": 38,
+                              "menuGutter": 8,
+                            },
+                          }
+                        }
                         type="text"
                         value=""
                       >
@@ -440,6 +614,35 @@ exports[`defaults - snapshot 1`] = `
                               }
                             }
                             tabIndex="0"
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(218, 0%, 100%)",
+                                  "neutral10": "hsl(218, 10%, 90%)",
+                                  "neutral20": "hsl(218, 15%, 80%)",
+                                  "neutral30": "hsl(218, 20%, 70%)",
+                                  "neutral40": "hsl(218, 25%, 60%)",
+                                  "neutral5": "hsl(218, 5%, 95%)",
+                                  "neutral50": "hsl(218, 30%, 50%)",
+                                  "neutral60": "hsl(218, 35%, 40%)",
+                                  "neutral70": "hsl(218, 40%, 30%)",
+                                  "neutral80": "hsl(218, 45%, 20%)",
+                                  "neutral90": "hsl(218, 50%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
                             type="text"
                             value=""
                           />
@@ -525,6 +728,35 @@ exports[`defaults - snapshot 1`] = `
                   }
                 }
                 setValue={[Function]}
+                theme={
+                  Object {
+                    "borderRadius": 4,
+                    "colors": Object {
+                      "danger": "#DE350B",
+                      "dangerLight": "#FFBDAD",
+                      "neutral0": "hsl(218, 0%, 100%)",
+                      "neutral10": "hsl(218, 10%, 90%)",
+                      "neutral20": "hsl(218, 15%, 80%)",
+                      "neutral30": "hsl(218, 20%, 70%)",
+                      "neutral40": "hsl(218, 25%, 60%)",
+                      "neutral5": "hsl(218, 5%, 95%)",
+                      "neutral50": "hsl(218, 30%, 50%)",
+                      "neutral60": "hsl(218, 35%, 40%)",
+                      "neutral70": "hsl(218, 40%, 30%)",
+                      "neutral80": "hsl(218, 45%, 20%)",
+                      "neutral90": "hsl(218, 50%, 10%)",
+                      "primary": "#2684FF",
+                      "primary25": "#DEEBFF",
+                      "primary50": "#B2D4FF",
+                      "primary75": "#4C9AFF",
+                    },
+                    "spacing": Object {
+                      "baseUnit": 4,
+                      "controlHeight": 38,
+                      "menuGutter": 8,
+                    },
+                  }
+                }
               >
                 <div
                   className="css-1wy0on6"
@@ -593,6 +825,35 @@ exports[`defaults - snapshot 1`] = `
                       }
                     }
                     setValue={[Function]}
+                    theme={
+                      Object {
+                        "borderRadius": 4,
+                        "colors": Object {
+                          "danger": "#DE350B",
+                          "dangerLight": "#FFBDAD",
+                          "neutral0": "hsl(218, 0%, 100%)",
+                          "neutral10": "hsl(218, 10%, 90%)",
+                          "neutral20": "hsl(218, 15%, 80%)",
+                          "neutral30": "hsl(218, 20%, 70%)",
+                          "neutral40": "hsl(218, 25%, 60%)",
+                          "neutral5": "hsl(218, 5%, 95%)",
+                          "neutral50": "hsl(218, 30%, 50%)",
+                          "neutral60": "hsl(218, 35%, 40%)",
+                          "neutral70": "hsl(218, 40%, 30%)",
+                          "neutral80": "hsl(218, 45%, 20%)",
+                          "neutral90": "hsl(218, 50%, 10%)",
+                          "primary": "#2684FF",
+                          "primary25": "#DEEBFF",
+                          "primary50": "#B2D4FF",
+                          "primary75": "#4C9AFF",
+                        },
+                        "spacing": Object {
+                          "baseUnit": 4,
+                          "controlHeight": 38,
+                          "menuGutter": 8,
+                        },
+                      }
+                    }
                   >
                     <span
                       className="css-1etbf2r"
@@ -669,6 +930,35 @@ exports[`defaults - snapshot 1`] = `
                       }
                     }
                     setValue={[Function]}
+                    theme={
+                      Object {
+                        "borderRadius": 4,
+                        "colors": Object {
+                          "danger": "#DE350B",
+                          "dangerLight": "#FFBDAD",
+                          "neutral0": "hsl(218, 0%, 100%)",
+                          "neutral10": "hsl(218, 10%, 90%)",
+                          "neutral20": "hsl(218, 15%, 80%)",
+                          "neutral30": "hsl(218, 20%, 70%)",
+                          "neutral40": "hsl(218, 25%, 60%)",
+                          "neutral5": "hsl(218, 5%, 95%)",
+                          "neutral50": "hsl(218, 30%, 50%)",
+                          "neutral60": "hsl(218, 35%, 40%)",
+                          "neutral70": "hsl(218, 40%, 30%)",
+                          "neutral80": "hsl(218, 45%, 20%)",
+                          "neutral90": "hsl(218, 50%, 10%)",
+                          "primary": "#2684FF",
+                          "primary25": "#DEEBFF",
+                          "primary50": "#B2D4FF",
+                          "primary75": "#4C9AFF",
+                        },
+                        "spacing": Object {
+                          "baseUnit": 4,
+                          "controlHeight": 38,
+                          "menuGutter": 8,
+                        },
+                      }
+                    }
                   >
                     <div
                       aria-hidden="true"

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -167,6 +167,35 @@ exports[`defaults - snapshot 1`] = `
             }
           }
           setValue={[Function]}
+          theme={
+            Object {
+              "borderRadius": 4,
+              "colors": Object {
+                "danger": "#DE350B",
+                "dangerLight": "#FFBDAD",
+                "neutral0": "hsl(218, 0%, 100%)",
+                "neutral10": "hsl(218, 10%, 90%)",
+                "neutral20": "hsl(218, 15%, 80%)",
+                "neutral30": "hsl(218, 20%, 70%)",
+                "neutral40": "hsl(218, 25%, 60%)",
+                "neutral5": "hsl(218, 5%, 95%)",
+                "neutral50": "hsl(218, 30%, 50%)",
+                "neutral60": "hsl(218, 35%, 40%)",
+                "neutral70": "hsl(218, 40%, 30%)",
+                "neutral80": "hsl(218, 45%, 20%)",
+                "neutral90": "hsl(218, 50%, 10%)",
+                "primary": "#2684FF",
+                "primary25": "#DEEBFF",
+                "primary50": "#B2D4FF",
+                "primary75": "#4C9AFF",
+              },
+              "spacing": Object {
+                "baseUnit": 4,
+                "controlHeight": 38,
+                "menuGutter": 8,
+              },
+            }
+          }
         >
           <div
             className="css-10nd86i"
@@ -248,6 +277,35 @@ exports[`defaults - snapshot 1`] = `
                 }
               }
               setValue={[Function]}
+              theme={
+                Object {
+                  "borderRadius": 4,
+                  "colors": Object {
+                    "danger": "#DE350B",
+                    "dangerLight": "#FFBDAD",
+                    "neutral0": "hsl(218, 0%, 100%)",
+                    "neutral10": "hsl(218, 10%, 90%)",
+                    "neutral20": "hsl(218, 15%, 80%)",
+                    "neutral30": "hsl(218, 20%, 70%)",
+                    "neutral40": "hsl(218, 25%, 60%)",
+                    "neutral5": "hsl(218, 5%, 95%)",
+                    "neutral50": "hsl(218, 30%, 50%)",
+                    "neutral60": "hsl(218, 35%, 40%)",
+                    "neutral70": "hsl(218, 40%, 30%)",
+                    "neutral80": "hsl(218, 45%, 20%)",
+                    "neutral90": "hsl(218, 50%, 10%)",
+                    "primary": "#2684FF",
+                    "primary25": "#DEEBFF",
+                    "primary50": "#B2D4FF",
+                    "primary75": "#4C9AFF",
+                  },
+                  "spacing": Object {
+                    "baseUnit": 4,
+                    "controlHeight": 38,
+                    "menuGutter": 8,
+                  },
+                }
+              }
             >
               <div
                 className="css-adi9xj"
@@ -322,6 +380,35 @@ exports[`defaults - snapshot 1`] = `
                     }
                   }
                   setValue={[Function]}
+                  theme={
+                    Object {
+                      "borderRadius": 4,
+                      "colors": Object {
+                        "danger": "#DE350B",
+                        "dangerLight": "#FFBDAD",
+                        "neutral0": "hsl(218, 0%, 100%)",
+                        "neutral10": "hsl(218, 10%, 90%)",
+                        "neutral20": "hsl(218, 15%, 80%)",
+                        "neutral30": "hsl(218, 20%, 70%)",
+                        "neutral40": "hsl(218, 25%, 60%)",
+                        "neutral5": "hsl(218, 5%, 95%)",
+                        "neutral50": "hsl(218, 30%, 50%)",
+                        "neutral60": "hsl(218, 35%, 40%)",
+                        "neutral70": "hsl(218, 40%, 30%)",
+                        "neutral80": "hsl(218, 45%, 20%)",
+                        "neutral90": "hsl(218, 50%, 10%)",
+                        "primary": "#2684FF",
+                        "primary25": "#DEEBFF",
+                        "primary50": "#B2D4FF",
+                        "primary75": "#4C9AFF",
+                      },
+                      "spacing": Object {
+                        "baseUnit": 4,
+                        "controlHeight": 38,
+                        "menuGutter": 8,
+                      },
+                    }
+                  }
                 >
                   <div
                     className="css-1hwfws3"
@@ -395,6 +482,35 @@ exports[`defaults - snapshot 1`] = `
                         }
                       }
                       setValue={[Function]}
+                      theme={
+                        Object {
+                          "borderRadius": 4,
+                          "colors": Object {
+                            "danger": "#DE350B",
+                            "dangerLight": "#FFBDAD",
+                            "neutral0": "hsl(218, 0%, 100%)",
+                            "neutral10": "hsl(218, 10%, 90%)",
+                            "neutral20": "hsl(218, 15%, 80%)",
+                            "neutral30": "hsl(218, 20%, 70%)",
+                            "neutral40": "hsl(218, 25%, 60%)",
+                            "neutral5": "hsl(218, 5%, 95%)",
+                            "neutral50": "hsl(218, 30%, 50%)",
+                            "neutral60": "hsl(218, 35%, 40%)",
+                            "neutral70": "hsl(218, 40%, 30%)",
+                            "neutral80": "hsl(218, 45%, 20%)",
+                            "neutral90": "hsl(218, 50%, 10%)",
+                            "primary": "#2684FF",
+                            "primary25": "#DEEBFF",
+                            "primary50": "#B2D4FF",
+                            "primary75": "#4C9AFF",
+                          },
+                          "spacing": Object {
+                            "baseUnit": 4,
+                            "controlHeight": 38,
+                            "menuGutter": 8,
+                          },
+                        }
+                      }
                     >
                       <div
                         className="css-11zjhuz"
@@ -418,6 +534,35 @@ exports[`defaults - snapshot 1`] = `
                       onFocus={[Function]}
                       spellCheck="false"
                       tabIndex="0"
+                      theme={
+                        Object {
+                          "borderRadius": 4,
+                          "colors": Object {
+                            "danger": "#DE350B",
+                            "dangerLight": "#FFBDAD",
+                            "neutral0": "hsl(218, 0%, 100%)",
+                            "neutral10": "hsl(218, 10%, 90%)",
+                            "neutral20": "hsl(218, 15%, 80%)",
+                            "neutral30": "hsl(218, 20%, 70%)",
+                            "neutral40": "hsl(218, 25%, 60%)",
+                            "neutral5": "hsl(218, 5%, 95%)",
+                            "neutral50": "hsl(218, 30%, 50%)",
+                            "neutral60": "hsl(218, 35%, 40%)",
+                            "neutral70": "hsl(218, 40%, 30%)",
+                            "neutral80": "hsl(218, 45%, 20%)",
+                            "neutral90": "hsl(218, 50%, 10%)",
+                            "primary": "#2684FF",
+                            "primary25": "#DEEBFF",
+                            "primary50": "#B2D4FF",
+                            "primary75": "#4C9AFF",
+                          },
+                          "spacing": Object {
+                            "baseUnit": 4,
+                            "controlHeight": 38,
+                            "menuGutter": 8,
+                          },
+                        }
+                      }
                       type="text"
                       value=""
                     >
@@ -451,6 +596,35 @@ exports[`defaults - snapshot 1`] = `
                           onFocus={[Function]}
                           spellCheck="false"
                           tabIndex="0"
+                          theme={
+                            Object {
+                              "borderRadius": 4,
+                              "colors": Object {
+                                "danger": "#DE350B",
+                                "dangerLight": "#FFBDAD",
+                                "neutral0": "hsl(218, 0%, 100%)",
+                                "neutral10": "hsl(218, 10%, 90%)",
+                                "neutral20": "hsl(218, 15%, 80%)",
+                                "neutral30": "hsl(218, 20%, 70%)",
+                                "neutral40": "hsl(218, 25%, 60%)",
+                                "neutral5": "hsl(218, 5%, 95%)",
+                                "neutral50": "hsl(218, 30%, 50%)",
+                                "neutral60": "hsl(218, 35%, 40%)",
+                                "neutral70": "hsl(218, 40%, 30%)",
+                                "neutral80": "hsl(218, 45%, 20%)",
+                                "neutral90": "hsl(218, 50%, 10%)",
+                                "primary": "#2684FF",
+                                "primary25": "#DEEBFF",
+                                "primary50": "#B2D4FF",
+                                "primary75": "#4C9AFF",
+                              },
+                              "spacing": Object {
+                                "baseUnit": 4,
+                                "controlHeight": 38,
+                                "menuGutter": 8,
+                              },
+                            }
+                          }
                           type="text"
                           value=""
                         >
@@ -487,6 +661,35 @@ exports[`defaults - snapshot 1`] = `
                                 }
                               }
                               tabIndex="0"
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(218, 0%, 100%)",
+                                    "neutral10": "hsl(218, 10%, 90%)",
+                                    "neutral20": "hsl(218, 15%, 80%)",
+                                    "neutral30": "hsl(218, 20%, 70%)",
+                                    "neutral40": "hsl(218, 25%, 60%)",
+                                    "neutral5": "hsl(218, 5%, 95%)",
+                                    "neutral50": "hsl(218, 30%, 50%)",
+                                    "neutral60": "hsl(218, 35%, 40%)",
+                                    "neutral70": "hsl(218, 40%, 30%)",
+                                    "neutral80": "hsl(218, 45%, 20%)",
+                                    "neutral90": "hsl(218, 50%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
                               type="text"
                               value=""
                             />
@@ -577,6 +780,35 @@ exports[`defaults - snapshot 1`] = `
                     }
                   }
                   setValue={[Function]}
+                  theme={
+                    Object {
+                      "borderRadius": 4,
+                      "colors": Object {
+                        "danger": "#DE350B",
+                        "dangerLight": "#FFBDAD",
+                        "neutral0": "hsl(218, 0%, 100%)",
+                        "neutral10": "hsl(218, 10%, 90%)",
+                        "neutral20": "hsl(218, 15%, 80%)",
+                        "neutral30": "hsl(218, 20%, 70%)",
+                        "neutral40": "hsl(218, 25%, 60%)",
+                        "neutral5": "hsl(218, 5%, 95%)",
+                        "neutral50": "hsl(218, 30%, 50%)",
+                        "neutral60": "hsl(218, 35%, 40%)",
+                        "neutral70": "hsl(218, 40%, 30%)",
+                        "neutral80": "hsl(218, 45%, 20%)",
+                        "neutral90": "hsl(218, 50%, 10%)",
+                        "primary": "#2684FF",
+                        "primary25": "#DEEBFF",
+                        "primary50": "#B2D4FF",
+                        "primary75": "#4C9AFF",
+                      },
+                      "spacing": Object {
+                        "baseUnit": 4,
+                        "controlHeight": 38,
+                        "menuGutter": 8,
+                      },
+                    }
+                  }
                 >
                   <div
                     className="css-1wy0on6"
@@ -650,6 +882,35 @@ exports[`defaults - snapshot 1`] = `
                         }
                       }
                       setValue={[Function]}
+                      theme={
+                        Object {
+                          "borderRadius": 4,
+                          "colors": Object {
+                            "danger": "#DE350B",
+                            "dangerLight": "#FFBDAD",
+                            "neutral0": "hsl(218, 0%, 100%)",
+                            "neutral10": "hsl(218, 10%, 90%)",
+                            "neutral20": "hsl(218, 15%, 80%)",
+                            "neutral30": "hsl(218, 20%, 70%)",
+                            "neutral40": "hsl(218, 25%, 60%)",
+                            "neutral5": "hsl(218, 5%, 95%)",
+                            "neutral50": "hsl(218, 30%, 50%)",
+                            "neutral60": "hsl(218, 35%, 40%)",
+                            "neutral70": "hsl(218, 40%, 30%)",
+                            "neutral80": "hsl(218, 45%, 20%)",
+                            "neutral90": "hsl(218, 50%, 10%)",
+                            "primary": "#2684FF",
+                            "primary25": "#DEEBFF",
+                            "primary50": "#B2D4FF",
+                            "primary75": "#4C9AFF",
+                          },
+                          "spacing": Object {
+                            "baseUnit": 4,
+                            "controlHeight": 38,
+                            "menuGutter": 8,
+                          },
+                        }
+                      }
                     >
                       <span
                         className="css-1etbf2r"
@@ -731,6 +992,35 @@ exports[`defaults - snapshot 1`] = `
                         }
                       }
                       setValue={[Function]}
+                      theme={
+                        Object {
+                          "borderRadius": 4,
+                          "colors": Object {
+                            "danger": "#DE350B",
+                            "dangerLight": "#FFBDAD",
+                            "neutral0": "hsl(218, 0%, 100%)",
+                            "neutral10": "hsl(218, 10%, 90%)",
+                            "neutral20": "hsl(218, 15%, 80%)",
+                            "neutral30": "hsl(218, 20%, 70%)",
+                            "neutral40": "hsl(218, 25%, 60%)",
+                            "neutral5": "hsl(218, 5%, 95%)",
+                            "neutral50": "hsl(218, 30%, 50%)",
+                            "neutral60": "hsl(218, 35%, 40%)",
+                            "neutral70": "hsl(218, 40%, 30%)",
+                            "neutral80": "hsl(218, 45%, 20%)",
+                            "neutral90": "hsl(218, 50%, 10%)",
+                            "primary": "#2684FF",
+                            "primary25": "#DEEBFF",
+                            "primary50": "#B2D4FF",
+                            "primary75": "#4C9AFF",
+                          },
+                          "spacing": Object {
+                            "baseUnit": 4,
+                            "controlHeight": 38,
+                            "menuGutter": 8,
+                          },
+                        }
+                      }
                     >
                       <div
                         aria-hidden="true"

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -60,6 +60,35 @@ exports[`snapshot - defaults 1`] = `
     }
   }
   setValue={[Function]}
+  theme={
+    Object {
+      "borderRadius": 4,
+      "colors": Object {
+        "danger": "#DE350B",
+        "dangerLight": "#FFBDAD",
+        "neutral0": "hsl(218, 0%, 100%)",
+        "neutral10": "hsl(218, 10%, 90%)",
+        "neutral20": "hsl(218, 15%, 80%)",
+        "neutral30": "hsl(218, 20%, 70%)",
+        "neutral40": "hsl(218, 25%, 60%)",
+        "neutral5": "hsl(218, 5%, 95%)",
+        "neutral50": "hsl(218, 30%, 50%)",
+        "neutral60": "hsl(218, 35%, 40%)",
+        "neutral70": "hsl(218, 40%, 30%)",
+        "neutral80": "hsl(218, 45%, 20%)",
+        "neutral90": "hsl(218, 50%, 10%)",
+        "primary": "#2684FF",
+        "primary25": "#DEEBFF",
+        "primary50": "#B2D4FF",
+        "primary75": "#4C9AFF",
+      },
+      "spacing": Object {
+        "baseUnit": 4,
+        "controlHeight": 38,
+        "menuGutter": 8,
+      },
+    }
+  }
 >
   <Control
     clearValue={[Function]}
@@ -121,6 +150,35 @@ exports[`snapshot - defaults 1`] = `
       }
     }
     setValue={[Function]}
+    theme={
+      Object {
+        "borderRadius": 4,
+        "colors": Object {
+          "danger": "#DE350B",
+          "dangerLight": "#FFBDAD",
+          "neutral0": "hsl(218, 0%, 100%)",
+          "neutral10": "hsl(218, 10%, 90%)",
+          "neutral20": "hsl(218, 15%, 80%)",
+          "neutral30": "hsl(218, 20%, 70%)",
+          "neutral40": "hsl(218, 25%, 60%)",
+          "neutral5": "hsl(218, 5%, 95%)",
+          "neutral50": "hsl(218, 30%, 50%)",
+          "neutral60": "hsl(218, 35%, 40%)",
+          "neutral70": "hsl(218, 40%, 30%)",
+          "neutral80": "hsl(218, 45%, 20%)",
+          "neutral90": "hsl(218, 50%, 10%)",
+          "primary": "#2684FF",
+          "primary25": "#DEEBFF",
+          "primary50": "#B2D4FF",
+          "primary75": "#4C9AFF",
+        },
+        "spacing": Object {
+          "baseUnit": 4,
+          "controlHeight": 38,
+          "menuGutter": 8,
+        },
+      }
+    }
   >
     <ValueContainer
       clearValue={[Function]}
@@ -174,6 +232,35 @@ exports[`snapshot - defaults 1`] = `
         }
       }
       setValue={[Function]}
+      theme={
+        Object {
+          "borderRadius": 4,
+          "colors": Object {
+            "danger": "#DE350B",
+            "dangerLight": "#FFBDAD",
+            "neutral0": "hsl(218, 0%, 100%)",
+            "neutral10": "hsl(218, 10%, 90%)",
+            "neutral20": "hsl(218, 15%, 80%)",
+            "neutral30": "hsl(218, 20%, 70%)",
+            "neutral40": "hsl(218, 25%, 60%)",
+            "neutral5": "hsl(218, 5%, 95%)",
+            "neutral50": "hsl(218, 30%, 50%)",
+            "neutral60": "hsl(218, 35%, 40%)",
+            "neutral70": "hsl(218, 40%, 30%)",
+            "neutral80": "hsl(218, 45%, 20%)",
+            "neutral90": "hsl(218, 50%, 10%)",
+            "primary": "#2684FF",
+            "primary25": "#DEEBFF",
+            "primary50": "#B2D4FF",
+            "primary75": "#4C9AFF",
+          },
+          "spacing": Object {
+            "baseUnit": 4,
+            "controlHeight": 38,
+            "menuGutter": 8,
+          },
+        }
+      }
     >
       <Placeholder
         clearValue={[Function]}
@@ -228,6 +315,35 @@ exports[`snapshot - defaults 1`] = `
           }
         }
         setValue={[Function]}
+        theme={
+          Object {
+            "borderRadius": 4,
+            "colors": Object {
+              "danger": "#DE350B",
+              "dangerLight": "#FFBDAD",
+              "neutral0": "hsl(218, 0%, 100%)",
+              "neutral10": "hsl(218, 10%, 90%)",
+              "neutral20": "hsl(218, 15%, 80%)",
+              "neutral30": "hsl(218, 20%, 70%)",
+              "neutral40": "hsl(218, 25%, 60%)",
+              "neutral5": "hsl(218, 5%, 95%)",
+              "neutral50": "hsl(218, 30%, 50%)",
+              "neutral60": "hsl(218, 35%, 40%)",
+              "neutral70": "hsl(218, 40%, 30%)",
+              "neutral80": "hsl(218, 45%, 20%)",
+              "neutral90": "hsl(218, 50%, 10%)",
+              "primary": "#2684FF",
+              "primary25": "#DEEBFF",
+              "primary50": "#B2D4FF",
+              "primary75": "#4C9AFF",
+            },
+            "spacing": Object {
+              "baseUnit": 4,
+              "controlHeight": 38,
+              "menuGutter": 8,
+            },
+          }
+        }
       >
         Select...
       </Placeholder>
@@ -247,6 +363,35 @@ exports[`snapshot - defaults 1`] = `
         onFocus={[Function]}
         spellCheck="false"
         tabIndex="0"
+        theme={
+          Object {
+            "borderRadius": 4,
+            "colors": Object {
+              "danger": "#DE350B",
+              "dangerLight": "#FFBDAD",
+              "neutral0": "hsl(218, 0%, 100%)",
+              "neutral10": "hsl(218, 10%, 90%)",
+              "neutral20": "hsl(218, 15%, 80%)",
+              "neutral30": "hsl(218, 20%, 70%)",
+              "neutral40": "hsl(218, 25%, 60%)",
+              "neutral5": "hsl(218, 5%, 95%)",
+              "neutral50": "hsl(218, 30%, 50%)",
+              "neutral60": "hsl(218, 35%, 40%)",
+              "neutral70": "hsl(218, 40%, 30%)",
+              "neutral80": "hsl(218, 45%, 20%)",
+              "neutral90": "hsl(218, 50%, 10%)",
+              "primary": "#2684FF",
+              "primary25": "#DEEBFF",
+              "primary50": "#B2D4FF",
+              "primary75": "#4C9AFF",
+            },
+            "spacing": Object {
+              "baseUnit": 4,
+              "controlHeight": 38,
+              "menuGutter": 8,
+            },
+          }
+        }
         type="text"
       />
     </ValueContainer>
@@ -302,6 +447,35 @@ exports[`snapshot - defaults 1`] = `
         }
       }
       setValue={[Function]}
+      theme={
+        Object {
+          "borderRadius": 4,
+          "colors": Object {
+            "danger": "#DE350B",
+            "dangerLight": "#FFBDAD",
+            "neutral0": "hsl(218, 0%, 100%)",
+            "neutral10": "hsl(218, 10%, 90%)",
+            "neutral20": "hsl(218, 15%, 80%)",
+            "neutral30": "hsl(218, 20%, 70%)",
+            "neutral40": "hsl(218, 25%, 60%)",
+            "neutral5": "hsl(218, 5%, 95%)",
+            "neutral50": "hsl(218, 30%, 50%)",
+            "neutral60": "hsl(218, 35%, 40%)",
+            "neutral70": "hsl(218, 40%, 30%)",
+            "neutral80": "hsl(218, 45%, 20%)",
+            "neutral90": "hsl(218, 50%, 10%)",
+            "primary": "#2684FF",
+            "primary25": "#DEEBFF",
+            "primary50": "#B2D4FF",
+            "primary75": "#4C9AFF",
+          },
+          "spacing": Object {
+            "baseUnit": 4,
+            "controlHeight": 38,
+            "menuGutter": 8,
+          },
+        }
+      }
     >
       <IndicatorSeparator
         clearValue={[Function]}
@@ -356,6 +530,35 @@ exports[`snapshot - defaults 1`] = `
           }
         }
         setValue={[Function]}
+        theme={
+          Object {
+            "borderRadius": 4,
+            "colors": Object {
+              "danger": "#DE350B",
+              "dangerLight": "#FFBDAD",
+              "neutral0": "hsl(218, 0%, 100%)",
+              "neutral10": "hsl(218, 10%, 90%)",
+              "neutral20": "hsl(218, 15%, 80%)",
+              "neutral30": "hsl(218, 20%, 70%)",
+              "neutral40": "hsl(218, 25%, 60%)",
+              "neutral5": "hsl(218, 5%, 95%)",
+              "neutral50": "hsl(218, 30%, 50%)",
+              "neutral60": "hsl(218, 35%, 40%)",
+              "neutral70": "hsl(218, 40%, 30%)",
+              "neutral80": "hsl(218, 45%, 20%)",
+              "neutral90": "hsl(218, 50%, 10%)",
+              "primary": "#2684FF",
+              "primary25": "#DEEBFF",
+              "primary50": "#B2D4FF",
+              "primary75": "#4C9AFF",
+            },
+            "spacing": Object {
+              "baseUnit": 4,
+              "controlHeight": 38,
+              "menuGutter": 8,
+            },
+          }
+        }
       />
       <DropdownIndicator
         clearValue={[Function]}
@@ -417,6 +620,35 @@ exports[`snapshot - defaults 1`] = `
           }
         }
         setValue={[Function]}
+        theme={
+          Object {
+            "borderRadius": 4,
+            "colors": Object {
+              "danger": "#DE350B",
+              "dangerLight": "#FFBDAD",
+              "neutral0": "hsl(218, 0%, 100%)",
+              "neutral10": "hsl(218, 10%, 90%)",
+              "neutral20": "hsl(218, 15%, 80%)",
+              "neutral30": "hsl(218, 20%, 70%)",
+              "neutral40": "hsl(218, 25%, 60%)",
+              "neutral5": "hsl(218, 5%, 95%)",
+              "neutral50": "hsl(218, 30%, 50%)",
+              "neutral60": "hsl(218, 35%, 40%)",
+              "neutral70": "hsl(218, 40%, 30%)",
+              "neutral80": "hsl(218, 45%, 20%)",
+              "neutral90": "hsl(218, 50%, 10%)",
+              "primary": "#2684FF",
+              "primary25": "#DEEBFF",
+              "primary50": "#B2D4FF",
+              "primary75": "#4C9AFF",
+            },
+            "spacing": Object {
+              "baseUnit": 4,
+              "controlHeight": 38,
+              "menuGutter": 8,
+            },
+          }
+        }
       />
     </IndicatorsContainer>
   </Control>

--- a/src/components/Control.js
+++ b/src/components/Control.js
@@ -2,7 +2,6 @@
 import React, { type Node, type ElementRef } from 'react';
 import { css as emotionCSS } from 'emotion';
 
-import { borderRadius, colors, spacing } from '../theme';
 import type { CommonProps, PropsWithStyles } from '../types';
 
 type State = {
@@ -24,7 +23,11 @@ export type ControlProps = CommonProps &
     },
   };
 
-export const css = ({ isDisabled, isFocused }: State) => ({
+export const css = ({
+  isDisabled,
+  isFocused,
+  theme: { colors, borderRadius, spacing },
+}: ControlProps) => ({
   alignItems: 'center',
   backgroundColor: isDisabled ? colors.neutral5 : colors.neutral0,
   borderColor: isDisabled

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -10,6 +10,8 @@ type ComponentProps = {
   children: Node,
   /** Component to wrap the label, recieves headingProps. */
   Heading: ComponentType<any>,
+  /** Props to pass to Heading. */
+  headingProps: any,
   /** Label to be displayed in the heading component. */
   label: Node,
 };
@@ -27,6 +29,7 @@ const Group = (props: GroupProps) => {
     cx,
     getStyles,
     Heading,
+    headingProps,
     label,
   } = props;
   return (
@@ -37,7 +40,7 @@ const Group = (props: GroupProps) => {
         className,
       )}
     >
-      <Heading getStyles={getStyles} cx={cx}>
+      <Heading {...headingProps} getStyles={getStyles} cx={cx}>
         {label}
       </Heading>
       <div>{children}</div>

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -2,7 +2,6 @@
 import React, { type Node, type ComponentType } from 'react';
 import { css } from 'emotion';
 
-import { spacing } from '../theme';
 import type { CommonProps } from '../types';
 
 type ComponentProps = {
@@ -17,7 +16,7 @@ type ComponentProps = {
 };
 export type GroupProps = CommonProps & ComponentProps;
 
-export const groupCSS = () => ({
+export const groupCSS = ({ theme: { spacing } }: GroupProps) => ({
   paddingBottom: spacing.baseUnit * 2,
   paddingTop: spacing.baseUnit * 2,
 });
@@ -31,6 +30,7 @@ const Group = (props: GroupProps) => {
     Heading,
     headingProps,
     label,
+    theme,
   } = props;
   return (
     <div
@@ -40,7 +40,7 @@ const Group = (props: GroupProps) => {
         className,
       )}
     >
-      <Heading {...headingProps} getStyles={getStyles} cx={cx}>
+      <Heading {...headingProps} theme={theme} getStyles={getStyles} cx={cx}>
         {label}
       </Heading>
       <div>{children}</div>
@@ -48,7 +48,7 @@ const Group = (props: GroupProps) => {
   );
 };
 
-export const groupHeadingCSS = () => ({
+export const groupHeadingCSS = ({ theme: { spacing } }: GroupProps) => ({
   color: '#999',
   cursor: 'default',
   display: 'block',

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -2,8 +2,6 @@
 import React, { type ElementRef } from 'react';
 import AutosizeInput from 'react-input-autosize';
 
-import { colors, spacing } from '../theme';
-
 import type { PropsWithStyles, ClassNamesState } from '../types';
 
 export type InputProps = PropsWithStyles & {
@@ -17,7 +15,7 @@ export type InputProps = PropsWithStyles & {
   className?: string,
 };
 
-export const inputCSS = ({ isDisabled }: InputProps) => ({
+export const inputCSS = ({ isDisabled, theme: { spacing, colors } }: InputProps) => ({
   margin: spacing.baseUnit / 2,
   paddingBottom: spacing.baseUnit / 2,
   paddingTop: spacing.baseUnit / 2,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -17,13 +17,13 @@ import {
   getScrollTop,
   scrollTo,
 } from '../utils';
-import { borderRadius, colors, spacing } from '../theme';
 import type {
   InnerRef,
   MenuPlacement,
   MenuPosition,
   CommonProps,
 } from '../types';
+import type { Theme } from '../types';
 
 // ==============================
 // Menu
@@ -32,7 +32,10 @@ import type {
 // Get Menu Placement
 // ------------------------------
 
-type MenuState = { placement: 'bottom' | 'top' | null, maxHeight: number };
+type MenuState = {
+  placement: 'bottom' | 'top' | null,
+  maxHeight: number,
+};
 type PlacementArgs = {
   maxHeight: number,
   menuEl: ElementRef<*>,
@@ -40,6 +43,7 @@ type PlacementArgs = {
   placement: 'bottom' | 'top' | 'auto',
   shouldScroll: boolean,
   isFixedPosition: boolean,
+  theme: Theme,
 };
 
 export function getMenuPlacement({
@@ -49,7 +53,9 @@ export function getMenuPlacement({
   placement,
   shouldScroll,
   isFixedPosition,
+  theme,
 }: PlacementArgs): MenuState {
+  const { spacing } = theme;
   const scrollParent = getScrollParent(menuEl);
   const defaultState = { placement: 'bottom', maxHeight };
 
@@ -226,7 +232,9 @@ function alignToControl(placement) {
 }
 const coercePlacement = p => (p === 'auto' ? 'bottom' : p);
 
-export const menuCSS = ({ placement }: MenuState) => ({
+type MenuStateWithProps = MenuState & MenuProps;
+
+export const menuCSS = ({ placement, theme: { borderRadius, spacing, colors } }: MenuStateWithProps) => ({
   [alignToControl(placement)]: '100%',
   backgroundColor: colors.neutral0,
   borderRadius: borderRadius,
@@ -253,6 +261,7 @@ export class Menu extends Component<MenuProps, MenuState> {
       menuPlacement,
       menuPosition,
       menuShouldScrollIntoView,
+      theme,
     } = this.props;
     const { getPortalPlacement } = this.context;
 
@@ -269,6 +278,7 @@ export class Menu extends Component<MenuProps, MenuState> {
       placement: menuPlacement,
       shouldScroll,
       isFixedPosition,
+      theme,
     });
 
     if (getPortalPlacement) getPortalPlacement(state);
@@ -324,11 +334,11 @@ export type MenuListProps = {
 export type MenuListComponentProps = CommonProps &
   MenuListProps &
   MenuListState;
-export const menuListCSS = ({ maxHeight }: MenuState) => ({
+export const menuListCSS = ({ maxHeight, theme: { spacing: { baseUnit } } }: MenuListComponentProps) => ({
   maxHeight,
   overflowY: 'auto',
-  paddingBottom: spacing.baseUnit,
-  paddingTop: spacing.baseUnit,
+  paddingBottom: baseUnit,
+  paddingTop: baseUnit,
   position: 'relative', // required for offset[Height, Top] > keyboard scroll
   WebkitOverflowScrolling: 'touch',
 });
@@ -355,9 +365,9 @@ export const MenuList = (props: MenuListComponentProps) => {
 // Menu Notices
 // ==============================
 
-const noticeCSS = () => ({
+const noticeCSS = ({ theme: { spacing: { baseUnit }, colors } }: NoticeProps) => ({
   color: colors.neutral40,
-  padding: `${spacing.baseUnit * 2}px ${spacing.baseUnit * 3}px`,
+  padding: `${baseUnit * 2}px ${baseUnit * 3}px`,
   textAlign: 'center',
 });
 export const noOptionsMessageCSS = noticeCSS;

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -2,11 +2,10 @@
 import React, { Component, type Node } from 'react';
 import { css } from 'emotion';
 
-import { borderRadius, colors, spacing } from '../theme';
 import { CrossIcon } from './indicators';
 import type { CommonProps } from '../types';
 
-export type MultiValueProps = CommonProps &{
+export type MultiValueProps = CommonProps & {
   children: Node,
   components: any,
   cropWithEllipsis: boolean,
@@ -21,14 +20,17 @@ export type MultiValueProps = CommonProps &{
   },
 };
 
-export const multiValueCSS = () => ({
+export const multiValueCSS = ({
+  theme: { spacing, borderRadius, colors },
+}: MultiValueProps) => ({
   backgroundColor: colors.neutral10,
   borderRadius: borderRadius / 2,
   display: 'flex',
   margin: spacing.baseUnit / 2,
   minWidth: 0, // resolves flex/text-overflow bug
 });
-export const multiValueLabelCSS = ({ cropWithEllipsis }: MultiValueProps) => ({
+
+export const multiValueLabelCSS = ({ theme: { borderRadius, colors }, cropWithEllipsis }: MultiValueProps) => ({
   borderRadius: borderRadius / 2,
   color: colors.neutral80,
   fontSize: '85%',
@@ -38,7 +40,11 @@ export const multiValueLabelCSS = ({ cropWithEllipsis }: MultiValueProps) => ({
   textOverflow: cropWithEllipsis ? 'ellipsis' : null,
   whiteSpace: 'nowrap',
 });
-export const multiValueRemoveCSS = ({ isFocused }: MultiValueProps) => ({
+
+export const multiValueRemoveCSS = ({
+  theme: { spacing, borderRadius, colors },
+  isFocused,
+}: MultiValueProps) => ({
   alignItems: 'center',
   borderRadius: borderRadius / 2,
   backgroundColor: isFocused && colors.dangerLight,

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -2,7 +2,6 @@
 import React, { type Node } from 'react';
 import { css } from 'emotion';
 
-import { colors, spacing } from '../theme';
 import type { CommonProps, PropsWithStyles, InnerRef } from '../types';
 
 type State = {
@@ -36,7 +35,12 @@ export type OptionProps = PropsWithStyles &
     type: 'option',
   };
 
-export const optionCSS = ({ isDisabled, isFocused, isSelected }: State) => ({
+export const optionCSS = ({
+  isDisabled,
+  isFocused,
+  isSelected,
+  theme: { spacing, colors },
+}: OptionProps) => ({
   backgroundColor: isSelected
     ? colors.primary
     : isFocused ? colors.primary25 : 'transparent',

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -2,7 +2,6 @@
 import React, { type Node } from 'react';
 import { css } from 'emotion';
 
-import { colors, spacing } from '../theme';
 import type { CommonProps } from '../types';
 
 export type PlaceholderProps = CommonProps & {
@@ -12,7 +11,7 @@ export type PlaceholderProps = CommonProps & {
   innerProps: { [string]: any },
 };
 
-export const placeholderCSS = () => ({
+export const placeholderCSS = ({ theme: { spacing, colors } }: PlaceholderProps) => ({
   color: colors.neutral50,
   marginLeft: spacing.baseUnit / 2,
   marginRight: spacing.baseUnit / 2,

--- a/src/components/SingleValue.js
+++ b/src/components/SingleValue.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import { css as emotionCss } from 'emotion';
-import { colors, spacing } from '../theme';
 import type { CommonProps } from '../types';
 
 type State = {
@@ -18,7 +17,7 @@ type ValueProps = {
 };
 export type SingleValueProps = CommonProps & ValueProps & State;
 
-export const css = ({ isDisabled }: SingleValueProps) => ({
+export const css = ({ isDisabled, theme: { spacing, colors } }: SingleValueProps) => ({
   color: isDisabled ? colors.neutral40 : colors.neutral80,
   marginLeft: spacing.baseUnit / 2,
   marginRight: spacing.baseUnit / 2,

--- a/src/components/containers.js
+++ b/src/components/containers.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component, type Node } from 'react';
 import { css } from 'emotion';
-import { spacing } from '../theme';
 import type { CommonProps, KeyboardEventHandler } from '../types';
 
 // ==============================
@@ -58,7 +57,7 @@ export type ValueContainerProps = CommonProps & {
   /** The children to be rendered. */
   children: Node,
 };
-export const valueContainerCSS = () => ({
+export const valueContainerCSS = ({ theme: { spacing } }: ValueContainerProps) => ({
   alignItems: 'center',
   display: 'flex',
   flex: 1,

--- a/src/components/indicators.js
+++ b/src/components/indicators.js
@@ -2,8 +2,8 @@
 import React, { type ElementType } from 'react';
 import { injectGlobal, css } from 'emotion';
 
-import { colors, spacing } from '../theme';
 import { type CommonProps } from '../types';
+import type { Theme } from '../types';
 
 // ==============================
 // Dropdown & Clear Icons
@@ -53,10 +53,13 @@ export type IndicatorProps = CommonProps & {
   isRtl: boolean,
 };
 
-const baseCSS = ({ isFocused }: IndicatorProps) => ({
+const baseCSS = ({
+  isFocused,
+  theme: { spacing: { baseUnit }, colors },
+}: IndicatorProps) => ({
   color: isFocused ? colors.neutral60 : colors.neutral20,
   display: 'flex',
-  padding: spacing.baseUnit * 2,
+  padding: baseUnit * 2,
   transition: 'color 150ms',
 
   ':hover': {
@@ -109,11 +112,14 @@ export const ClearIndicator = (props: IndicatorProps) => {
 
 type SeparatorState = { isDisabled: boolean };
 
-export const indicatorSeparatorCSS = ({ isDisabled }: SeparatorState) => ({
+export const indicatorSeparatorCSS = ({
+  isDisabled,
+  theme: { spacing: { baseUnit }, colors },
+}: (CommonProps & SeparatorState)) => ({
   alignSelf: 'stretch',
   backgroundColor: isDisabled ? colors.neutral10 : colors.neutral20,
-  marginBottom: spacing.baseUnit * 2,
-  marginTop: spacing.baseUnit * 2,
+  marginBottom: baseUnit * 2,
+  marginTop: baseUnit * 2,
   width: 1,
 });
 
@@ -140,13 +146,15 @@ const keyframesName = 'react-select-loading-indicator';
 export const loadingIndicatorCSS = ({
   isFocused,
   size,
+  theme: { colors, spacing: { baseUnit } },
 }: {
   isFocused: boolean,
   size: number,
+  theme: Theme,
 }) => ({
   color: isFocused ? colors.neutral60 : colors.neutral20,
   display: 'flex',
-  padding: spacing.baseUnit * 2,
+  padding: baseUnit * 2,
   transition: 'color 150ms',
   alignSelf: 'center',
   fontSize: size,
@@ -194,7 +202,7 @@ export type LoadingIconProps = {
   size: number,
 };
 export const LoadingIndicator = (props: LoadingIconProps) => {
-  const { className, cx, getStyles, innerProps, isFocused, isRtl } = props;
+  const { className, cx, getStyles, innerProps, isFocused, isRtl, theme: { colors } } = props;
   const color = isFocused ? colors.neutral80 : colors.neutral20;
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -13,3 +13,4 @@ export { createFilter } from './filters';
 export { default as makeAnimated } from './animated/index';
 export { components } from './components/index';
 export { mergeStyles } from './styles';
+export { defaultTheme } from './theme';

--- a/src/index.umd.js
+++ b/src/index.umd.js
@@ -13,6 +13,7 @@ import Creatable from './Creatable';
 import { createFilter } from './filters';
 import { components } from './components/index';
 import { mergeStyles } from './styles';
+import { defaultTheme } from './theme';
 
 const Select = manageState(SelectBase);
 Select.Async = Async;
@@ -22,5 +23,6 @@ Select.SelectBase = SelectBase;
 Select.createFilter = createFilter;
 Select.components = components;
 Select.mergeStyles = mergeStyles;
+Select.defaultTheme = defaultTheme;
 
 export default Select;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,6 @@
 // @flow
 
-export const borderRadius = 4;
+import type { Theme } from './types';
 
 export const colors = {
   primary: '#2684FF',
@@ -24,13 +24,19 @@ export const colors = {
   neutral90: 'hsl(218, 50%, 10%)',
 };
 
-const baseUnit = 4;
+const borderRadius = 4;
+const baseUnit = 4;  /* Used to calculate consistent margin/padding on elements */
+const controlHeight = 38;  /* The minimum height of the control */
+const menuGutter = baseUnit * 2;  /* The amount of space between the control and menu */
 
 export const spacing = {
-  /* Used to calculate consistent margin/padding on elements */
   baseUnit,
-  /* The minimum height of the control */
-  controlHeight: 38,
-  /* The amount of space between the control and menu */
-  menuGutter: baseUnit * 2,
+  controlHeight,
+  menuGutter,
+};
+
+export const defaultTheme: Theme = {
+  borderRadius,
+  colors,
+  spacing,
 };

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,3 +40,5 @@ export const defaultTheme: Theme = {
   colors,
   spacing,
 };
+
+export type ThemeConfig = Theme | ((theme: Theme) => Theme);

--- a/src/types.js
+++ b/src/types.js
@@ -26,6 +26,18 @@ export type PropsWithInnerRef = {
   innerRef: Ref<*>,
 };
 
+type ThemeSpacing = {
+  baseUnit: number,
+  controlHeight: number,
+  menuGutter: number,
+};
+
+export type Theme = {
+  borderRadius: number,
+  colors: { [key: string]: string },
+  spacing: ThemeSpacing,
+};
+
 export type PropsWithStyles = {
   /**
     Get the styles of a particular part of the select. Pass in the name of the
@@ -33,6 +45,7 @@ export type PropsWithStyles = {
     See the `styles` object for the properties available.
   */
   getStyles: (string, any) => {},
+  theme: Theme,
 };
 
 export type ClassNameList = Array<string>;
@@ -48,6 +61,7 @@ export type CommonProps = {
     See the `styles` object for the properties available.
   */
   getStyles: (string, any) => {},
+  theme: Theme,
   getValue: () => ValueType,
   hasValue: boolean,
   isMulti: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9910,8 +9910,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 update-notifier@^2.2.0:
   version "2.5.0"


### PR DESCRIPTION
As discussed in #2590, the global theme object is (was) very hard-coded.

This PR makes it a top-level prop that is then propagated down through `CommonProps` (and you can pass in a ready `Theme` object as well as a mutator function – the default theme is available as a `defaultTheme` export):

```jsx
<Select
    theme={(theme) => ({
      ...theme,
      borderRadius: 0,
      colors: {
      ...theme.colors,
        text: 'orangered',
        primary25: 'hotpink',
        primary: 'black',
      },
    })}
/>
```

Please let me know if I've done something silly – this is my first time working with the `react-select` codebase, and actually my first time working with Flow too :)

As an aside, I think the actual keys within `Theme.colors` should be pared down and formalized; right now there's 37 (!) different colors, most of which are various shades of black.