### PR TITLE
Centralize babelrc config & use loose mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,3 @@
 {
-  "plugins": [
-    "emotion",
-    "transform-class-properties",
-    "transform-object-rest-spread"
-  ],
-  "presets": ["env", "react"],
-  "ignore": ["node_modules"],
-  "env": {
-    "test": {
-      "plugins": ["istanbul"]
-    }
-  }
+  "presets": ["./.babelrc.js"]
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,20 @@
+const { BABEL_ENV, NODE_ENV } = process.env;
+const test = NODE_ENV === 'test';
+const cjs = BABEL_ENV === 'cjs' || test;
+
+module.exports = {
+  plugins: [
+    'emotion',
+    'transform-class-properties',
+    'transform-object-rest-spread',
+    test && 'istanbul',
+  ].filter(Boolean),
+  presets: [
+    ['env', {
+      modules: cjs ? 'commonjs' : false,
+      loose: true,
+    }],
+    'react',
+  ],
+  ignore: ['node_modules'],
+};

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -17,8 +17,8 @@ module.exports = {
         rimraf('lib/__tests__')
       ),
       rollup: 'rollup --config',
-      babel: 'babel src -d lib',
-      watch: 'babel src -d lib -w',
+      babel: 'cross-env BABEL_ENV=cjs babel src -d lib',
+      watch: 'cross-env BABEL_ENV=cjs babel src -d lib -w',
       flowtype: {
         description: 'make flow types available to consumers',
         default: concurrent.nps('build.flowtype.lib'),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,14 +21,10 @@ const globals = {
 const external = Object.keys(globals);
 const babelOptions = () => {
   let result = {
-    babelrc: false,
-    presets: [['env', { modules: false }], 'react'],
     plugins: [
-      'emotion',
-      'transform-class-properties',
-      'transform-object-rest-spread',
       'external-helpers',
     ],
+    exclude: 'node_modules/**',
   };
   return result;
 };


### PR DESCRIPTION
1. do not duplicate babel config in rollup.config.js, should be easier to keep this in sync now 

2. loose mode - mainly bundle size optiomation. Measuring with `npx terser -cm --toplevel dist/react-select.esm.js | gzip -c | wc -c` from 19047 bytes to 18545 bytes. Should u chose loose mode? Thread - https://twitter.com/brian_d_vaughn/status/1021183132135931905