### PR TITLE
Pressing <Tab> in IME mode should not enter a option

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1158,6 +1158,8 @@ export default class Select extends Component<Props, State> {
         }
         break;
       case 'Tab':
+        if (isComposing) return;
+
         if (
           event.shiftKey ||
           !menuIsOpen ||

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1449,7 +1449,7 @@ test('should call onChange with an array on hitting backspace when backspaceRemo
   selectWrapper
     .find(Control)
     .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
-  expect(onChangeSpy).toHaveBeenCalledWith([], { action: 'pop-value', name: 'test-input-name' });
+  expect(onChangeSpy).toHaveBeenCalledWith([], { action: 'pop-value', name: 'test-input-name', removedValue: undefined });
 });
 
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {


### PR DESCRIPTION
Fix the tab behavior with IME.

Fixes #3295 

## ref

https://github.com/JedWatson/react-select/pull/2767