### PR TITLE
Create new options with CreatableSelect and filterOption

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -17,6 +17,9 @@ export const createFilter = (config: ?Config) => (
   option: { label: string, value: string, data: any },
   rawInput: string
 ) => {
+  if (option.data.__isNew__) {
+    return true;
+  }
   const { ignoreCase, ignoreAccents, stringify, trim, matchFrom } = {
     ignoreCase: true,
     ignoreAccents: true,


### PR DESCRIPTION
Solves #2945 

Issue:-
- While using CreatableSelect, If **filterOption** prop is provided and that has 'matchFrom' property as 'start'.
- In that case, we will not be able to create new options, because the **createFilter** function will search in the label from start and that label will have text as "Create New "xxx"" which doesn't start with xxx, hence will **return false** and the option will not be displayed.

Fix:-
- The fix is very simple.
- If __isNew__ flag is true, ignore all the filter config and return true.