### PR TITLE
Adds a primitive typing to String in the compareOption function.

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -36,10 +36,10 @@ export type CreatableProps = {
 export type Props = SelectProps & CreatableProps;
 
 const compareOption = (inputValue, option) => {
-  const candidate = inputValue.toLowerCase();
+  const candidate = String.toString(inputValue).toLowerCase();
   return (
-    option.value.toLowerCase() === candidate ||
-    option.label.toLowerCase() === candidate
+    String.toString(option.value).toLowerCase() === candidate ||
+    String.toString(option.label).toLowerCase() === candidate
   );
 };
 


### PR DESCRIPTION
This allows the compare function to work on any typing that might be provided to the selectOptions interface.

number typing fails in typescript 