### PR TITLE
Respect `isClearable` and `isMulti` in `backspaceRemovesValue`

### DIFF
--- a/cypress/integration/select_spec.js
+++ b/cypress/integration/select_spec.js
@@ -133,6 +133,17 @@ describe('New Select', function() {
             .get(selector.noOptionsValue)
             .should('contain', 'No options');
         });
+
+        it('Should not clear the value when backspace is pressed ' + view, function() {
+          cy
+            .get(selector.singleBasicSelect)
+            .click()
+            .find('input')
+            .type('{backspace}', { force: true })
+            .get(selector.singleBasicSelect)
+            .find(selector.placeholder)
+            .should('not.be.visible');
+        });
       });
     });
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -1137,7 +1137,7 @@ export default class Select extends Component<Props, State> {
           if (!backspaceRemovesValue) return;
           if (isMulti) {
             this.popValue();
-          } else {
+          } else if (isClearable) {
             this.clearValue();
           }
         }

--- a/src/Select.js
+++ b/src/Select.js
@@ -1135,7 +1135,11 @@ export default class Select extends Component<Props, State> {
           this.removeValue(focusedValue);
         } else {
           if (!backspaceRemovesValue) return;
-          this.popValue();
+          if (isMulti) {
+            this.popValue();
+          } else {
+            this.clearValue();
+          }
         }
         break;
       case 'Tab':

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1416,6 +1416,40 @@ test('should not call onChange on hitting backspace even when backspaceRemovesVa
   expect(onChangeSpy).not.toHaveBeenCalled();
 });
 
+test('should call onChange with `null` on hitting backspace when backspaceRemovesValue is true and isMulti is false', () => {
+  let onChangeSpy = jest.fn();
+  let selectWrapper = mount(
+    <Select
+      {...BASIC_PROPS}
+      backspaceRemovesValue
+      isClearable
+      isMulti={false}
+      onChange={onChangeSpy}
+    />
+  );
+  selectWrapper
+    .find(Control)
+    .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
+  expect(onChangeSpy).toHaveBeenCalledWith(null, { action: 'clear' });
+});
+
+test('should call onChange with an array on hitting backspace when backspaceRemovesValue is true and isMulti is true', () => {
+  let onChangeSpy = jest.fn();
+  let selectWrapper = mount(
+    <Select
+      {...BASIC_PROPS}
+      backspaceRemovesValue
+      isClearable
+      isMulti
+      onChange={onChangeSpy}
+    />
+  );
+  selectWrapper
+    .find(Control)
+    .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
+  expect(onChangeSpy).toHaveBeenCalledWith([], { action: 'pop-value' });
+});
+
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {
   let onChangeSpy = jest.fn();
   let selectWrapper = mount(

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1400,6 +1400,22 @@ test('should not call onChange on hitting backspace when backspaceRemovesValue i
   expect(onChangeSpy).not.toHaveBeenCalled();
 });
 
+test('should not call onChange on hitting backspace even when backspaceRemovesValue is true if isClearable is false', () => {
+  let onChangeSpy = jest.fn();
+  let selectWrapper = mount(
+    <Select
+      {...BASIC_PROPS}
+      backspaceRemovesValue
+      isClearable={false}
+      onChange={onChangeSpy}
+    />
+  );
+  selectWrapper
+    .find(Control)
+    .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
+  expect(onChangeSpy).not.toHaveBeenCalled();
+});
+
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {
   let onChangeSpy = jest.fn();
   let selectWrapper = mount(


### PR DESCRIPTION
Currently, `backspaceRemovesValue` seems to assume that the select component is both clearable, and a multi-select.  This PR will change the following behavior:

- The `clear` action will be used when `isMulti` is `false.
- Nothing will happen when backspace or delete is pressed if `isMulti` is false _and_ `isClearable` is also `false`.
- When `isMulti` is true, this PR changes no behavior, and `isClearable` still has no impact.  I'm not sure if it should or not, but wanted to limit the scope of this PR to only non-multi components.

Fixes #2682
Fixes #1560

Seemingly duplicates:
Closes #2804
Closes #3129
Closes #1344
Closes #1215