### PR TITLE
Added new props : autoFocusOption

### DIFF
--- a/docs/examples/AsyncCallbacks.js
+++ b/docs/examples/AsyncCallbacks.js
@@ -35,7 +35,7 @@ export default class WithCallbacks extends Component<*, State> {
           loadOptions={loadOptions}
           defaultOptions
           onInputChange={this.handleInputChange}
-        />
+          />
       </div>
     );
   }

--- a/docs/examples/AsyncCallbacks.js
+++ b/docs/examples/AsyncCallbacks.js
@@ -35,7 +35,7 @@ export default class WithCallbacks extends Component<*, State> {
           loadOptions={loadOptions}
           defaultOptions
           onInputChange={this.handleInputChange}
-          />
+        />
       </div>
     );
   }

--- a/src/Select.js
+++ b/src/Select.js
@@ -402,13 +402,13 @@ export default class Select extends Component<Props, State> {
     ) {
       const selectValue = cleanValue(nextProps.value);
       const menuOptions = this.buildMenuOptions(nextProps, selectValue);
-      let focusedValue = this.getNextFocusedValue(selectValue);
-      let focusedOption = this.getNextFocusedOption(menuOptions.focusable);
-
-      if (nextProps.autoFocusFirstOption === false  && this.state.focusedOption === null) {
-        focusedValue = null;
-        focusedOption = null;
-      }
+      const { focusedOption, focusedValue } =
+        nextProps.autoFocusFirstOption === false && this.state.focusedOption === null
+        ? { focusedValue: null, focusedOption: null }
+        : {
+          focusedValue: this.getNextFocusedValue(selectValue),
+          focusedOption: this.getNextFocusedOption(menuOptions.focusable)
+        };
 
       this.setState({ menuOptions, selectValue, focusedOption, focusedValue });
     }

--- a/src/Select.js
+++ b/src/Select.js
@@ -82,6 +82,8 @@ export type Props = {
   'aria-labelledby'?: string,
   /* Focus the control when it is mounted */
   autoFocus?: boolean,
+  /* Focus first focusable option on menu open and when user is typing */
+  autoFocusFirstOption: boolean,
   /* Remove the currently focused option when the user presses backspace */
   backspaceRemovesValue: boolean,
   /* Remove focus from the input when the user selects an option (handy for dismissing the keyboard on touch devices) */
@@ -276,6 +278,7 @@ export const defaultProps = {
   noOptionsMessage: () => 'No options',
   openMenuOnFocus: false,
   openMenuOnClick: true,
+  autoFocusFirstOption: true,
   options: [],
   pageSize: 5,
   placeholder: 'Select...',
@@ -399,8 +402,14 @@ export default class Select extends Component<Props, State> {
     ) {
       const selectValue = cleanValue(nextProps.value);
       const menuOptions = this.buildMenuOptions(nextProps, selectValue);
-      const focusedValue = this.getNextFocusedValue(selectValue);
-      const focusedOption = this.getNextFocusedOption(menuOptions.focusable);
+      let focusedValue = this.getNextFocusedValue(selectValue);
+      let focusedOption = this.getNextFocusedOption(menuOptions.focusable);
+
+      if (nextProps.autoFocusFirstOption === false  && this.state.focusedOption === null) {
+        focusedValue = null;
+        focusedOption = null;
+      }
+
       this.setState({ menuOptions, selectValue, focusedOption, focusedValue });
     }
     // some updates should toggle the state of the input visibility
@@ -481,7 +490,8 @@ export default class Select extends Component<Props, State> {
 
   openMenu(focusOption: 'first' | 'last') {
     const { menuOptions, selectValue, isFocused } = this.state;
-    const { isMulti } = this.props;
+    const { isMulti, autoFocusFirstOption } = this.props;
+
     let openAtIndex =
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
@@ -499,7 +509,7 @@ export default class Select extends Component<Props, State> {
     this.onMenuOpen();
     this.setState({
       focusedValue: null,
-      focusedOption: menuOptions.focusable[openAtIndex],
+      focusedOption: autoFocusFirstOption ? menuOptions.focusable[openAtIndex] : null,
     });
 
     this.announceAriaLiveContext({ event: 'menu' });

--- a/src/Select.js
+++ b/src/Select.js
@@ -83,7 +83,7 @@ export type Props = {
   /* Focus the control when it is mounted */
   autoFocus?: boolean,
   /* Focus first focusable option on menu open and when user is typing */
-  autoFocusFirstOption: boolean,
+  autoFocusOption: boolean,
   /* Remove the currently focused option when the user presses backspace */
   backspaceRemovesValue: boolean,
   /* Remove focus from the input when the user selects an option (handy for dismissing the keyboard on touch devices) */
@@ -278,7 +278,7 @@ export const defaultProps = {
   noOptionsMessage: () => 'No options',
   openMenuOnFocus: false,
   openMenuOnClick: true,
-  autoFocusFirstOption: true,
+  autoFocusOption: true,
   options: [],
   pageSize: 5,
   placeholder: 'Select...',
@@ -403,7 +403,7 @@ export default class Select extends Component<Props, State> {
       const selectValue = cleanValue(nextProps.value);
       const menuOptions = this.buildMenuOptions(nextProps, selectValue);
       const { focusedOption, focusedValue } =
-        nextProps.autoFocusFirstOption === false && this.state.focusedOption === null
+        nextProps.autoFocusOption === false && this.state.focusedOption === null
         ? { focusedValue: null, focusedOption: null }
         : {
           focusedValue: this.getNextFocusedValue(selectValue),
@@ -490,7 +490,7 @@ export default class Select extends Component<Props, State> {
 
   openMenu(focusOption: 'first' | 'last') {
     const { menuOptions, selectValue, isFocused } = this.state;
-    const { isMulti, autoFocusFirstOption } = this.props;
+    const { isMulti, autoFocusOption } = this.props;
 
     let openAtIndex =
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
@@ -509,7 +509,7 @@ export default class Select extends Component<Props, State> {
     this.onMenuOpen();
     this.setState({
       focusedValue: null,
-      focusedOption: autoFocusFirstOption ? menuOptions.focusable[openAtIndex] : null,
+      focusedOption: autoFocusOption ? menuOptions.focusable[openAtIndex] : null,
     });
 
     this.announceAriaLiveContext({ event: 'menu' });

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -18,7 +18,7 @@ exports[`defaults - snapshot 1`] = `
     options={Array []}
   >
     <Select
-      autoFocusFirstOption={true}
+      autoFocusOption={true}
       backspaceRemovesValue={true}
       blurInputOnSelect={true}
       cacheOptions={false}
@@ -84,7 +84,7 @@ exports[`defaults - snapshot 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
-            "autoFocusFirstOption": true,
+            "autoFocusOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "cacheOptions": false,
@@ -188,7 +188,7 @@ exports[`defaults - snapshot 1`] = `
             selectOption={[Function]}
             selectProps={
               Object {
-                "autoFocusFirstOption": true,
+                "autoFocusOption": true,
                 "backspaceRemovesValue": true,
                 "blurInputOnSelect": true,
                 "cacheOptions": false,
@@ -284,7 +284,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
-                    "autoFocusFirstOption": true,
+                    "autoFocusOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -380,7 +380,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
-                        "autoFocusFirstOption": true,
+                        "autoFocusOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -480,7 +480,7 @@ exports[`defaults - snapshot 1`] = `
                     onFocus={[Function]}
                     selectProps={
                       Object {
-                        "autoFocusFirstOption": true,
+                        "autoFocusOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -662,7 +662,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
-                    "autoFocusFirstOption": true,
+                    "autoFocusOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -757,7 +757,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
-                        "autoFocusFirstOption": true,
+                        "autoFocusOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -860,7 +860,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
-                        "autoFocusFirstOption": true,
+                        "autoFocusOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -18,6 +18,7 @@ exports[`defaults - snapshot 1`] = `
     options={Array []}
   >
     <Select
+      autoFocusFirstOption={true}
       backspaceRemovesValue={true}
       blurInputOnSelect={true}
       cacheOptions={false}
@@ -83,6 +84,7 @@ exports[`defaults - snapshot 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "cacheOptions": false,
@@ -186,6 +188,7 @@ exports[`defaults - snapshot 1`] = `
             selectOption={[Function]}
             selectProps={
               Object {
+                "autoFocusFirstOption": true,
                 "backspaceRemovesValue": true,
                 "blurInputOnSelect": true,
                 "cacheOptions": false,
@@ -281,6 +284,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoFocusFirstOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -376,6 +380,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -475,6 +480,7 @@ exports[`defaults - snapshot 1`] = `
                     onFocus={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -656,6 +662,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoFocusFirstOption": true,
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -750,6 +757,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -852,6 +860,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoFocusFirstOption": true,
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -38,6 +38,7 @@ exports[`defaults - snapshot 1`] = `
     >
       <Select
         allowCreateWhileLoading={false}
+        autoFocusFirstOption={true}
         backspaceRemovesValue={true}
         blurInputOnSelect={true}
         cacheOptions={false}
@@ -108,6 +109,7 @@ exports[`defaults - snapshot 1`] = `
           selectProps={
             Object {
               "allowCreateWhileLoading": false,
+              "autoFocusFirstOption": true,
               "backspaceRemovesValue": true,
               "blurInputOnSelect": true,
               "cacheOptions": false,
@@ -216,6 +218,7 @@ exports[`defaults - snapshot 1`] = `
               selectProps={
                 Object {
                   "allowCreateWhileLoading": false,
+                  "autoFocusFirstOption": true,
                   "backspaceRemovesValue": true,
                   "blurInputOnSelect": true,
                   "cacheOptions": false,
@@ -316,6 +319,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoFocusFirstOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -416,6 +420,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -520,6 +525,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -706,6 +712,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoFocusFirstOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -805,6 +812,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -912,6 +920,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoFocusFirstOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -38,7 +38,7 @@ exports[`defaults - snapshot 1`] = `
     >
       <Select
         allowCreateWhileLoading={false}
-        autoFocusFirstOption={true}
+        autoFocusOption={true}
         backspaceRemovesValue={true}
         blurInputOnSelect={true}
         cacheOptions={false}
@@ -109,7 +109,7 @@ exports[`defaults - snapshot 1`] = `
           selectProps={
             Object {
               "allowCreateWhileLoading": false,
-              "autoFocusFirstOption": true,
+              "autoFocusOption": true,
               "backspaceRemovesValue": true,
               "blurInputOnSelect": true,
               "cacheOptions": false,
@@ -218,7 +218,7 @@ exports[`defaults - snapshot 1`] = `
               selectProps={
                 Object {
                   "allowCreateWhileLoading": false,
-                  "autoFocusFirstOption": true,
+                  "autoFocusOption": true,
                   "backspaceRemovesValue": true,
                   "blurInputOnSelect": true,
                   "cacheOptions": false,
@@ -319,7 +319,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
-                      "autoFocusFirstOption": true,
+                      "autoFocusOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -420,7 +420,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
-                          "autoFocusFirstOption": true,
+                          "autoFocusOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -525,7 +525,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
-                          "autoFocusFirstOption": true,
+                          "autoFocusOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -712,7 +712,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
-                      "autoFocusFirstOption": true,
+                      "autoFocusOption": true,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -812,7 +812,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
-                          "autoFocusFirstOption": true,
+                          "autoFocusOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -920,7 +920,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
-                          "autoFocusFirstOption": true,
+                          "autoFocusOption": true,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -21,6 +21,7 @@ exports[`snapshot - defaults 1`] = `
   selectOption={[Function]}
   selectProps={
     Object {
+      "autoFocusFirstOption": true,
       "backspaceRemovesValue": true,
       "blurInputOnSelect": true,
       "captureMenuScroll": false,
@@ -112,6 +113,7 @@ exports[`snapshot - defaults 1`] = `
     selectOption={[Function]}
     selectProps={
       Object {
+        "autoFocusFirstOption": true,
         "backspaceRemovesValue": true,
         "blurInputOnSelect": true,
         "captureMenuScroll": false,
@@ -194,6 +196,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoFocusFirstOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -278,6 +281,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -365,6 +369,7 @@ exports[`snapshot - defaults 1`] = `
         onFocus={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -450,6 +455,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoFocusFirstOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -533,6 +539,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -623,6 +630,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoFocusFirstOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -21,7 +21,7 @@ exports[`snapshot - defaults 1`] = `
   selectOption={[Function]}
   selectProps={
     Object {
-      "autoFocusFirstOption": true,
+      "autoFocusOption": true,
       "backspaceRemovesValue": true,
       "blurInputOnSelect": true,
       "captureMenuScroll": false,
@@ -113,7 +113,7 @@ exports[`snapshot - defaults 1`] = `
     selectOption={[Function]}
     selectProps={
       Object {
-        "autoFocusFirstOption": true,
+        "autoFocusOption": true,
         "backspaceRemovesValue": true,
         "blurInputOnSelect": true,
         "captureMenuScroll": false,
@@ -196,7 +196,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
-          "autoFocusFirstOption": true,
+          "autoFocusOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -281,7 +281,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
-            "autoFocusFirstOption": true,
+            "autoFocusOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -369,7 +369,7 @@ exports[`snapshot - defaults 1`] = `
         onFocus={[Function]}
         selectProps={
           Object {
-            "autoFocusFirstOption": true,
+            "autoFocusOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -455,7 +455,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
-          "autoFocusFirstOption": true,
+          "autoFocusOption": true,
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -539,7 +539,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
-            "autoFocusFirstOption": true,
+            "autoFocusOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -630,7 +630,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
-            "autoFocusFirstOption": true,
+            "autoFocusOption": true,
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,

--- a/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`defaults > snapshot 1`] = `
 <Select
-  autoFocusFirstOption={true}
+  autoFocusOption={true}
   backspaceRemovesValue={true}
   blurInputOnSelect={true}
   captureMenuScroll={false}

--- a/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`defaults > snapshot 1`] = `
 <Select
+  autoFocusFirstOption={true}
   backspaceRemovesValue={true}
   blurInputOnSelect={true}
   captureMenuScroll={false}


### PR DESCRIPTION
Hello,

Recently, I have been facing a problem : Using React Select without preselection of the first available (focusable) option.
This option didn't exist at all. The problem has been raised in multiples issues : 
#2848 

Behavior with this option is simple : 
1 : Click on the select : No option is focused
2 : Your user starts typing a word, no option is focused until the user do an action for that.