### PR TITLE
Add prop to make "automatically focusing to the first option" optional

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -82,6 +82,8 @@ export type Props = {
   'aria-labelledby'?: string,
   /* Focus the control when it is mounted */
   autoFocus?: boolean,
+  /* Focus first option when the menu opens */
+  autoFocusFirstOption?: boolean,
   /* Remove the currently focused option when the user presses backspace */
   backspaceRemovesValue: boolean,
   /* Remove focus from the input when the user selects an option (handy for dismissing the keyboard on touch devices) */
@@ -225,6 +227,7 @@ export type Props = {
 };
 
 export const defaultProps = {
+  autoFocusFirstOption: true,
   backspaceRemovesValue: true,
   blurInputOnSelect: isTouchCapable(),
   captureMenuScroll: !isTouchCapable(),
@@ -725,9 +728,12 @@ export default class Select extends Component<Props, State> {
 
   getNextFocusedOption(options: OptionsType) {
     const { focusedOption: lastFocusedOption } = this.state;
+    const { autoFocusFirstOption } = this.props;
     return lastFocusedOption && options.indexOf(lastFocusedOption) > -1
       ? lastFocusedOption
-      : options[0];
+      : autoFocusFirstOption
+        ? options[0]
+        : null;
   }
   getOptionLabel = (data: OptionType): string => {
     return this.props.getOptionLabel(data);

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -727,15 +727,31 @@ cases(
     expect(selectWrapper.state('focusedOption')).toEqual(expectedToFocus);
   },
   {
-    'single select > should focus the first option': {
+    'single select > should focus the first option if autoFocusFirstOption prop is true': {
       expectedToFocus: { label: '0', value: 'zero' },
     },
-    'multi select > should focus the first option': {
+    'multi select > should focus the first option if autoFocusFirstOption prop is true': {
       props: {
         ...BASIC_PROPS,
         isMulti: true,
       },
       expectedToFocus: { label: '0', value: 'zero' },
+    },
+  },
+  {
+    'single select > should not focus any option if autoFocusFirstOption prop is false': {
+      props: {
+        ...BASIC_PROPS,
+        autoFocusFirstOption: false,
+      },
+      expectedToFocus: null,
+    },
+    'multi select > should not focus any option if autoFocusFirstOption prop is false': {
+      props: {
+        ...BASIC_PROPS,
+        expectedToFocus: false,
+      },
+      expectedToFocus: null,
     },
   }
 );

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -17,6 +17,7 @@ exports[`defaults - snapshot 1`] = `
     options={Array []}
   >
     <Select
+      autoFocusFirstOption={true}
       backspaceRemovesValue={true}
       blurInputOnSelect={true}
       cacheOptions={false}
@@ -85,6 +86,7 @@ exports[`defaults - snapshot 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "cacheOptions": false,
@@ -190,6 +192,7 @@ exports[`defaults - snapshot 1`] = `
             selectOption={[Function]}
             selectProps={
               Object {
+                "autoFocusFirstOption": true,
                 "backspaceRemovesValue": true,
                 "blurInputOnSelect": true,
                 "cacheOptions": false,
@@ -288,6 +291,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoFocusFirstOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -385,6 +389,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -678,6 +683,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoFocusFirstOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -775,6 +781,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -880,6 +887,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -40,6 +40,7 @@ exports[`defaults - snapshot 1`] = `
     >
       <Select
         allowCreateWhileLoading={false}
+        autoFocusFirstOption={true}
         backspaceRemovesValue={true}
         blurInputOnSelect={true}
         cacheOptions={false}
@@ -113,6 +114,7 @@ exports[`defaults - snapshot 1`] = `
           selectProps={
             Object {
               "allowCreateWhileLoading": false,
+              "autoFocusFirstOption": true,
               "backspaceRemovesValue": true,
               "blurInputOnSelect": true,
               "cacheOptions": false,
@@ -223,6 +225,7 @@ exports[`defaults - snapshot 1`] = `
               selectProps={
                 Object {
                   "allowCreateWhileLoading": false,
+                  "autoFocusFirstOption": true,
                   "backspaceRemovesValue": true,
                   "blurInputOnSelect": true,
                   "cacheOptions": false,
@@ -326,6 +329,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoFocusFirstOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -428,6 +432,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -726,6 +731,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoFocusFirstOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -828,6 +834,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -938,6 +945,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -21,6 +21,7 @@ exports[`snapshot - defaults 1`] = `
   selectOption={[Function]}
   selectProps={
     Object {
+      "autoFocusFirstOption": true,
       "backspaceRemovesValue": true,
       "blurInputOnSelect": true,
       "captureMenuScroll": false,
@@ -111,6 +112,7 @@ exports[`snapshot - defaults 1`] = `
     selectOption={[Function]}
     selectProps={
       Object {
+        "autoFocusFirstOption": true,
         "backspaceRemovesValue": true,
         "blurInputOnSelect": true,
         "captureMenuScroll": false,
@@ -193,6 +195,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoFocusFirstOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -276,6 +279,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -408,6 +412,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoFocusFirstOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -491,6 +496,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -581,6 +587,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,

--- a/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`defaults > snapshot 1`] = `
 <Select
+  autoFocusFirstOption={true}
   backspaceRemovesValue={true}
   blurInputOnSelect={true}
   captureMenuScroll={false}


### PR DESCRIPTION
Related to #2653 

This PR:

- Add autoFocusFirstOption prop to make "automatically focusing to the first option" optional.
- Update "Select" test.
- Update snapshots