### PR TITLE
3.x Normalise value removal

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -645,8 +645,9 @@ export default class Select extends Component<Props, State> {
   removeValue = (removedValue: OptionType) => {
     const { selectValue } = this.state;
     const candidate = this.getOptionValue(removedValue);
+    const newValue = selectValue.filter(i => this.getOptionValue(i) !== candidate);
     this.onChange(
-      selectValue.filter(i => this.getOptionValue(i) !== candidate),
+      newValue.length ? newValue : null,
       {
         action: 'remove-value',
         removedValue,
@@ -667,13 +668,14 @@ export default class Select extends Component<Props, State> {
   popValue = () => {
     const { selectValue } = this.state;
     const lastSelectedValue = selectValue[selectValue.length - 1];
+    const newValue = selectValue.slice(0, selectValue.length - 1);
     this.announceAriaLiveSelection({
       event: 'pop-value',
       context: {
         value: lastSelectedValue ? this.getOptionLabel(lastSelectedValue) : '',
       },
     });
-    this.onChange(selectValue.slice(0, selectValue.length - 1), {
+    this.onChange(newValue.length ? newValue : null, {
       action: 'pop-value',
       removedValue: lastSelectedValue,
     });

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1448,39 +1448,44 @@ test('should not call onChange on hitting backspace even when backspaceRemovesVa
   expect(onChangeSpy).not.toHaveBeenCalled();
 });
 
-test('should call onChange with `null` on hitting backspace when backspaceRemovesValue is true and isMulti is false', () => {
+cases('should call onChange with `null` on hitting backspace when backspaceRemovesValue is true', ({ props = { ...BASIC_PROPS }, expectedValue }) => {
   let onChangeSpy = jest.fn();
   let selectWrapper = mount(
     <Select
-      {...BASIC_PROPS}
+      {...props}
       backspaceRemovesValue
       isClearable
-      isMulti={false}
       onChange={onChangeSpy}
     />
   );
   selectWrapper
     .find(Control)
     .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
-  expect(onChangeSpy).toHaveBeenCalledWith(null, { action: 'clear', name: 'test-input-name' });
+  expect(onChangeSpy).toHaveBeenCalledWith(null, expectedValue);
+}, {
+  'and isMulti is false': {
+    props: {
+      ...BASIC_PROPS,
+      isMulti: false,
+    },
+    expectedValue: {
+      action: 'clear',
+      name: 'test-input-name',
+    }
+  },
+  'and isMulti is true': {
+    props: {
+      ...BASIC_PROPS,
+      isMulti: true,
+    },
+    expectedValue: {
+      action: 'pop-value',
+      name: 'test-input-name',
+      removedValue: undefined
+    }
+  },
 });
 
-test('should call onChange with an array on hitting backspace when backspaceRemovesValue is true and isMulti is true', () => {
-  let onChangeSpy = jest.fn();
-  let selectWrapper = mount(
-    <Select
-      {...BASIC_PROPS}
-      backspaceRemovesValue
-      isClearable
-      isMulti
-      onChange={onChangeSpy}
-    />
-  );
-  selectWrapper
-    .find(Control)
-    .simulate('keyDown', { keyCode: 8, key: 'Backspace' });
-  expect(onChangeSpy).toHaveBeenCalledWith([], { action: 'pop-value', name: 'test-input-name', removedValue: undefined });
-});
 
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {
   let onChangeSpy = jest.fn();


### PR DESCRIPTION
At the moment, if no value is specified by the consumer, it's instantiated as a null value, regardless of whether the select isMulti or not. 

When isMulti is false this is fine. On selection of an option, the value becomes an object, and on clearing of said value, it returns to being null. (null --> {} --> null)

However when isMulti is true, this becomes more inconsistent. On selection of options, the value becomes an array of options, removing values extricates them from this array, removing the last selected value results in an empty array, instead of the initial base state of null. (null --> [{}] --> []) 

This PR aims to resolve this inconsistency with the view that when isMulti is true, the value should resolve back to a null when no more options are left in the array, especially since the serialized form value is computed from cleanValue(), which converts null values to an empty array anyways. 

@JedWatson @jossmac, is there any context behind this decision that I'm not aware of? 
As an aside this change will make supporting the isRequired prop substantially less complex. 
