### PR TITLE
Fix #2805

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -884,7 +884,9 @@ export default class Select extends Component<Props, State> {
       }
       this.focusInput();
     } else if (!this.props.menuIsOpen) {
-      this.openMenu('first');
+      if (openMenuOnClick) {
+        this.openMenu('first');
+      }
     } else {
       // $FlowFixMe HTMLElement type does not have tagName property
       if (event.target.tagName !== 'INPUT') {

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -742,6 +742,17 @@ cases(
   }
 );
 
+test('clicking when focused does not open select when openMenuOnClick=false', () => {
+  let spy = jest.fn();
+  let selectWrapper = mount(<Select {...BASIC_PROPS} openMenuOnClick={false} onMenuOpen={spy} />);
+
+  // this will get updated on input click, though click on input is not bubbling up to control component
+  selectWrapper.setState({ isFocused: true });
+  let controlComponent = selectWrapper.find('div.react-select__control');
+  controlComponent.simulate('mouseDown', { target: { tagName: 'div' } });
+  expect(spy).not.toHaveBeenCalled();
+});
+
 cases(
   'focus on options > keyboard interaction with Menu',
   ({ props, selectedOption, nextFocusOption, keyEvent = [] }) => {


### PR DESCRIPTION
This prevents the select from opening when clicked (and already focused) when openMenuOnClick=false

Rebased master ontop of this PR from @rscotten
https://github.com/JedWatson/react-select/pull/3334

Thanks @caleb for the unit tests and the rebase 👍 
