### PR TITLE
Upgrade memoize one to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "emotion": "^9.1.2",
-    "memoize-one": "^4.0.0",
+    "memoize-one": "^5.0.0",
     "prop-types": "^15.6.0",
     "raf": "^3.4.0",
     "react-input-autosize": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,10 +7578,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
-  integrity sha512-wdpOJ4XBejprGn/xhd1i2XR8Dv1A25FJeIvR7syQhQlz9eXsv+06llcvcmBxlWVGv4C73QBsWA8kxvZozzNwiQ==
+memoize-one@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
+  integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Should resolve issue: #3369

Mayor change for v5 was signature for equality function:

https://github.com/alexreardon/memoize-one/tree/v4.1.0#equality-function-type-signature
https://github.com/alexreardon/memoize-one/tree/v5.0.0#custom-equality-function

`react-select` doesn't use it in [compare function](https://github.com/JedWatson/react-select/blob/master/src/internal/react-fast-compare.js#L7) so it can be safely upgraded. 