### PR TITLE
Use isOptionSelected to find selectedIndex

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -484,7 +484,7 @@ export default class Select extends Component<Props, State> {
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
     if (!isMulti) {
-      const selectedIndex = menuOptions.focusable.indexOf(selectValue[0]);
+      const selectedIndex = menuOptions.focusable.findIndex((e) => this.isOptionSelected(e, selectValue));
       if (selectedIndex > -1) {
         openAtIndex = selectedIndex;
       }


### PR DESCRIPTION
The selectedIndex is not always consistent when using Array.indexOf(). indexOf() will not work correctly when the isOptionSelected is overriten, or the selectValue is a clone of the Option object and is not in Options.