### PR TITLE
Allow 'focusOption' to define menu item to focus when input is cleared

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -136,6 +136,8 @@ export type Props = {
     An example can be found in the [Replacing builtins](/advanced#replacing-builtins) documentation.
   */
   formatGroupLabel: typeof formatGroupLabel,
+  /* Focuses option when input is cleared or when no value is selected */
+  focusedOption: Object,
   /* Formats option labels in the menu and control as React components */
   formatOptionLabel?: (OptionType, FormatOptionLabelMeta) => Node,
   /* Resolves option data to a string to be displayed as the label by components */
@@ -465,6 +467,9 @@ export default class Select extends Component<Props, State> {
     this.props.onMenuClose();
   }
   onInputChange(newValue: string, actionMeta: InputActionMeta) {
+    if (newValue === undefined && this.props.hasOwnProperty('focusedOption')) {
+      this.setState({ focusedOption: this.props.focusedOption });
+    }
     this.props.onInputChange(newValue, actionMeta);
   }
 


### PR DESCRIPTION
Adds the behaviour to auto focus the 'focusedOption' (if defined in props) when the input field if cleared. 

Issue:
[#3269](https://github.com/JedWatson/react-select/issues/3269)