### PR TITLE
Add a wrapper container for multivalue labels

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1372,6 +1372,7 @@ export default class Select extends Component<Props, State> {
       MultiValue,
       MultiValueContainer,
       MultiValueLabel,
+      MultiValueLabelsContainer,
       MultiValueRemove,
       SingleValue,
       Placeholder,
@@ -1422,7 +1423,11 @@ export default class Select extends Component<Props, State> {
           </MultiValue>
         );
       });
-      return selectValues;
+      return (
+        <MultiValueLabelsContainer {...commonProps}>
+          {selectValues}
+        </MultiValueLabelsContainer>
+      );
     }
 
     if (inputValue) {

--- a/src/components/MultiValue.js
+++ b/src/components/MultiValue.js
@@ -68,6 +68,7 @@ export const MultiValueGeneric = ({
   innerProps,
 }: MultiValueGenericProps) => <div {...innerProps}>{children}</div>;
 
+export const MultiValueLabelsContainer = MultiValueGeneric;
 export const MultiValueContainer = MultiValueGeneric;
 export const MultiValueLabel = MultiValueGeneric;
 export type MultiValueRemoveProps = CommonProps & {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -37,6 +37,7 @@ import Menu, {
 } from './Menu';
 import MultiValue, {
   type MultiValueProps,
+  MultiValueLabelsContainer,
   MultiValueContainer,
   MultiValueLabel,
   MultiValueRemove,
@@ -70,6 +71,7 @@ export type SelectComponents = {
   LoadingMessage: ComponentType<NoticeProps>,
   NoOptionsMessage: ComponentType<NoticeProps>,
   MultiValue: ComponentType<MultiValueProps>,
+  MultiValueLabelsContainer: ComponentType<any>,
   MultiValueContainer: ComponentType<any>,
   MultiValueLabel: ComponentType<any>,
   MultiValueRemove: ComponentType<any>,
@@ -100,6 +102,7 @@ export const components: SelectComponents = {
   LoadingMessage: LoadingMessage,
   NoOptionsMessage: NoOptionsMessage,
   MultiValue: MultiValue,
+  MultiValueLabelsContainer: MultiValueLabelsContainer,
   MultiValueContainer: MultiValueContainer,
   MultiValueLabel: MultiValueLabel,
   MultiValueRemove: MultiValueRemove,


### PR DESCRIPTION
I need to replace the labels container with `A, B, C, and 23 more` in my project, which is not currently possible in v2 because the `selectValues` returns an array of `MultiValueContainer`, and if I replace the `ValueContainer` I have to recreate `Select.prototype.renderInput`. This will allow a happy medium between the two.