### PR TITLE
Fix documentation code link for Custom Filter Options

### DIFF
--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -58,8 +58,8 @@ export default function Advanced() {
       ${(
         <ExampleWrapper
           label="Custom filterOption with createFilter"
-          urlPath="docs/examples/CreateFilter.js"
-          raw={require('!!raw-loader!../../examples/CreateFilter.js')}
+          urlPath="docs/examples/CustomFilterOptions.js"
+          raw={require('!!raw-loader!../../examples/CustomFilterOptions.js')}
         >
           <CustomFilterOptions />
         </ExampleWrapper>


### PR DESCRIPTION
The "Custom Filter Options" section in the advanced usage guide displays the incorrect code sample. This PR replaces that code sample with the one corresponding to "Custom Filter Options".