### PR TITLE
Reload defaultOptions when cacheOptions changes in Async

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -57,17 +57,16 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
       this.mounted = true;
       const { defaultOptions } = this.props;
       if (defaultOptions === true) {
-        this.loadOptions('', options => {
-          if (!this.mounted) return;
-          const isLoading = !!this.lastRequest;
-          this.setState({ defaultOptions: options || [], isLoading });
-        });
+        this.reloadDefaultOptions();
       }
     }
     componentWillReceiveProps(nextProps: Props) {
       // if the cacheOptions prop changes, clear the cache
       if (nextProps.cacheOptions !== this.props.cacheOptions) {
         this.optionsCache = {};
+        if (defaultOptions === true) {
+          this.reloadDefaultOptions();
+        }
       }
       if (nextProps.defaultOptions !== this.props.defaultOptions) {
         this.setState({
@@ -87,6 +86,13 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
     blur() {
       this.select.blur();
     }
+    reloadDefaultOptions() {
+      this.loadOptions('', options => {
+        if (!this.mounted) return;
+        const isLoading = !!this.lastRequest;
+        this.setState({ defaultOptions: options || [], isLoading });
+      });
+    },
     loadOptions(inputValue: string, callback: (?Array<*>) => void) {
       const { loadOptions } = this.props;
       if (!loadOptions) return callback();

--- a/src/Async.js
+++ b/src/Async.js
@@ -64,7 +64,7 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
       // if the cacheOptions prop changes, clear the cache
       if (nextProps.cacheOptions !== this.props.cacheOptions) {
         this.optionsCache = {};
-        if (defaultOptions === true) {
+        if (nextProps.defaultOptions === true) {
           this.reloadDefaultOptions();
         }
       }
@@ -92,7 +92,7 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
         const isLoading = !!this.lastRequest;
         this.setState({ defaultOptions: options || [], isLoading });
       });
-    },
+    }
     loadOptions(inputValue: string, callback: (?Array<*>) => void) {
       const { loadOptions } = this.props;
       if (!loadOptions) return callback();


### PR DESCRIPTION
Previously the default options did not reload when the cache changes, leading to incorrect results.