### PR TITLE
Fix creatable options with integer values

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -38,7 +38,7 @@ export type Props = SelectProps & CreatableProps;
 const compareOption = (inputValue, option) => {
   const candidate = inputValue.toLowerCase();
   return (
-    option.value.toLowerCase() === candidate ||
+    option.value.toString().toLowerCase() === candidate ||
     option.label.toLowerCase() === candidate
   );
 };


### PR DESCRIPTION
If I give options like
```
{
   label: "Apple",
   id: 1
}
```

The code breaks since `1` doesn't have a `toLowerCase` function.