### PR TITLE
Allow Node as placeholder

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -226,8 +226,8 @@ export type Props = {
   options: OptionsType,
   /* Number of options to jump in menu when page{up|down} keys are used */
   pageSize: number,
-  /* Placeholder text for the select value */
-  placeholder: string,
+  /* Placeholder for the select value */
+  placeholder: Node,
   /* Status to relay to screen readers */
   screenReaderStatus: ({ count: number }) => string,
   /*

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1837,19 +1837,28 @@ cases(
     'single select > should display default placeholder "Select..."': {},
     'single select > should display provided string placeholder': {
       props: {
+        ...BASIC_PROPS,
         placeholder: 'single Select...',
       },
       expectPlaceholder: 'single Select...',
     },
     'single select > should display provided node placeholder': {
       props: {
+        ...BASIC_PROPS,
         placeholder: <span>single Select...</span>,
       },
       expectPlaceholder: 'single Select...',
     },
-    'multi select > should display default placeholder "Select..."': {},
+    'multi select > should display default placeholder "Select..."': {
+      props: {
+        ...BASIC_PROPS,
+        isMulti: true
+      }
+    },
     'multi select > should display provided placeholder': {
       props: {
+        ...BASIC_PROPS,
+        isMulti: true,
         placeholder: 'multi Select...',
       },
       expectPlaceholder: 'multi Select...',

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1835,9 +1835,15 @@ cases(
   },
   {
     'single select > should display default placeholder "Select..."': {},
-    'single select > should display provided placeholder': {
+    'single select > should display provided string placeholder': {
       props: {
         placeholder: 'single Select...',
+      },
+      expectPlaceholder: 'single Select...',
+    },
+    'single select > should display provided node placeholder': {
+      props: {
+        placeholder: <span>single Select...</span>,
       },
       expectPlaceholder: 'single Select...',
     },


### PR DESCRIPTION
Fixes #1378

Even though Placeholder [accepts `Node` children](https://github.com/JedWatson/react-select/blob/a23e9cdd115e024ce9afb69082e5628ed2f0471e/src/components/Placeholder.js#L8), the `placeholder` prop on Select [expects `string` type](https://github.com/JedWatson/react-select/blob/a23e9cdd115e024ce9afb69082e5628ed2f0471e/src/Select.js#L230). This causes an unnecessary dev mode warning when using e.g. a React element as a placeholder, even though it already works.

This PR relaxes the prop type to allow any node as placeholder. I also fixed the placeholder tests to actually test what they say they test.