### PR TITLE
Find correct option when value is passed as a string

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "javascript.validate.enable": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "javascript.validate.enable": false
-}

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -94,11 +94,13 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
         inputValue,
         isLoading,
         isValidNewOption,
+        getOptionValue,
         value,
       } = nextProps;
       const options = nextProps.options || [];
       let { newOption } = this.state;
-      if (isValidNewOption(inputValue, cleanValue(value), options)) {
+      const cleanedValue = cleanValue(value, options, getOptionValue);
+      if (isValidNewOption(inputValue, cleanedValue, options)) {
         newOption = getNewOptionData(inputValue, formatCreateLabel(inputValue));
       } else {
         newOption = undefined;
@@ -119,6 +121,8 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
         onChange,
         onCreateOption,
         value,
+        options,
+        getOptionValue,
       } = this.props;
       if (actionMeta.action !== 'select-option') {
         return onChange(newValue, actionMeta);
@@ -132,7 +136,7 @@ export const makeCreatableSelect = (SelectComponent: ComponentType<*>) =>
           const newOptionData = getNewOptionData(inputValue, inputValue);
           const newActionMeta = { action: 'create-option' };
           if (isMulti) {
-            onChange([...cleanValue(value), newOptionData], newActionMeta);
+            onChange([...cleanValue(value, options, getOptionValue), newOptionData], newActionMeta);
           } else {
             onChange(newOptionData, newActionMeta);
           }

--- a/src/Select.js
+++ b/src/Select.js
@@ -344,13 +344,13 @@ export default class Select extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    const { value } = props;
+    const { value, options } = props;
     this.cacheComponents = memoizeOne(this.cacheComponents, isEqual).bind(this);
     this.cacheComponents(props.components);
     this.instancePrefix =
       'react-select-' + (this.props.instanceId || ++instanceId);
 
-    const selectValue = cleanValue(value);
+    const selectValue = cleanValue(value, options, props.getOptionValue);
     const menuOptions = this.buildMenuOptions(props, selectValue);
 
     this.state.menuOptions = menuOptions;
@@ -379,7 +379,7 @@ export default class Select extends Component<Props, State> {
       nextProps.options !== options ||
       nextProps.inputValue !== inputValue
     ) {
-      const selectValue = cleanValue(nextProps.value);
+      const selectValue = cleanValue(nextProps.value, nextProps.options, nextProps.getOptionValue);
       const menuOptions = this.buildMenuOptions(nextProps, selectValue);
       const focusedValue = this.getNextFocusedValue(selectValue);
       const focusedOption = this.getNextFocusedOption(menuOptions.focusable);

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1976,6 +1976,23 @@ test('not render any groups when there is not a single match when filtering', ()
   expect(selectWrapper.find('Group').length).toBe(0);
 });
 
+test('Show the correct option label when value is given as string', () => {
+  const options = [{
+    label: 'First option label',
+    value: 'firstValue'
+  }, {
+    label: 'First value text',
+    value: 'secondValue'
+  }];
+
+  const selectWrapper = mount(
+    <Select options={options} value="firstValue" />
+  );
+
+  let value = selectWrapper.find(SingleValue).at(0);
+  expect(value.props().children).toBe('First option label');
+});
+
 test('multi select > have default value delimiter seperated', () => {
   let selectWrapper = mount(
     <Select

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,8 +61,12 @@ export function classNames(
 // Clean Value
 // ==============================
 
-export const cleanValue = (value: ValueType, options: OptionsType, getOptionValue: (option: OptionType) => string): OptionsType => {
-  if (typeof value === 'string') {
+export const cleanValue = (
+  value: ValueType,
+  options: OptionsType,
+  getOptionValue: (option: OptionType) => string
+): OptionsType => {
+  if (value && typeof value === 'string') {
     return options.filter(option => getOptionValue(option));
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@ import { type ElementRef } from 'react';
 import type {
   ClassNamesState,
   InputActionMeta,
+  OptionType,
   OptionsType,
   ValueType,
 } from './types';
@@ -60,7 +61,11 @@ export function classNames(
 // Clean Value
 // ==============================
 
-export const cleanValue = (value: ValueType): OptionsType => {
+export const cleanValue = (value: ValueType, options: OptionsType, getOptionValue: (option: OptionType) => string): OptionsType => {
+  if (typeof value === 'string') {
+    return options.filter(option => getOptionValue(option));
+  }
+
   if (Array.isArray(value)) return value.filter(Boolean);
   if (typeof value === 'object' && value !== null) return [value];
   return [];


### PR DESCRIPTION
Aims to resolve: https://github.com/JedWatson/react-select/issues/2669. 

I believe this is a pretty common use case so I think it's nice to support this by default.

Our main use case for this is that we set the `value` of a `<Select />` based on a string value from an API response. Instead of having to map the string value to one of the `options` object passed to the `<Select />` I think it would be nice to be done automatically because it seems to be a common use case.

The implementation is pretty straightforward so maybe (likely) I'm missing some cases.

