### PR TITLE
Pass selectProps to Input component

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1381,7 +1381,7 @@ export default class Select extends Component<Props, State> {
       'aria-labelledby': this.props['aria-labelledby'],
     };
 
-    const { cx, theme } = this.commonProps;
+    const { cx, theme, selectProps } = this.commonProps;
 
     return (
       <Input
@@ -1397,6 +1397,7 @@ export default class Select extends Component<Props, State> {
         onBlur={this.onInputBlur}
         onChange={this.handleInputChange}
         onFocus={this.onInputFocus}
+        selectProps={selectProps}
         spellCheck="false"
         tabIndex={tabIndex}
         theme={theme}


### PR DESCRIPTION
I ran into an issue with this a few months when attempting to create a custom `Input` component, and not having any way to pass props to that custom component. I've seen a few mentions of this in other issues and thought I'd just create a PR for it.

I noticed that a handful of other components don't have `selectProps`, and was curious if there is a reason for not passing `selectProps` to every component that can be customized.