### PR TITLE
Added prop that allows custom Menu's to close themselves

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1597,6 +1597,7 @@ export default class Select extends Component<Props, State> {
           menuPlacement={menuPlacement}
           menuPosition={menuPosition}
           menuShouldScrollIntoView={menuShouldScrollIntoView}
+          closeMenu={this.props.onMenuClose}
         >
           <ScrollCaptor
             isEnabled={captureMenuScroll}


### PR DESCRIPTION
See #2870

I needed to be able to close the menu from within a custom `Menu` component, so I added a prop `closeMenu` that does this.