### PR TITLE
fix for control disabled state

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -855,6 +855,7 @@ export default class Select extends Component<Props, State> {
     this.blockOptionHover = false;
   };
   onControlMouseDown = (event: MouseOrTouchEvent) => {
+    if (this.props.isDisabled) return;
     const { openMenuOnClick } = this.props;
     if (!this.state.isFocused) {
       if (openMenuOnClick) {


### PR DESCRIPTION
There was a check in onDropdownIndicatorMouseDown, but not in onControlMouseDown, so it was possible to open dropdown still even if disabled.