### PR TITLE
Add missing `data` prop type to `Option`

### DIFF
--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -33,6 +33,8 @@ export type OptionProps = PropsWithStyles &
     /* Type is used by the menu to determine whether this is an option or a group.
     In the case of option this is always `option`. */
     type: 'option',
+    /* The data of the selected option. */
+    data: any,
   };
 
 export const optionCSS = ({


### PR DESCRIPTION
The `data` prop type is missing in the docs here https://react-select.com/props, it exists in `Option` 's props.