### PR TITLE
Fix redirection in docs/advanced

### DIFF
--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -66,7 +66,7 @@ export default function Advanced() {
       )}
 
       ## Replacing builtins
-      For a list of builtins that we expose, please see the API docs [here](/api#prop-types).
+      For a list of builtins that we expose, please see the API docs [here](/props#prop-types).
 
       ${(
         <ExampleWrapper


### PR DESCRIPTION
Redirect to props#prop-types instead of api#prop-types.

I also searched for any other occurrences of /api in docs/pages but couldn't find any