### PR TITLE
Prevent backspace from returning [] in non-multi select (issue #2682)

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1114,7 +1114,7 @@ export default class Select extends Component<Props, State> {
         if (focusedValue) {
           this.removeValue(focusedValue);
         } else {
-          if (!backspaceRemovesValue) return;
+          if (!backspaceRemovesValue || !isMulti) return;
           this.popValue();
         }
         break;


### PR DESCRIPTION
The backspace key causes onChange to be called with `[]` on a non-multi select control, which breaks untold things.

This patch changes the backspace behavior to only pop values when `isMulti` is true. This prevents the issue with the incorrect call to onChange.