### PR TITLE
export makeAsyncSelect and makeCreatableSelect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,9 @@ import manageState from './stateManager';
 export default manageState<ElementConfig<typeof SelectBase>>(SelectBase);
 
 export { SelectBase };
-export { default as Async } from './Async';
+export { default as Async, makeAsyncSelect } from './Async';
 export { default as AsyncCreatable } from './AsyncCreatable';
-export { default as Creatable } from './Creatable';
+export { default as Creatable, makeCreatableSelect } from './Creatable';
 export { createFilter } from './filters';
 export { default as makeAnimated } from './animated/index';
 export { components } from './components/index';


### PR DESCRIPTION
### Description 
We are starting to see more and more use cases where complex components built around Selects need a good way to hook into async or creatable functionality. 

Exporting `makeAsyncSelect` and `makeCreatableSelect` as core exports seems like a good thing to do, to enable users to easily adopt async / creatable functionality into their custom selects. 