### PR TITLE
Fix load options onmount

### DIFF
--- a/docs/examples/AccessingInternals.js
+++ b/docs/examples/AccessingInternals.js
@@ -7,12 +7,9 @@ import { Note } from '../styled-components';
 import { colourOptions } from '../data';
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const promiseOptions = inputValue =>

--- a/docs/examples/AsyncCallbacks.js
+++ b/docs/examples/AsyncCallbacks.js
@@ -8,12 +8,9 @@ type State = {
 };
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const loadOptions = (inputValue, callback) => {

--- a/docs/examples/AsyncCreatable.js
+++ b/docs/examples/AsyncCreatable.js
@@ -4,12 +4,9 @@ import AsyncCreatableSelect from '../../src/AsyncCreatable';
 import { colourOptions } from '../data';
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const promiseOptions = inputValue =>

--- a/docs/examples/AsyncMulti.js
+++ b/docs/examples/AsyncMulti.js
@@ -8,12 +8,9 @@ type State = {
 };
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const promiseOptions = inputValue =>

--- a/docs/examples/AsyncPromises.js
+++ b/docs/examples/AsyncPromises.js
@@ -8,12 +8,9 @@ type State = {
 };
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+      i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const promiseOptions = inputValue =>

--- a/docs/examples/DefaultOptions.js
+++ b/docs/examples/DefaultOptions.js
@@ -8,12 +8,9 @@ type State = {
 };
 
 const filterColors = (inputValue: string) => {
-  if (inputValue) {
-    return colourOptions.filter(i =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase())
-      );
-  }
-  return colourOptions;
+  return colourOptions.filter(i =>
+    i.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
 };
 
 const promiseOptions = inputValue =>

--- a/docs/examples/StyledSingle.js
+++ b/docs/examples/StyledSingle.js
@@ -11,7 +11,7 @@ const dot = (color = '#ccc') => ({
   ':before': {
     backgroundColor: color,
     borderRadius: 10,
-    content: ' ',
+    content: '" "',
     display: 'block',
     marginRight: 8,
     height: 10,

--- a/src/Async.js
+++ b/src/Async.js
@@ -47,7 +47,7 @@ export const makeAsyncSelect = (SelectComponent: ComponentType<*>) =>
         defaultOptions: Array.isArray(props.defaultOptions)
           ? props.defaultOptions
           : undefined,
-        inputValue: props.inputValue,
+        inputValue: typeof props.inputValue !== 'undefined' ? props.inputValue : '',
         isLoading: props.defaultOptions === true ? true : false,
         loadedOptions: [],
         passEmptyOptions: false,

--- a/src/__tests__/Async.test.js
+++ b/src/__tests__/Async.test.js
@@ -43,6 +43,17 @@ cases(
   }
 );
 
+test('load options prop with defaultOptions true and inputValue prop', () => {
+  const loadOptionsSpy = jest.fn((value) => value);
+  const searchString = 'hello world';
+  mount(<Async
+      loadOptions={loadOptionsSpy}
+      defaultOptions
+      inputValue={searchString}
+    />);
+  expect(loadOptionsSpy).toHaveReturnedWith(searchString);
+});
+
 /**
  * loadOptions with promise is not resolved and it renders loading options
  * confirmed by logging in component that loadOptions is resolved and options are available


### PR DESCRIPTION
augmentation of the solution from #3161. 
InputValue should always be a string, if inputValue is not provided in props it should default to an empty string, not undefined.