### PR TITLE
Make MultiValueContainer's heading consistent

### DIFF
--- a/docs/pages/components/index.js
+++ b/docs/pages/components/index.js
@@ -350,7 +350,7 @@ export default function Components() {
         true. Takes responsibility for rendering the \`MultiValueContainer\`,
         \`MultiValueLabel\`, and \`MultiValueRemove\`.
 
-        #### MultiValueContainer
+        ### MultiValueContainer
 
         Wraps the Label and Remove in a Multi Value
 


### PR DESCRIPTION
The heading is currently an h4 but should be an h3 like all the rest. Yup, I'm doing this because it matters; I missed it the first time through the doc due to that.