### PR TITLE
[v2] Fixed bug where options were not reloaded when cacheOptions is false

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -72,14 +72,6 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
       if (nextProps.cacheOptions !== this.props.cacheOptions) {
         this.optionsCache = {};
       }
-      if (nextProps.defaultOptions !== this.props.defaultOptions) {
-        this.setState({
-          loadedOptions: Array.isArray(nextProps.defaultOptions)
-            ? nextProps.defaultOptions
-            : [],
-        });
-      }
-
     }
     componentWillUnmount() {
       this.mounted = false;

--- a/src/__tests__/Async.test.js
+++ b/src/__tests__/Async.test.js
@@ -141,6 +141,26 @@ test('in case of callbacks display the most recently-requested loaded options (i
   expect(asyncSelectWrapper.find(Option).text()).toBe('bar');
 });
 
+test('to update options when defaultOptions changes', () => {
+  const options = [
+    { label: 'a', value: 1 },
+    { label: 'b', value: 2 },
+  ];
+  const asyncSelectWrapper = mount(<Async defaultOptions={options} classNamePrefix="react-select" />);
+  let inputValueWrapper = asyncSelectWrapper.find(
+    'div.react-select__input input'
+  );
+  inputValueWrapper.simulate('change', { currentTarget: { value: 'bar' } });
+  expect(asyncSelectWrapper.find(Option).length).toBe(2);
+  asyncSelectWrapper.setProps({
+    defaultOptions: [
+      ...options,
+      { label: 'c', value: 3 },
+    ]
+  });
+  expect(asyncSelectWrapper.find(Option).length).toBe(3);
+});
+
 /**
  * This throws a jsdom exception
  */

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -9,7 +9,6 @@ exports[`defaults - snapshot 1`] = `
     cacheOptions={false}
     defaultInputValue=""
     defaultMenuIsOpen={false}
-    defaultOptions={false}
     defaultValue={null}
     filterOption={null}
     isLoading={false}
@@ -27,7 +26,6 @@ exports[`defaults - snapshot 1`] = `
       controlShouldRenderValue={true}
       defaultInputValue=""
       defaultMenuIsOpen={false}
-      defaultOptions={false}
       defaultValue={null}
       escapeClearsValue={false}
       filterOption={null}
@@ -95,7 +93,6 @@ exports[`defaults - snapshot 1`] = `
             "controlShouldRenderValue": true,
             "defaultInputValue": "",
             "defaultMenuIsOpen": false,
-            "defaultOptions": false,
             "defaultValue": null,
             "escapeClearsValue": false,
             "filterOption": null,
@@ -171,7 +168,6 @@ exports[`defaults - snapshot 1`] = `
                 "controlShouldRenderValue": true,
                 "defaultInputValue": "",
                 "defaultMenuIsOpen": false,
-                "defaultOptions": false,
                 "defaultValue": null,
                 "escapeClearsValue": false,
                 "filterOption": null,
@@ -240,7 +236,6 @@ exports[`defaults - snapshot 1`] = `
                     "controlShouldRenderValue": true,
                     "defaultInputValue": "",
                     "defaultMenuIsOpen": false,
-                    "defaultOptions": false,
                     "defaultValue": null,
                     "escapeClearsValue": false,
                     "filterOption": null,
@@ -308,7 +303,6 @@ exports[`defaults - snapshot 1`] = `
                         "controlShouldRenderValue": true,
                         "defaultInputValue": "",
                         "defaultMenuIsOpen": false,
-                        "defaultOptions": false,
                         "defaultValue": null,
                         "escapeClearsValue": false,
                         "filterOption": null,
@@ -485,7 +479,6 @@ exports[`defaults - snapshot 1`] = `
                     "controlShouldRenderValue": true,
                     "defaultInputValue": "",
                     "defaultMenuIsOpen": false,
-                    "defaultOptions": false,
                     "defaultValue": null,
                     "escapeClearsValue": false,
                     "filterOption": null,
@@ -553,7 +546,6 @@ exports[`defaults - snapshot 1`] = `
                         "controlShouldRenderValue": true,
                         "defaultInputValue": "",
                         "defaultMenuIsOpen": false,
-                        "defaultOptions": false,
                         "defaultValue": null,
                         "escapeClearsValue": false,
                         "filterOption": null,
@@ -629,7 +621,6 @@ exports[`defaults - snapshot 1`] = `
                         "controlShouldRenderValue": true,
                         "defaultInputValue": "",
                         "defaultMenuIsOpen": false,
-                        "defaultOptions": false,
                         "defaultValue": null,
                         "escapeClearsValue": false,
                         "filterOption": null,

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -9,7 +9,6 @@ exports[`defaults - snapshot 1`] = `
     cacheOptions={false}
     defaultInputValue=""
     defaultMenuIsOpen={false}
-    defaultOptions={false}
     defaultValue={null}
     filterOption={null}
     isLoading={false}
@@ -22,7 +21,6 @@ exports[`defaults - snapshot 1`] = `
       createOptionPosition="last"
       defaultInputValue=""
       defaultMenuIsOpen={false}
-      defaultOptions={false}
       defaultValue={null}
       filterOption={null}
       formatCreateLabel={[Function]}
@@ -51,7 +49,6 @@ exports[`defaults - snapshot 1`] = `
         createOptionPosition="last"
         defaultInputValue=""
         defaultMenuIsOpen={false}
-        defaultOptions={false}
         defaultValue={null}
         escapeClearsValue={false}
         filterOption={null}
@@ -124,7 +121,6 @@ exports[`defaults - snapshot 1`] = `
               "createOptionPosition": "last",
               "defaultInputValue": "",
               "defaultMenuIsOpen": false,
-              "defaultOptions": false,
               "defaultValue": null,
               "escapeClearsValue": false,
               "filterOption": null,
@@ -205,7 +201,6 @@ exports[`defaults - snapshot 1`] = `
                   "createOptionPosition": "last",
                   "defaultInputValue": "",
                   "defaultMenuIsOpen": false,
-                  "defaultOptions": false,
                   "defaultValue": null,
                   "escapeClearsValue": false,
                   "filterOption": null,
@@ -279,7 +274,6 @@ exports[`defaults - snapshot 1`] = `
                       "createOptionPosition": "last",
                       "defaultInputValue": "",
                       "defaultMenuIsOpen": false,
-                      "defaultOptions": false,
                       "defaultValue": null,
                       "escapeClearsValue": false,
                       "filterOption": null,
@@ -352,7 +346,6 @@ exports[`defaults - snapshot 1`] = `
                           "createOptionPosition": "last",
                           "defaultInputValue": "",
                           "defaultMenuIsOpen": false,
-                          "defaultOptions": false,
                           "defaultValue": null,
                           "escapeClearsValue": false,
                           "filterOption": null,
@@ -534,7 +527,6 @@ exports[`defaults - snapshot 1`] = `
                       "createOptionPosition": "last",
                       "defaultInputValue": "",
                       "defaultMenuIsOpen": false,
-                      "defaultOptions": false,
                       "defaultValue": null,
                       "escapeClearsValue": false,
                       "filterOption": null,
@@ -607,7 +599,6 @@ exports[`defaults - snapshot 1`] = `
                           "createOptionPosition": "last",
                           "defaultInputValue": "",
                           "defaultMenuIsOpen": false,
-                          "defaultOptions": false,
                           "defaultValue": null,
                           "escapeClearsValue": false,
                           "filterOption": null,
@@ -688,7 +679,6 @@ exports[`defaults - snapshot 1`] = `
                           "createOptionPosition": "last",
                           "defaultInputValue": "",
                           "defaultMenuIsOpen": false,
-                          "defaultOptions": false,
                           "defaultValue": null,
                           "escapeClearsValue": false,
                           "filterOption": null,


### PR DESCRIPTION
## The Problem

With Async, if `defaultOptions` was set to `true` and `cacheOptions` set to `false`. I would expect the default options to be reloaded every time that the user cleared out the input field; however, as it stands, the options are loaded once on mount and then cached, regardless of the value of `cacheOptions`.

## The Solution

In this bugfix, I made the value of `cacheOptions` affect the behavior of `defaultOptions={true}` meaning the results for `loadOptions('')` are found each time they are needed instead of once at the start.

## The Use Case

This caused a bug in my application where newly-created options (those added on the server were not being populated in the default options, but did show up in search results).


Comments and concerns welcome.

Cheers!