### PR TITLE
pass previously moved menu props from menuplacer back into menu

### DIFF
--- a/docs/examples/Popout.js
+++ b/docs/examples/Popout.js
@@ -60,7 +60,7 @@ export default class PopoutExample extends Component<*, State> {
 // styled components
 
 const Menu = props => {
-  const shadow = colors.neutral10a;
+  const shadow = 'hsla(218, 50%, 10%, 0.1)';
   return (
     <div
       css={{

--- a/src/Select.js
+++ b/src/Select.js
@@ -1613,19 +1613,23 @@ export default class Select extends Component<Props, State> {
       if (message === null) return null;
       menuUI = <NoOptionsMessage {...commonProps}>{message}</NoOptionsMessage>;
     }
+    const menuPlacementProps = {
+      minMenuHeight,
+      maxMenuHeight,
+      menuPlacement,
+      menuPosition,
+      menuShouldScrollIntoView,
+    };
 
     const menuElement = (
       <MenuPlacer
         {...commonProps}
-        minMenuHeight={minMenuHeight}
-        maxMenuHeight={maxMenuHeight}
-        menuPlacement={menuPlacement}
-        menuPosition={menuPosition}
-        menuShouldScrollIntoView={menuShouldScrollIntoView}
+        {...menuPlacementProps}
       >
         {({ ref, placerProps: { placement, maxHeight } }) => (
           <Menu
             {...commonProps}
+            {...menuPlacementProps}
             innerRef={ref}
             innerProps={{
               onMouseDown: this.onMenuMouseDown,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -305,7 +305,9 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
     return { ...this.props, placement, maxHeight: this.state.maxHeight };
   };
   render() {
-    const { children } = this.props;
+    const {
+      children,
+    } = this.props;
 
     return children({
       ref: this.getPlacement,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -305,9 +305,7 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
     return { ...this.props, placement, maxHeight: this.state.maxHeight };
   };
   render() {
-    const {
-      children,
-    } = this.props;
+    const { children } = this.props;
 
     return children({
       ref: this.getPlacement,


### PR DESCRIPTION
to avoid having to affect a breaking change for users configuring their own custom Menu component.