### PR TITLE
fix custom filter function example in docs

### DIFF
--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -57,9 +57,9 @@ export default function Advanced() {
 
       ${(
         <ExampleWrapper
-          label="Custom filterOption with createFilter"
-          urlPath="docs/examples/CreateFilter.js"
-          raw={require('!!raw-loader!../../examples/CreateFilter.js')}
+          label="Custom filterOption function"
+          urlPath="docs/examples/CustomFilterOptions.js"
+          raw={require('!!raw-loader!../../examples/CustomFilterOptions.js')}
         >
           <CustomFilterOptions />
         </ExampleWrapper>


### PR DESCRIPTION
There are [two custom custom filter examples](https://react-select.com/advanced#custom-filter-logic) on the advanced page of the docs. The `ExampleWrapper` of the second one has the same label and raw code as the first one, instead of the actual example component that gets rendered.