### PR TITLE
tweak rendering to display a small coloured box next to each option

### DIFF
--- a/docs/examples/CustomSingleValue.js
+++ b/docs/examples/CustomSingleValue.js
@@ -1,18 +1,24 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import Select, { components } from '../../src';
 import { colourOptions } from '../data';
 
 
-const SingleValue = ({ children, ...props }) => (
+const SingleValue = ({ children, ...props }) => {
+  const boxStyle = {
+    height: '10px',
+    width: '10px',
+    margin: '4px 5px 0 0',
+    background: props.data.color
+  };
+  return (
     <components.SingleValue {...props}>
+      <div style={boxStyle}/>
       {children}
     </components.SingleValue>
-);
+  );
+};
 
-type State = {};
-
-export default class CustomControl extends Component<*, State> {
-  state = {};
+export default class CustomControl extends PureComponent<*> {
   render() {
     return (
       <Select


### PR DESCRIPTION
I am curious if this is the expected way to modify the rendering of a custom shape option?  I came up with this whilst working on the typescript typedef for the library.

You can see the changes in a sandbox [here](https://codesandbox.io/s/kx7oy7j1p3)