### PR TITLE
Feature: cx-function as a Prop

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -63,6 +63,7 @@ import type {
   OptionsType,
   OptionType,
   ValueType,
+  ClassNamesState,
 } from './types';
 
 type MouseOrTouchEvent =
@@ -244,6 +245,9 @@ export type Props = {
   tabSelectsValue: boolean,
   /* The value of the select; reflected by the selected option */
   value: ValueType,
+
+  /* External cx-function. */
+  cxx?: (?string | null, ClassNamesState | void, string | void) => string | void,
 };
 
 export const defaultProps = {
@@ -704,12 +708,12 @@ export default class Select extends Component<Props, State> {
 
   getCommonProps() {
     const { clearValue, getStyles, setValue, selectOption, props } = this;
-    const { classNamePrefix, isMulti, isRtl, options } = props;
+    const { classNamePrefix, isMulti, isRtl, options, cxx } = props;
     const { selectValue } = this.state;
     const hasValue = this.hasValue();
     const getValue = () => selectValue;
 
-    const cx = classNames.bind(null, classNamePrefix);
+    const cx = cxx || classNames.bind(null, classNamePrefix);
     return {
       cx,
       clearValue,


### PR DESCRIPTION
Pretty small change should be self-explanatory.

Motivation: I'm using css-modules & would like to keep my styling for react-select together with component's style I use it with.

I've found it the easiest to simply pass my own cx function (that is already bound with my styles loaded) to the Select component, and thus, to everything else.

This allows me simply target 'control', 'indicator' and all other classes in my css files.

Any chance this can be a useful feature for react-select? If so - what documentation / tests/ anything you want me to add to this PR?

Thank You!