### PR TITLE
Disable focusable when isDisabled=true and isSearchable=false

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1354,6 +1354,7 @@ export default class Select extends Component<Props, State> {
           onChange={noop}
           onFocus={this.onInputFocus}
           readOnly
+          disabled={isDisabled}
           tabIndex={tabIndex}
           value=""
         />


### PR DESCRIPTION
When props.isSearchable is false, isDisabled property is not passed to the DummyInput control. As a result user can focus Select even though it is disabled.
