### PR TITLE
Add a line to the docs homepage explaining what Creatable is used for

### DIFF
--- a/docs/pages/home/index.js
+++ b/docs/pages/home/index.js
@@ -162,6 +162,8 @@ export default function Home() {
   You can see a full explanation of how to do this on the [async](/async) page.
 
   # Creatable
+  The Creatable component enables users to create new options along with choosing existing options.
+
 
   ~~~jsx
   import Creatable from 'react-select/lib/Creatable';

--- a/docs/pages/home/index.js
+++ b/docs/pages/home/index.js
@@ -164,7 +164,6 @@ export default function Home() {
   # Creatable
   The Creatable component enables users to create new options along with choosing existing options.
 
-
   ~~~jsx
   import Creatable from 'react-select/lib/Creatable';
   ~~~


### PR DESCRIPTION
I wasted time trying to figure out how to enable users to add new options before realizing that this capability was already there in Creatable, but the docs didn't actually explain what Creatable was. This PR adds a line to the docs to explain. 