### PR TITLE
replace event.target to event.currentTarget

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -886,13 +886,11 @@ export default class Select extends Component<Props, State> {
     } else if (!this.props.menuIsOpen) {
       this.openMenu('first');
     } else {
-      // $FlowFixMe HTMLElement type does not have tagName property
-      if (event.target.tagName !== 'INPUT') {
+      if (event.currentTarget.tagName !== 'INPUT') {
         this.onMenuClose();
       }
     }
-    // $FlowFixMe HTMLElement type does not have tagName property
-    if (event.target.tagName !== 'INPUT') {
+    if (event.currentTarget.tagName !== 'INPUT') {
       event.preventDefault();
     }
   };
@@ -1012,15 +1010,12 @@ export default class Select extends Component<Props, State> {
   onTouchEnd = (event: TouchEvent) => {
     if (this.userIsDragging) return;
 
-    // type cast the EventTarget
-    const target = ((event.target: any): HTMLElement);
-
     // close the menu if the user taps outside
     if (
       this.controlRef &&
-      !this.controlRef.contains(target) &&
+      !this.controlRef.contains(event.currentTarget) &&
       this.menuListRef &&
-      !this.menuListRef.contains(target)
+      !this.menuListRef.contains(event.currentTarget)
     ) {
       this.blurInput();
     }


### PR DESCRIPTION
fix flow error in Select.js, related to #3350

The reason why you want to use event.currentTarget is that event.target may be the wrong element due to [event propagation](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Examples#Example_5:_Event_Propagation).
see more in:
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
- https://flow.org/en/docs/react/events/

flow types from react
```
declare class SyntheticEvent<+T: EventTarget = EventTarget, +E: Event = Event> {
  bubbles: boolean;
  cancelable: boolean;
  +currentTarget: T;
  defaultPrevented: boolean;
  eventPhase: number;
  isDefaultPrevented(): boolean;
  isPropagationStopped(): boolean;
  isTrusted: boolean;
  nativeEvent: E;
  preventDefault(): void;
  stopPropagation(): void;
  // This should not be `T`. Use `currentTarget` instead. See:
  // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
  +target: EventTarget;
  timeStamp: number;
  type: string;
  persist(): void;
}
```