### PR TITLE
fix CustomGetOptionLabel path

### DIFF
--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -80,8 +80,8 @@ export default function Advanced() {
       ${(
         <ExampleWrapper
           label="custom getOptionLabel function example"
-          urlPath="docs/examples/CustomSingleValue.js"
-          raw={require('!!raw-loader!../../examples/CustomSingleValue.js')}
+          urlPath="docs/examples/CustomGetOptionLabel.js"
+          raw={require('!!raw-loader!../../examples/CustomGetOptionLabel.js')}
         >
           <CustomGetOptionLabel />
         </ExampleWrapper>


### PR DESCRIPTION
Fix component path at custom getOptionLabel function example.

`docs/examples/CustomSingleValue.js` → `docs/examples/CustomGetOptionLabel.js`