### PR TITLE
Fix broken link to examples/CustomFilterOptions.js in index.js

### DIFF
--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -57,9 +57,9 @@ export default function Advanced() {
 
       ${(
         <ExampleWrapper
-          label="Custom filterOption with createFilter"
-          urlPath="docs/examples/CreateFilter.js"
-          raw={require('!!raw-loader!../../examples/CreateFilter.js')}
+          label="Custom filterOption from ground up"
+          urlPath="docs/examples/CustomFilterOptions.js"
+          raw={require('!!raw-loader!../../examples/CustomFilterOptions.js')}
         >
           <CustomFilterOptions />
         </ExampleWrapper>


### PR DESCRIPTION
The link must point to examples/CustomFilterOptions.js This was probably a copy'n'paste error from the paragraph above. The links in the rest of the file seem fine (I checked).