### PR TITLE
removing usage of componentWillReceiveProps

### DIFF
--- a/packages/react-select/src/Async.js
+++ b/packages/react-select/src/Async.js
@@ -83,6 +83,7 @@ export const makeAsyncSelect = <C: {}>(
       const state = {
         cacheOptions: nextProps.cacheOptions,
         optionsCache: nextState.optionsCache,
+        defaultOptions: undefined,
       };
 
       if (nextState.defaultOptions !== nextProps.defaultOptions) {

--- a/packages/react-select/src/Creatable.js
+++ b/packages/react-select/src/Creatable.js
@@ -93,7 +93,7 @@ export const makeCreatableSelect = <C: {}>(
         options: options,
       };
     }
-    UNSAFE_componentWillReceiveProps(nextProps: CreatableProps & C) {
+    static getDerivedStateFromProps(nextProps: CreatableProps & C, nextState) {
       const {
         allowCreateWhileLoading,
         createOptionPosition,
@@ -105,21 +105,21 @@ export const makeCreatableSelect = <C: {}>(
         value,
       } = nextProps;
       const options = nextProps.options || [];
-      let { newOption } = this.state;
+      let { newOption } = nextState;
       if (isValidNewOption(inputValue, cleanValue(value), options)) {
         newOption = getNewOptionData(inputValue, formatCreateLabel(inputValue));
       } else {
         newOption = undefined;
       }
-      this.setState({
+      return {
         newOption: newOption,
         options:
           (allowCreateWhileLoading || !isLoading) && newOption
             ? createOptionPosition === 'first'
-              ? [newOption, ...options]
-              : [...options, newOption]
+            ? [newOption, ...options]
+            : [...options, newOption]
             : options,
-      });
+      };
     }
     onChange = (newValue: ValueType, actionMeta: ActionMeta) => {
       const {

--- a/packages/react-select/src/__tests__/Async.test.js
+++ b/packages/react-select/src/__tests__/Async.test.js
@@ -122,12 +122,9 @@ test.skip('to not call loadOptions again for same value when cacheOptions is tru
 
 test('to create new cache for each instance', () => {
   const asyncSelectWrapper = mount(<Async cacheOptions />);
-  const instanceOne = asyncSelectWrapper.instance();
-
   const asyncSelectTwoWrapper = mount(<Async cacheOptions />);
-  const instanceTwo = asyncSelectTwoWrapper.instance();
 
-  expect(instanceOne.optionsCache).not.toBe(instanceTwo.optionsCache);
+  expect(asyncSelectWrapper.state('optionsCache')).not.toBe(asyncSelectTwoWrapper.state('optionsCache'));
 });
 
 test('in case of callbacks display the most recently-requested loaded options (if results are returned out of order)', () => {


### PR DESCRIPTION
Removes usage of `componentWillReceiveProps` and uses `getDerivedStateFromProps` instead.

Haven't done a lot of testing on this but passes all tests and seems fine when randomly clicking around in the dev server.

Fixes these, and probably some others:
https://github.com/JedWatson/react-select/issues/3374
https://github.com/JedWatson/react-select/issues/3191
https://github.com/JedWatson/react-select/issues/2277