### PR TITLE
Docs: Remove references to theme `colors.text`

### DIFF
--- a/docs/ExampleWrapper.js
+++ b/docs/ExampleWrapper.js
@@ -183,7 +183,6 @@ const Action = ({ css, tag: Tag = 'button', ...props }: ActionProps) => {
 
         ':hover': {
           backgroundColor: colors.neutral5,
-          color: colors.text,
           outline: 0,
         },
         ':active': {

--- a/docs/examples/Theme.js
+++ b/docs/examples/Theme.js
@@ -13,7 +13,6 @@ export default () => (
       borderRadius: 0,
       colors: {
       ...theme.colors,
-        text: 'orangered',
         primary25: 'hotpink',
         primary: 'black',
       },


### PR DESCRIPTION
## Reason for this PR
`colors.text` is no longer defined in the [theme](https://github.com/JedWatson/react-select/blob/master/src/theme.js) (removed in https://github.com/JedWatson/react-select/pull/2934/)


## Changes proposed in this PR
- Remove `text` property from the theme customisation [example](https://react-select.com/styles#overriding-the-theme).

- Remove reference to `colors.text` in `ExampleWrapper`  
(It was supposedly being used for the color of action icons on hover, but it looks fine without)
![peek 2018-11-02 14-33](https://user-images.githubusercontent.com/18108338/47918256-51a04800-deac-11e8-8b9e-d0360b7950e7.gif)


