### PR TITLE
Fix link to components docs

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -118,7 +118,7 @@ export type Props = {
 
     If you only wish to restyle a component, we recommend using the `styles` prop
     instead. For a list of the components that can be passed in, and the shape
-    that will be passed to them, see [the components docs](/api#components)
+    that will be passed to them, see [the components docs](/components)
   */
   components: SelectComponentsConfig,
   /* Whether the value of the select, e.g. SingleValue, should be displayed in the control. */


### PR DESCRIPTION
It's currently pointing to `/api#components`, but that appears to be
a link to the old docs, and ends up just redirecting to the home
page of the new docs.

Fix this by using the new path to the components docs.

---

Verified that link is fixed in a local dev environment as
per contributing guidelines.