### PR TITLE
Change currentTarget to target in mousedown event

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -894,11 +894,13 @@ export default class Select extends Component<Props, State> {
         this.openMenu('first');
       }
     } else {
-      if (event.currentTarget.tagName !== 'INPUT') {
+      //$FlowFixMe
+      if (event.target.tagName !== 'INPUT') {
         this.onMenuClose();
       }
     }
-    if (event.currentTarget.tagName !== 'INPUT') {
+    //$FlowFixMe
+    if (event.target.tagName !== 'INPUT') {
       event.preventDefault();
     }
   };


### PR DESCRIPTION
There was a fix recently to allow the text in the select to be clicked in order to change the cursor position. (see https://github.com/JedWatson/react-select/pull/3060)

A recent change to how react select uses event.currentTarget has meant that the fix no longer works, but event.target needed to be used instead.