### PR TITLE
Docs: Add theme colors to docs

### DIFF
--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -3,6 +3,8 @@ import Helmet from 'react-helmet';
 import md from '../../markdown/renderer';
 import ExampleWrapper from '../../ExampleWrapper';
 import { StyledSingle, StyledMulti, Theme } from '../../examples';
+import { ColorSample } from '../../styled-components';
+import { defaultTheme } from '../../../src/theme';
 
 export default function Styles() {
   return (
@@ -162,6 +164,14 @@ export default function Styles() {
       >
         <Theme />
       </ExampleWrapper>
+    )}
+
+    ###### Theme colors
+
+    ${(
+      <div css={{ marginTop: '1em' }}>
+        {Object.keys(defaultTheme.colors).map(key => <ColorSample key={key} name={key} color={defaultTheme.colors[key]} />)}
+      </div>
     )}
 
     `}

--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -170,7 +170,13 @@ export default function Styles() {
 
     ${(
       <div css={{ marginTop: '1em' }}>
-        {Object.keys(defaultTheme.colors).map(key => <ColorSample key={key} name={key} color={defaultTheme.colors[key]} />)}
+        {Object.keys(defaultTheme.colors).map(key => (
+          <ColorSample
+            key={key}
+            name={key}
+            color={defaultTheme.colors[key]}
+          />
+        ))}
       </div>
     )}
 

--- a/docs/styled-components.js
+++ b/docs/styled-components.js
@@ -49,14 +49,29 @@ export const Note = ({ Tag = 'div', ...props }: { Tag?: string }) => (
 export const H1 = (props: any) => <h1 css={{ marginTop: 0 }} {...props} />;
 export const H2 = (props: any) => <h2 css={{ marginTop: '2em' }} {...props} />;
 
-export const ColorSample =
-  ({ name, color }: { color: string, name: string }) =>
-  (
-    <div css={{ display: 'inline-flex', marginBottom: '0.5em', alignItems: 'center', minWidth: '10em' }}>
-      <span title={color} css={{ marginRight: '0.5em', display: 'inline-block', borderRadius: '3px', width: '1em', height: '1em', backgroundColor: color }} />
-      <Code>{name}</Code>
-    </div>
-  );
+export const ColorSample = ({ name, color }: { color: string, name: string }) => (
+  <div
+    css={{
+      display: 'inline-flex',
+      marginBottom: '0.5em',
+      alignItems: 'center',
+      minWidth: '10em'
+    }}
+  >
+    <span
+      title={color}
+      css={{
+        marginRight: '0.5em',
+        display: 'inline-block',
+        borderRadius: 3,
+        width: '1em',
+        height: '1em',
+        backgroundColor: color
+      }}
+    />
+    <Code>{name}</Code>
+  </div>
+);
 
 // ==============================
 // Code

--- a/docs/styled-components.js
+++ b/docs/styled-components.js
@@ -49,6 +49,15 @@ export const Note = ({ Tag = 'div', ...props }: { Tag?: string }) => (
 export const H1 = (props: any) => <h1 css={{ marginTop: 0 }} {...props} />;
 export const H2 = (props: any) => <h2 css={{ marginTop: '2em' }} {...props} />;
 
+export const ColorSample =
+  ({ name, color }: { color: string, name: string }) =>
+  (
+    <div css={{ display: 'inline-flex', marginBottom: '0.5em', alignItems: 'center', minWidth: '10em' }}>
+      <span title={color} css={{ marginRight: '0.5em', display: 'inline-block', borderRadius: '3px', width: '1em', height: '1em', backgroundColor: color }} />
+      <Code>{name}</Code>
+    </div>
+  );
+
 // ==============================
 // Code
 // ==============================


### PR DESCRIPTION
## Reason for this PR
- When trying to override theme colors, I had to check the source code to find out which keys to use. I think adding the keys into the documentation would make things easier for users. Also open to other suggestions :slightly_smiling_face: 

## Changes proposed in this PR
- Expose keys and default values of all `theme.colors` in documentation, in order to make it easier for users to take advantage of the `theme` prop.
- Added `ColorSample` component

## Screenshot of changes
![image](https://user-images.githubusercontent.com/18108338/47922570-adbc9980-deb7-11e8-8270-d82ce5dc5a77.png)
