### PR TITLE
Do not close menu on input click

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -868,7 +868,10 @@ export default class Select extends Component<Props, State> {
     } else if (!this.props.menuIsOpen) {
       this.openMenu('first');
     } else {
-      this.onMenuClose();
+      // $FlowFixMe HTMLElement type does not have tagName property
+      if (event.target.tagName !== 'INPUT') {
+        this.onMenuClose();
+      }
     }
     // $FlowFixMe HTMLElement type does not have tagName property
     if (event.target.tagName !== 'INPUT') {


### PR DESCRIPTION
This allows you to type some text in the input, then set the cursor somewhere inside that text and edit the text without the menu closing and losing the input