### PR TITLE
Add support for menuScrollIntoViewElement

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -194,6 +194,8 @@ export type Props = {
   menuPortalTarget?: HTMLElement,
   /* Whether to block scroll events when the menu is open */
   menuShouldBlockScroll: boolean,
+  /* Custom element used when scrolling into view */
+  menuScrollIntoViewElement?: HTMLElement,
   /* Whether the menu should be scrolled into view when it opens */
   menuShouldScrollIntoView: boolean,
   /* Name of the HTML Input (optional - without this, no input will be rendered) */
@@ -1633,6 +1635,7 @@ export default class Select extends Component<Props, State> {
       menuPosition,
       menuPortalTarget,
       menuShouldBlockScroll,
+      menuScrollIntoViewElement,
       menuShouldScrollIntoView,
       noOptionsMessage,
       onMenuScrollToTop,
@@ -1694,6 +1697,7 @@ export default class Select extends Component<Props, State> {
       maxMenuHeight,
       menuPlacement,
       menuPosition,
+      menuScrollIntoViewElement,
       menuShouldScrollIntoView,
     };
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -41,6 +41,7 @@ type PlacementArgs = {
   menuEl: ElementRef<*>,
   minHeight: number,
   placement: 'bottom' | 'top' | 'auto',
+  scrollElement?: HTMLElement,
   shouldScroll: boolean,
   isFixedPosition: boolean,
   theme: Theme,
@@ -51,12 +52,13 @@ export function getMenuPlacement({
   menuEl,
   minHeight,
   placement,
+  scrollElement,
   shouldScroll,
   isFixedPosition,
   theme,
 }: PlacementArgs): MenuState {
   const { spacing } = theme;
-  const scrollParent = getScrollParent(menuEl);
+  const scrollParent = scrollElement || getScrollParent(menuEl);
   const defaultState = { placement: 'bottom', maxHeight };
 
   // something went wrong, return default state
@@ -219,6 +221,8 @@ export type MenuAndPlacerCommon = CommonProps & {
   menuPosition: MenuPosition,
   /** Set the minimum height of the menu. */
   minMenuHeight: number,
+  /* Set custom element used when scrolling into view. */
+  menuScrollIntoViewElement?: HTMLElement,
   /** Set whether the page should scroll to show the menu. */
   menuShouldScrollIntoView: boolean,
 };
@@ -272,6 +276,7 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
       maxMenuHeight,
       menuPlacement,
       menuPosition,
+      menuScrollIntoViewElement,
       menuShouldScrollIntoView,
       theme,
     } = this.props;
@@ -284,6 +289,7 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
     const shouldScroll = menuShouldScrollIntoView && !isFixedPosition;
 
     const state = getMenuPlacement({
+      scrollElement: menuScrollIntoViewElement,
       maxHeight: maxMenuHeight,
       menuEl: ref,
       minHeight: minMenuHeight,


### PR DESCRIPTION
### Current behavior

Currently, `react-select` tries to find the appropriate element to scroll by traversing parents and finding a parent with `overflow=scroll / auto` and defaults to the root document. See  https://github.com/JedWatson/react-select/blob/292bad3298f2cafad6767f2134bd79a9c27e4073/src/utils.js#L127-L143

This doesn't work a `react-select` element is positioned inside a static positioned parent (example using CSS Grid). 

### Suggestion

This PR adds a new `menuScrollIntoViewElement` to support this custom behavior. You can try this PR out here: https://codepen.io/skovhus/pen/JVVGdO

It does not solve all use cases, as there is still code that checks for available view height on window (`viewSpaceBelow >= menuHeight`), and not inside the container. Here `menuScrollIntoViewElement` does not have any effect (yet). Demo https://codepen.io/skovhus/pen/LvvNJE 


### Related issues
https://github.com/JedWatson/react-select/issues/810

### TODO

- [x] proposal
- [ ] get feedback from maintainers
- [ ] see if I can add some unit tests
- [ ] more documentation