### PR TITLE
Fix missing hidden input when nothing is selected

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1648,18 +1648,21 @@ export default class Select extends Component<Props, State> {
           .join(delimiter);
         return <input name={name} type="hidden" value={value} />;
       } else {
-        return (
-          <div>
-            {selectValue.map((opt, i) => (
+        const input =
+          selectValue.length > 0 ? (
+            selectValue.map((opt, i) => (
               <input
                 key={`i-${i}`}
                 name={name}
                 type="hidden"
                 value={this.getOptionValue(opt)}
               />
-            ))}
-          </div>
-        );
+            ))
+          ) : (
+            <input name={name} type="hidden" />
+          );
+
+        return <div>{input}</div>;
       }
     } else {
       const value = selectValue[0] ? this.getOptionValue(selectValue[0]) : '';

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -58,6 +58,13 @@ test('hidden input field is not present if name is not passes', () => {
   expect(selectWrapper.find('input[type="hidden"]').exists()).toBeFalsy();
 });
 
+test('hidden input field is present if name passes', () => {
+  let selectWrapper = mount(
+    <Select name="test-input-name" options={OPTIONS} />
+  );
+  expect(selectWrapper.find('input[type="hidden"]').exists()).toBeTruthy();
+});
+
 test('single select > passing multiple values > should select the first value', () => {
   const props = { ...BASIC_PROPS, value: [OPTIONS[0], OPTIONS[4]] };
   let selectWrapper = mount(<Select {...props} />);


### PR DESCRIPTION
This is related to issue https://github.com/JedWatson/react-select/issues/2551. There was an old PR here https://github.com/JedWatson/react-select/pull/2552

This PR is for v2:
- renders a hidden field (with no value) when nothing is selected