### PR TITLE
classNamePrefix documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Common props you may want to specify include:
 
 * `autoFocus` - focus the control when it mounts
 * `className` - apply a className to the control
+* `classNamePrefix` - apply classNames to inner elements with the given prefix
 * `isDisabled` - disable the control
 * `isMulti` - allow the user to select multiple values
 * `isSearchable` - allow the user to search for matching options

--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -108,27 +108,12 @@ export default function Styles() {
     ## Using classNames
 
     If you provide the \`className\` prop to react-select, the SelectContainer will be given a className based on the provided value.
-    If you provide the \`classNamePrefix\` prop to react-select, all inner elements will
-    be given a className based on the one you have provided.
 
-    For example, given \`classNamePrefix="react-select"\`, the DOM would roughtly look
-    like this:
+    If you provide the \`classNamePrefix\` prop to react-select, all inner elements will be given a className
+    with the provided prefix.
 
-    ~~~html
-    <div>
-      <div class="react-select__control">
-        <div class="react-select__value-container">...</div>
-        <div class="react-select__indicators">...</div>
-      </div>
-      <div class="react-select__menu">
-        <div class="react-select__menu-list">
-          <div class="react-select__option">...</div>
-        </div>
-      </div>
-    </div>
-    ~~~
-
-    while giving \`className='react-select-container'\` and \`classNamePrefix='react-select'\`, the DOM would roughly look like this:
+    For example, given \`className='react-select-container'\` and \`classNamePrefix="react-select"\`,
+    the DOM structure is similar to this:
 
     ~~~html
     <div class="react-select-container">
@@ -144,8 +129,9 @@ export default function Styles() {
     </div>
     ~~~
 
-    While we encourage you to use the new Styles API, it's good to know that you
-    still have the option of adding class names to the components to style via CSS.
+    While we encourage you to use the new Styles API, you still have the option of styling via CSS classes.
+    This ensures compatibility with [styled components](https://www.styled-components.com/),
+    [CSS modules](https://github.com/css-modules/css-modules) and other libraries.
 
     ## Overriding the theme
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -88,23 +88,27 @@ export type Props = {
   blurInputOnSelect: boolean,
   /* When the user reaches the top/bottom of the menu, prevent scroll on the scroll-parent  */
   captureMenuScroll: boolean,
-  /* className attribute applied to the outer component */
+  /* Sets a className attribute on the outer component */
   className?: string,
-  /* classNamePrefix attribute used as a base for inner component classNames */
+  /*
+    If provided, all inner components will be given a prefixed className attribute.
+
+    This is useful when styling via CSS classes instead of the Styles API approach.
+  */
   classNamePrefix?: string | null,
   /* Close the select menu when the user selects an option */
   closeMenuOnSelect: boolean,
   /*
-     If `true`, close the select menu when the user scrolls the document/body.
+    If `true`, close the select menu when the user scrolls the document/body.
 
-     If a function, takes a standard javascript `ScrollEvent` you return a boolean:
+    If a function, takes a standard javascript `ScrollEvent` you return a boolean:
 
-     `true` => The menu closes
+    `true` => The menu closes
 
-     `false` => The menu stays open
+    `false` => The menu stays open
 
-     This is useful when you have a scrollable modal and want to portal the menu out,
-     but want to avoid graphical issues.
+    This is useful when you have a scrollable modal and want to portal the menu out,
+    but want to avoid graphical issues.
    */
   closeMenuOnScroll: boolean | EventListener,
   /*


### PR DESCRIPTION
The documentation lacks clarity around the `classNamePrefix` prop, making it difficult to integrate react-select with popular libraries such as [styled components](https://www.styled-components.com/) and [CSS modules](https://github.com/css-modules/css-modules).

This PR introduces:
- clear descriptions to the Props API docs for `classNamePrefix`
- an explanation that classNames are added to inner elements when the `classNamePrefix` is provided
- the removal of a redundant example in the Styles section
- a reference to other component styling methods to bolster react-select's integration capabilities