### PR TITLE
Menu: constrain to a maximum of maxHeight

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -131,14 +131,13 @@ export function getMenuPlacement({
       if (placement === 'auto' || isFixedPosition) {
         // may need to be constrained after flipping
         let constrainedHeight = maxHeight;
+        const spaceAbove = isFixedPosition ? viewSpaceAbove : scrollSpaceAbove;
 
-        if (
-          (!isFixedPosition && scrollSpaceAbove >= minHeight) ||
-          (isFixedPosition && viewSpaceAbove >= minHeight)
-        ) {
-          constrainedHeight = isFixedPosition
-            ? viewSpaceAbove - marginBottom - spacing.controlHeight
-            : scrollSpaceAbove - marginBottom - spacing.controlHeight;
+        if (spaceAbove >= minHeight) {
+          constrainedHeight = Math.min(
+            spaceAbove - marginBottom - spacing.controlHeight,
+            maxHeight
+          );
         }
 
         return { placement: 'top', maxHeight: constrainedHeight };


### PR DESCRIPTION
When automatically flipping, the menu constraint math may result in a "constrained" height that exceeds the original max height.

This change uses `Math.min` to choose the constrained height only when it is _less_ than the original `maxHeight`.

I made these changes with the web UI so I have not had a chance yet to run the tests/lints, will do that when I get a chance.