### PR TITLE
remove focusOption invocation on Enter key press

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1182,11 +1182,9 @@ export default class Select extends Component<Props, State> {
           if (!focusedOption) return;
           if (isComposing) return;
           this.selectOption(focusedOption);
-        } else {
-          this.focusOption('first');
-          return;
+          break;
         }
-        break;
+        return;
       case 'Escape':
         if (menuIsOpen) {
           this.inputIsHiddenAfterUpdate = false;


### PR DESCRIPTION
Menu opening on ENTER is not a thing in v2.x, therefore focusOption call when menuIsOpen is false shouldn't be a thing. 