### PR TITLE
Disabled options should be highlightable for accessibility

### DIFF
--- a/docs/data.js
+++ b/docs/data.js
@@ -1,6 +1,6 @@
 export const colourOptions = [
   { value: 'ocean', label: 'Ocean', color: '#00B8D9', isFixed: true },
-  { value: 'blue', label: 'Blue', color: '#0052CC', disabled: true },
+  { value: 'blue', label: 'Blue', color: '#0052CC', isDisabled: true },
   { value: 'purple', label: 'Purple', color: '#5243AA' },
   { value: 'red', label: 'Red', color: '#FF5630', isFixed: true },
   { value: 'orange', label: 'Orange', color: '#FF8B00' },

--- a/src/Select.js
+++ b/src/Select.js
@@ -588,6 +588,7 @@ export default class Select extends Component<Props, State> {
       focusedOption: options[nextFocus],
       focusedValue: null,
     });
+    this.announceAriaLiveContext({ event: 'menu', context: { isDisabled: isOptionDisabled(options[nextFocus]) } });
   }
   onChange = (newValue: ValueType, actionMeta: ActionMeta) => {
     const { onChange, name } = this.props;
@@ -610,9 +611,9 @@ export default class Select extends Component<Props, State> {
   };
   selectOption = (newValue: OptionType) => {
     const { blurInputOnSelect, isMulti } = this.props;
+    const { selectValue } = this.state;
 
     if (isMulti) {
-      const { selectValue } = this.state;
       if (this.isOptionSelected(newValue, selectValue)) {
         const candidate = this.getOptionValue(newValue);
         this.setValue(
@@ -625,18 +626,34 @@ export default class Select extends Component<Props, State> {
           context: { value: this.getOptionLabel(newValue) },
         });
       } else {
-        this.setValue([...selectValue, newValue], 'select-option', newValue);
+        if (!this.isOptionDisabled(newValue, selectValue)) {
+          this.setValue([...selectValue, newValue], 'select-option', newValue);
+          this.announceAriaLiveSelection({
+            event: 'select-option',
+            context: { value: this.getOptionLabel(newValue) },
+          });
+        } else {
+          // announce that option is disabled
+          this.announceAriaLiveSelection({
+            event: 'select-option',
+            context: { value: this.getOptionLabel(newValue), isDisabled: true },
+          });
+        }
+      }
+    } else {
+      if (!this.isOptionDisabled(newValue, selectValue)) {
+        this.setValue(newValue, 'select-option');
         this.announceAriaLiveSelection({
           event: 'select-option',
           context: { value: this.getOptionLabel(newValue) },
         });
+      } else {
+        // announce that option is disabled
+        this.announceAriaLiveSelection({
+          event: 'select-option',
+          context: { value: this.getOptionLabel(newValue), isDisabled: true },
+        });
       }
-    } else {
-      this.setValue(newValue, 'select-option');
-      this.announceAriaLiveSelection({
-        event: 'select-option',
-        context: { value: this.getOptionLabel(newValue) },
-      });
     }
 
     if (blurInputOnSelect) {
@@ -1294,7 +1311,7 @@ export default class Select extends Component<Props, State> {
           const children = items
             .map((child, i) => {
               const option = toOption(child, `${itemIndex}-${i}`);
-              if (option && !option.isDisabled) acc.focusable.push(child);
+              if (option) acc.focusable.push(child);
               return option;
             })
             .filter(Boolean);
@@ -1311,7 +1328,7 @@ export default class Select extends Component<Props, State> {
           const option = toOption(item, `${itemIndex}`);
           if (option) {
             acc.render.push(option);
-            if (!option.isDisabled) acc.focusable.push(item);
+            acc.focusable.push(item);
           }
         }
         return acc;

--- a/src/__tests__/constants.js
+++ b/src/__tests__/constants.js
@@ -20,6 +20,26 @@ export const OPTIONS = [
   { label: '16', value: 'sixteen' },
 ];
 
+export const OPTIONS_DISABLED = [
+  { label: '0', value: 'zero' },
+  { label: '1', value: 'one', isDisabled: true },
+  { label: '2', value: 'two' },
+  { label: '3', value: 'three' },
+  { label: '4', value: 'four' },
+  { label: '5', value: 'five' },
+  { label: '6', value: 'six' },
+  { label: '7', value: 'seven' },
+  { label: '8', value: 'eight' },
+  { label: '9', value: 'nine' },
+  { label: '10', value: 'ten' },
+  { label: '11', value: 'eleven' },
+  { label: '12', value: 'twelve' },
+  { label: '13', value: 'thirteen' },
+  { label: '14', value: 'fourteen' },
+  { label: '15', value: 'fifteen' },
+  { label: '16', value: 'sixteen' },
+];
+
 export const OPTIONS_NUMBER_VALUE = [
   { label: '0', value: 0 },
   { label: '1', value: 1 },

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -6,23 +6,24 @@ export type InstructionsContext = {
   isSearchable?: boolean,
   isMulti?: boolean,
   label?: string,
+  isDisabled?: boolean
 };
-export type ValueEventContext = { value: string };
+export type ValueEventContext = { value: string, isDisabled?: boolean };
 
 export const instructionsAriaMessage = (
   event: string,
   context?: InstructionsContext = {}
 ) => {
-  const { isSearchable, isMulti, label } = context;
+  const { isSearchable, isMulti, label, isDisabled } = context;
   switch (event) {
     case 'menu':
-      return 'Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.';
+      return `Use Up and Down to choose options${isDisabled ? '' : ', press Enter to select the currently focused option'}, press Escape to exit the menu, press Tab to select the option and exit the menu.`;
     case 'input':
       return `${label ? label : 'Select'} is focused ${
         isSearchable ? ',type to refine list' : ''
-      }, press Down to open the menu, ${
+        }, press Down to open the menu, ${
         isMulti ? ' press left to focus selected values' : ''
-      }`;
+        }`;
     case 'value':
       return 'Use left and right to toggle between focused values, press Backspace to remove the currently focused value';
   }
@@ -32,7 +33,7 @@ export const valueEventAriaMessage = (
   event: string,
   context: ValueEventContext
 ) => {
-  const { value } = context;
+  const { value, isDisabled } = context;
   if (!value) return;
   switch (event) {
     case 'deselect-option':
@@ -40,7 +41,7 @@ export const valueEventAriaMessage = (
     case 'remove-value':
       return `option ${value}, deselected.`;
     case 'select-option':
-      return `option ${value}, selected.`;
+      return isDisabled ? `option ${value} is disabled. Select another option.` : `option ${value}, selected.`;
   }
 };
 
@@ -66,7 +67,7 @@ export const optionFocusAriaMessage = ({
   getOptionLabel: (option: OptionType) => string,
   options: OptionsType,
 }) =>
-  `option ${getOptionLabel(focusedOption)} focused, ${options.indexOf(
+  `option ${getOptionLabel(focusedOption)} focused${focusedOption.isDisabled ? ' disabled' : ''}, ${options.indexOf(
     focusedOption
   ) + 1} of ${options.length}.`;
 
@@ -78,5 +79,5 @@ export const resultsAriaMessage = ({
   screenReaderMessage: string,
 }) =>
   `${screenReaderMessage}${
-    inputValue ? ' for search term ' + inputValue : ''
+  inputValue ? ' for search term ' + inputValue : ''
   }.`;


### PR DESCRIPTION
Fixes #3354 

- fixed test data
- make disabled options keyboard focusable
- changed aria message for when focusing a disabled option
- added aria message for when attempting to select a disabled option
- added tests for aria messaging + focusability + checking enter won't select a disabled option
- removed tests for skipping disabled options

Known issue: https://github.com/JedWatson/react-select/issues/3415

Possible enhancement: We should probably merge the render and focusable arrays because there's no longer a situation where an option should be rendered but not focusable. I started doing this but ran into a lot of issues due to the data structures of the array items being different, so I'm PR-ing this as is since it shouldn't be a blocking issue and I need to put my attention elsewhere atm :)