### PR TITLE
Fixed crash when the scrollTarget is undefined in ScrollCaptor

### DIFF
--- a/src/internal/ScrollCaptor.js
+++ b/src/internal/ScrollCaptor.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component, type Element } from 'react';
+
 import NodeResolver from './NodeResolver';
 
 export type CaptorProps = {
@@ -25,6 +26,7 @@ class ScrollCaptor extends Component<CaptorProps> {
   }
   startListening(el: HTMLElement) {
     // bail early if no scroll available
+    if (!el) return;
     if (el.scrollHeight <= el.clientHeight) return;
 
     // all the if statements are to appease Flow 😢


### PR DESCRIPTION
Fix the following crash in react-select 2.3.0:

> Uncaught TypeError: Cannot read property 'scrollHeight' of undefined
> at ScrollCaptor.startListening (react-select.esm.js:1353)
> at ScrollCaptor.componentDidMount (react-select.esm.js:1342)
> at commitLifeCycles (react-dom.development.js:14685)
> at commitAllLifeCycles (react-dom.development.js:15905)
> at HTMLUnknownElement.callCallback (react-dom.development.js:145)
> at Object.invokeGuardedCallbackDev (react-dom.development.js:195)
> at invokeGuardedCallback (react-dom.development.js:248)
> at commitRoot (react-dom.development.js:16075)
> at completeRoot (react-dom.development.js:17463)
> at performWorkOnRoot (react-dom.development.js:17391)
> at performWork (react-dom.development.js:17295)
> at performSyncWork (react-dom.development.js:17267)
> at interactiveUpdates$1 (react-dom.development.js:17558)
> at interactiveUpdates (react-dom.development.js:2208)
> at dispatchInteractiveEvent (react-dom.development.js:4913)`

The crash produced because of the following code:

> &lt;NodeResolver innerRef={this.getScrollTarget}>
> {this.props.children}
> &lt;/NodeResolver>

in class ScrollCaptor which is expected to set this.scrollTarget before componentDidMount from ScrollCaptor is called. But NodeResolver calls this.props.innerRef function also in componentDidMount so there is sometimes a time race condition triggered. And it let this.getScrollTarget undefined when componentDidMount from ScrollCaptor executes this.startListening(this.scrollTarget)

The workaround to this crash is to set the props captureMenuScroll={false} of Select as the default value is true because of 
`captureMenuScroll boolean = !isTouchCapable()`
