### PR TITLE
fix MenuList scrolling issue in IE11 with openMenuOnFocus option

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -480,7 +480,7 @@ export default class Select extends Component<Props, State> {
   blur = this.blurInput;
 
   openMenu(focusOption: 'first' | 'last') {
-    const { menuOptions, selectValue } = this.state;
+    const { menuOptions, selectValue, isFocused } = this.state;
     const { isMulti } = this.props;
     let openAtIndex =
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
@@ -492,7 +492,8 @@ export default class Select extends Component<Props, State> {
       }
     }
 
-    this.scrollToFocusedOptionOnUpdate = true;
+    // only scroll if the menu isn't already open
+    this.scrollToFocusedOptionOnUpdate = !(isFocused && this.menuListRef);
     this.inputIsHiddenAfterUpdate = false;
 
     this.onMenuOpen();


### PR DESCRIPTION
seems related to 30ead6d, a fix for the MenuList closing when the
scrollbar is clicked in IE11.  When the select input is refocused, the
openMenu method re-scrolls MenuList to the currently selected value,
causing the user to be unable to scroll to other values via mouse click

fixes #3342