### PR TITLE
New controlled inputValue example + ability to click/select inputValue text

### DIFF
--- a/docs/examples/ControlledInputValue.js
+++ b/docs/examples/ControlledInputValue.js
@@ -1,0 +1,37 @@
+import React, { Component, Fragment } from 'react';
+
+import Select from '../../src';
+import { colourOptions } from '../data';
+
+type State = {
+  inputValue: string,
+};
+
+export default class controlledInputValue extends Component<*, State> {
+  state = {
+    inputValue: 'Default Input Value',
+  };
+  select: ElementRef<*>;
+  onInputChange = (inputValue, { action }) => {
+    if (action === 'input-change') {
+      this.setState(() => ({ inputValue }));
+    }
+  }
+  render() {
+    const { inputValue } = this.state;
+    return (
+      <Fragment>
+        <p><code>inputValue:</code> {inputValue}</p>
+        <Select
+          ref={(ref) => { this.select = ref; }}
+          isClearable
+          inputValue={inputValue}
+          onInputChange={this.onInputChange}
+          styles={{ menu: base => ({ ...base, position: 'relative' }) }}
+          name="color"
+          options={colourOptions}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -1,5 +1,6 @@
 export { default as AccessingInternals } from './AccessingInternals';
 export { default as ControlledMenu } from './ControlledMenu';
+export { default as ControlledInputValue } from './ControlledInputValue';
 export { default as AnimatedMulti } from './AnimatedMulti';
 export { default as AsyncCallbacks } from './AsyncCallbacks';
 export { default as AsyncCreatable } from './AsyncCreatable';

--- a/docs/pages/advanced/index.js
+++ b/docs/pages/advanced/index.js
@@ -6,6 +6,7 @@ import ExampleWrapper from '../../ExampleWrapper';
 import {
   AccessingInternals,
   ControlledMenu,
+  ControlledInputValue,
   OnSelectResetsInput,
   BasicGrouped,
   CreateFilter,
@@ -175,6 +176,7 @@ export default function Advanced() {
       )}
 
       ## Controlled Props
+      Explicitly manage the state of React-select via various controlled props.
 
       ${(
         <ExampleWrapper
@@ -183,6 +185,16 @@ export default function Advanced() {
           raw={require('!!raw-loader!../../examples/ControlledMenu.js')}
         >
           <ControlledMenu />
+        </ExampleWrapper>
+      )}
+
+      ${(
+        <ExampleWrapper
+          label="Example of controlled inputValue"
+          urlPath="docs/examples/ControlledInputValue.js"
+          raw={require('!!raw-loader!../../examples/ControlledInputValue.js')}
+        >
+          <ControlledInputValue />
         </ExampleWrapper>
       )}
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -883,7 +883,10 @@ export default class Select extends Component<Props, State> {
     this.blockOptionHover = false;
   };
   onControlMouseDown = (event: MouseOrTouchEvent) => {
-    const { openMenuOnClick } = this.props;
+    const {
+      openMenuOnClick,
+      inputValue
+    } = this.props;
     if (!this.state.isFocused) {
       if (openMenuOnClick) {
         this.openAfterFocus = true;
@@ -898,8 +901,11 @@ export default class Select extends Component<Props, State> {
         this.onMenuClose();
       }
     }
+
     if (event.currentTarget.tagName !== 'INPUT') {
-      event.preventDefault();
+      if (!inputValue) {
+        event.preventDefault();
+      }
     }
   };
   onDropdownIndicatorMouseDown = (event: MouseOrTouchEvent) => {


### PR DESCRIPTION
## Summary of Changes
- I've added a new condition around the `.preventDefault()` call as shown below.
- Added an example of controlled inputValue which helps showcase the motivation for this change

## Motivation for Change
In some cases, developers will control the prop `inputValue` as shown in the example below, so that it can be displayed and/or controlled by another component elsewhere in the application. This makes `react-select` behave more like a plain 'ol `<input>` that "also does autocomplete". This is often a compelling use case. 

The problem here is that the user now expects to be able to click around and highlight text within the `react-select` just like they can with a normal `<input>`, but they aren't able to. This change enables them to.

See this video showcasing what I mean: [See Video](https://www.youtube.com/watch?v=Lh71yoR2Pu0)

I've tested in Chrome on macOS and ran the tests and the change appears to be backwards compatible with all existing use cases. 

There certainly is a risk however, of introducing this change. Not sure what 2nd order consequences there will be to other developers.

And, I don't fully understand what role this `event.preventDefault()` plays in the code (can anyone comment who is intimately familiar with the internals?). I know that without it, the menu falls into some weird corner case... so it's necessary - just not when `inputValue` is present, it seems.