### PR TITLE
Docs: custom 'filterOption' function example

### DIFF
--- a/docs/examples/CustomOptionFilter.js
+++ b/docs/examples/CustomOptionFilter.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
-import Select, { createFilter } from '../../src';
+import Select from '../../src';
 import { colourOptions } from '../data';
-import { Note } from '../styled-components';
 
 export default class SelectCreateFilter extends Component<*, State> {
   customOptionFilter = (option, inputValue) => () => {

--- a/docs/examples/CustomOptionFilter.js
+++ b/docs/examples/CustomOptionFilter.js
@@ -1,0 +1,25 @@
+import React, { Component, Fragment } from 'react';
+import Select, { createFilter } from '../../src';
+import { colourOptions } from '../data';
+import { Note } from '../styled-components';
+
+export default class SelectCreateFilter extends Component<*, State> {
+  customOptionFilter = (option, inputValue) => () => {
+    const expr = new RegExp(`^${inputValue}`, 'i');
+    return expr.test(option.label);
+  }
+  render () {
+    return (
+      <Fragment>
+        <Select
+          defaultValue={colourOptions[0]}
+          isClearable
+          isSearchable
+          name="color"
+          options={colourOptions}
+          filterOption={this.customOptionFilter}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -35,6 +35,7 @@ export { default as CustomSingleValue } from './CustomSingleValue';
 export { default as CustomValueContainer } from './CustomValueContainer';
 export { default as CustomGetOptionLabel } from './CustomGetOptionLabel';
 export { default as CustomGetOptionValue } from './CustomGetOptionValue';
+export { default as CustomOptionFilter } from './CustomOptionFilter';
 export { default as CustomFilterOptions } from './CustomFilterOptions';
 export { default as CustomIsOptionDisabled } from './CustomIsOptionDisabled';
 export { default as Experimental } from './Experimental';

--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -55,11 +55,13 @@ export default function Advanced() {
       If you really would like to rewrite the filtration logic from the ground up, simply declare a new filterOption function to be passed in as a prop to react-select.
       For details on the shape of the filterOption prop, please see the proptypes in the api docs [here](/props).
 
+      Below is a simple example of how you can write your own custom filter functions to filter the options displayed in react-select. It takes your `inputValue` and does a case-insensitive test only against the beginning of the option label.
+
       ${(
         <ExampleWrapper
-          label="Custom filterOption with createFilter"
-          urlPath="docs/examples/CreateFilter.js"
-          raw={require('!!raw-loader!../../examples/CreateFilter.js')}
+          label="Custom filterOption with a custom filter"
+          urlPath="docs/examples/CustomOptionFilter.js"
+          raw={require('!!raw-loader!../../examples/CustomOptionFilter.js')}
         >
           <CustomFilterOptions />
         </ExampleWrapper>

--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -9,7 +9,7 @@ import {
   OnSelectResetsInput,
   BasicGrouped,
   CreateFilter,
-  CustomFilterOptions,
+  CustomOptionFilter,
   CustomGetOptionLabel,
   CustomGetOptionValue,
   CustomIsOptionDisabled,
@@ -63,7 +63,7 @@ export default function Advanced() {
           urlPath="docs/examples/CustomOptionFilter.js"
           raw={require('!!raw-loader!../../examples/CustomOptionFilter.js')}
         >
-          <CustomFilterOptions />
+          <CustomOptionFilter />
         </ExampleWrapper>
       )}
 

--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -55,7 +55,7 @@ export default function Advanced() {
       If you really would like to rewrite the filtration logic from the ground up, simply declare a new filterOption function to be passed in as a prop to react-select.
       For details on the shape of the filterOption prop, please see the proptypes in the api docs [here](/props).
 
-      Below is a simple example of how you can write your own custom filter functions to filter the options displayed in react-select. It takes your `inputValue` and does a case-insensitive test only against the beginning of the option label.
+      Below is a simple example of how you can write your own custom filter functions to filter the options displayed in react-select. It takes your inputValue and does a case-insensitive test only against the beginning of the option label.
 
       ${(
         <ExampleWrapper

--- a/src/Select.js
+++ b/src/Select.js
@@ -127,8 +127,8 @@ export type Props = {
   delimiter?: string,
   /* Clear all values when the user presses escape AND the menu is closed */
   escapeClearsValue: boolean,
-  /* 
-    Custom method to filter whether an option should be displayed in the menu 
+  /*
+    Custom method to filter whether an option should be displayed in the menu
 
     A custom filter method takes two parameters, the `option`, and the `inputValue`, and will
     display all options for which your method returns `true`. For an example, please see

--- a/src/Select.js
+++ b/src/Select.js
@@ -127,7 +127,13 @@ export type Props = {
   delimiter?: string,
   /* Clear all values when the user presses escape AND the menu is closed */
   escapeClearsValue: boolean,
-  /* Custom method to filter whether an option should be displayed in the menu */
+  /* 
+    Custom method to filter whether an option should be displayed in the menu 
+
+    A custom filter method takes two parameters, the `option`, and the `inputValue`, and will
+    display all options for which your method returns `true`. For an example, please see
+    the [Custom Filter logic](/advanced#custom-filter-logic) example.
+  */
   filterOption: ((Object, string) => boolean) | null,
   /* Formats group labels in the menu as React components */
   formatGroupLabel: typeof formatGroupLabel,


### PR DESCRIPTION
Updating the 'Advanced' docs, making a clear example of overriding the `filterOption` with one's own custom filtering method.