### PR TITLE
Update badge for build status to use CircleCI instead of TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NPM](https://img.shields.io/npm/v/react-select.svg)](https://www.npmjs.com/package/react-select)
-[![Build Status](https://travis-ci.org/JedWatson/react-select.svg?branch=master)](https://travis-ci.org/JedWatson/react-select)
+[![CircleCI](https://circleci.com/gh/JedWatson/react-select/tree/master.svg?style=svg)](https://circleci.com/gh/JedWatson/react-select/tree/master)
 [![Coverage Status](https://coveralls.io/repos/JedWatson/react-select/badge.svg?branch=master&service=github)](https://coveralls.io/github/JedWatson/react-select?branch=master)
 [![Supported by Thinkmill](https://thinkmill.github.io/badge/heart.svg)](http://thinkmill.com.au/?utm_source=github&utm_medium=badge&utm_campaign=react-select)
 


### PR DESCRIPTION
The old badge for the build status still uses TravisCI but react-select changed to CircleCI around 11 months ago