### PR TITLE
Auto focus disabled with a new prop

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -487,7 +487,7 @@ export default class Select extends Component<Props, State> {
 
   openMenu(focusOption: 'first' | 'last') {
     const { menuOptions, selectValue } = this.state;
-    const { isMulti } = this.props;
+    const { isMulti, disableAutoFocus } = this.props;
     let openAtIndex =
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
@@ -504,7 +504,7 @@ export default class Select extends Component<Props, State> {
     this.onMenuOpen();
     this.setState({
       focusedValue: null,
-      focusedOption: menuOptions.focusable[openAtIndex],
+      focusedOption: disableAutoFocus ? null : menuOptions.focusable[openAtIndex],
     });
 
     this.announceAriaLiveContext({ event: 'menu' });


### PR DESCRIPTION
#2848 #3061 
Above issues could be resolved with this enhancement

@gwyneplaine I've added a new prop `disableAutoFocus`, which allows deactivation of auto focus of first or any option on opening of the option menu.