### PR TITLE
feat: Disable inline styles

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -740,9 +740,14 @@ export default class Select extends Component<Props, State> {
     return this.props.getOptionValue(data);
   };
   getStyles = (key: string, props: {}): {} => {
+    const { styles } = this.props;
+    if (styles === null) {
+      return {};
+    }
+
     const base = defaultStyles[key](props);
     base.boxSizing = 'border-box';
-    const custom = this.props.styles[key];
+    const custom = styles[key];
     return custom ? custom(base, props) : base;
   };
   getElementId = (element: 'group' | 'input' | 'listbox' | 'option') => {

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -2281,3 +2281,28 @@ test('renders with custom theme', () => {
   const firstOption = selectWrapper.find(Option).first();
   expect(window.getComputedStyle(firstOption.getDOMNode()).getPropertyValue('background-color')).toEqual(primary);
 });
+
+test.only('renders without inline styles if style is null', () => {
+  const primary = 'rgb(255, 164, 83)';
+  const selectWrapper = mount(
+    <Select
+      {...BASIC_PROPS}
+      value={OPTIONS[0]}
+      menuIsOpen
+      theme={(theme) => (
+        {
+          ... theme,
+          borderRadius: 180,
+          colors: {
+            ...theme.colors,
+            primary,
+          },
+        }
+      )}
+      styles={null} />
+  );
+  const menu = selectWrapper.find(Menu);
+  expect(window.getComputedStyle(menu.getDOMNode()).getPropertyValue('border-radius')).toEqual('');
+  const firstOption = selectWrapper.find(Option).first();
+  expect(window.getComputedStyle(firstOption.getDOMNode()).getPropertyValue('background-color')).toEqual('');
+});

--- a/src/styles.js
+++ b/src/styles.js
@@ -56,7 +56,7 @@ export type Styles = {
   singleValue?: Props => {},
   valueContainer: Props => {},
 };
-export type StylesConfig = $Shape<Styles>;
+export type StylesConfig = $Shape<Styles> | null;
 export type GetStyles = (string, Props) => {};
 
 export const defaultStyles: Styles = {


### PR DESCRIPTION
To disable the inline styles in 2.x you need to pass an object with a bunch of empty functions. With this PR I suggest the style prop to accept a null-value for these use cases.