### PR TITLE
Fix syntax error in styles docs

### DIFF
--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -68,7 +68,7 @@ export default function Styles() {
       control: () => ({
         // none of react-selects styles are passed to <View />
         width: 200,
-      })
+      }),
       singleValue: (base, state) => {
         const opacity = state.isDisabled ? 0.5 : 1;
         const transition = 'opacity 300ms';


### PR DESCRIPTION
### Problem
An example object for `customStyles` on `docs/styles` is missing a comma, it causes a syntax error.

### Solution
Add missing comma.

### References

Link to example object on the docs website: https://react-select.com/styles#base-and-state

Screenshot of failing example
![image](https://user-images.githubusercontent.com/2814874/43155610-7d83d3ce-8f3d-11e8-92fa-dc28de9af7b6.png)
