### PR TITLE
Added name param to actionMeta issue #3330

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -37,6 +37,7 @@ export type CreatableProps = {|
   value: ValueType,
   isLoading?: boolean,
   isMulti?: boolean,
+  name?: string,
   onChange: (ValueType, ActionMeta) => void,
 |};
 
@@ -129,9 +130,10 @@ export const makeCreatableSelect = <C: {}>(
         onChange,
         onCreateOption,
         value,
+        name
       } = this.props;
       if (actionMeta.action !== 'select-option') {
-        return onChange(newValue, actionMeta);
+        return  onChange(newValue, { ...actionMeta, name });
       }
       const { newOption } = this.state;
       const valueArray = Array.isArray(newValue) ? newValue : [newValue];
@@ -142,14 +144,14 @@ export const makeCreatableSelect = <C: {}>(
           const newOptionData = getNewOptionData(inputValue, inputValue);
           const newActionMeta = { action: 'create-option' };
           if (isMulti) {
-            onChange([...cleanValue(value), newOptionData], newActionMeta);
+            onChange([...cleanValue(value), newOptionData], { ...newActionMeta, name });
           } else {
-            onChange(newOptionData, newActionMeta);
+            onChange(newOptionData, { ...newActionMeta, name });
           }
         }
         return;
       }
-      onChange(newValue, actionMeta);
+      onChange(newValue, { ...actionMeta, name });
     };
     focus() {
       this.select.focus();


### PR DESCRIPTION
`Creatable`
There is an `actionMeta` missing `name` param of an input. 
Case: if i have multiple `Creatable` in an page there should be an identifier for that particular field.