### PR TITLE
Ignore keydown events on `Enter` in IME

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -1179,6 +1179,11 @@ export default class Select extends Component<Props, State> {
         this.selectOption(focusedOption);
         break;
       case 'Enter':
+        if (event.keyCode === 229) {
+          // ignore the keydown event from an Input Method Editor(IME)
+          // ref. https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
+          break;
+        }
         if (menuIsOpen) {
           if (!focusedOption) return;
           if (isComposing) return;

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1331,6 +1331,28 @@ cases(
   }
 );
 
+test('hitting Enter on option should not call onChange if the event comes from IME', () => {
+  let spy = jest.fn();
+  let selectWrapper = mount(
+    <Select
+      className="react-select"
+      classNamePrefix="react-select"
+      menuIsOpen
+      onChange={spy}
+      onInputChange={jest.fn()}
+      onMenuClose={jest.fn()}
+      options={OPTIONS}
+      tabSelectsValue={false}
+    />
+  );
+
+  let selectOption = selectWrapper.find('div.react-select__option').at(0);
+  selectWrapper.setState({ focusedOption: { label: '2', value: 'two' } });
+
+  selectOption.simulate('keyDown', { keyCode: 229, key: 'Enter' });
+  expect(spy).not.toHaveBeenCalled();
+});
+
 test('hitting tab on option should not call onChange if tabSelectsValue is false', () => {
   let spy = jest.fn();
   let selectWrapper = mount(


### PR DESCRIPTION
This PR is a bugfix and is helpful for people using an [input method editor(IME)](https://en.wikipedia.org/wiki/Input_method
)

e.g. `google input method`
https://www.google.com/intl/en/inputtools/services/features/input-method.html
<img width="1440" alt="screen_shot_0031-03-03_at_11_45_26" src="https://user-images.githubusercontent.com/1370842/53690246-4d2c6300-3daa-11e9-9678-430372dffd88.png">


## Problem
- There's a browser dependent difference in the way handling keydown events on Enter 
  - In Safari (confirmed with `Version 12.0.3 (12606.4.5.3.1)`), the event triggers `onChange` and selects an option consequently
  - In Chrome(confirmed with `Version 72.0.3626.119 (Official Build) (64-bit)`), the event does nothing on the browser, not affect the selected value. it just determines the IME value

## Expected behavior
-  Make browsers act in the same way aginst keydown events, especially the ones on Enter key
  - In my opinion, in this case, Safari is wrong. it should behave as like Chrome

## Proposal
- Ignore keydown events on Enter in IME
  - The specification on the key codes is mentioned in https://www.w3.org/TR/uievents
    - `If an Input Method Editor is processing key input and the event is keydown, return 229.`
    - https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
  - We can ignore events which satisfy `event.key === 'Enter'  && event.keyCode === 229` 



Please review and merge this one, thanks 🙇