### PR TITLE
Fixed incorrect prop in upgrade guide

### DIFF
--- a/docs/pages/upgradeGuide/index.js
+++ b/docs/pages/upgradeGuide/index.js
@@ -162,10 +162,10 @@ be handled with the new styles API:
 
 ### Using classNames
 
-If you provide the \`className\` prop to react-select, all inner elements will
+If you provide the \`classNamePrefix\` prop to react-select, all inner elements will
 be given a className based on the one you have provided.
 
-For example, given \`className="react-select"\`, the DOM would roughtly look
+For example, given \`classNamePrefix="react-select"\`, the DOM would roughly look
 like this:
 
 ~~~html


### PR DESCRIPTION
The upgrade guide was mentioning `className` as the prop which would supply classes to sub-components, when in fact, it was `classNamePrefix` which did the job.