### PR TITLE
AsyncSelect: Initialize state with `inputValue` when `defaultOptions` is true

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -47,7 +47,7 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
         defaultOptions: Array.isArray(props.defaultOptions)
           ? props.defaultOptions
           : undefined,
-        inputValue: '',
+        inputValue: props.inputValue,
         isLoading: props.defaultOptions === true ? true : false,
         loadedOptions: [],
         passEmptyOptions: false,
@@ -56,8 +56,9 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
     componentDidMount() {
       this.mounted = true;
       const { defaultOptions } = this.props;
+      const { inputValue } = this.state;
       if (defaultOptions === true) {
-        this.loadOptions('', options => {
+        this.loadOptions(inputValue, options => {
           if (!this.mounted) return;
           const isLoading = !!this.lastRequest;
           this.setState({ defaultOptions: options || [], isLoading });


### PR DESCRIPTION
Passes the `inputValue` to initial `loadOptions` request when `defaultOptions` is set to `true`.

Resolves #3160