### PR TITLE
Fix "Replacable" typo in docs header

### DIFF
--- a/docs/App/Header.js
+++ b/docs/App/Header.js
@@ -26,7 +26,7 @@ const changes = [
   {
     value: '/components',
     icon: '📦',
-    label: 'Replacable component architecture',
+    label: 'Replaceable component architecture',
   },
   {
     value: '/advanced',


### PR DESCRIPTION
This fixes a typo in Header's Select.