### PR TITLE
local instance of emotion not declared before use in A11yText.js

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -340,6 +340,7 @@ export default class Select extends Component<Props, State> {
   openAfterFocus: boolean = false;
   scrollToFocusedOptionOnUpdate: boolean = false;
   userIsDragging: ?boolean;
+  emotion: getEmotion();
 
   // Refs
   // ------------------------------


### PR DESCRIPTION
Local instance of emotion variable in Select component is not declared before use in A11yText.js. This causes a warning when rendering A11yText. 