### PR TITLE
Fix issue with disabled options and add some docs examples for :active

### DIFF
--- a/docs/examples/StyledMulti.js
+++ b/docs/examples/StyledMulti.js
@@ -19,6 +19,11 @@ const colourStyles = {
           ? chroma.contrast(color, 'white') > 2 ? 'white' : 'black'
           : data.color,
       cursor: isDisabled ? 'not-allowed' : 'default',
+
+      ':active': {
+        ...styles[':active'],
+        backgroundColor: !isDisabled && (isSelected ? data.color : color.alpha(0.3).css()),
+      },
     };
   },
   multiValue: (styles, { data }) => {

--- a/docs/examples/StyledSingle.js
+++ b/docs/examples/StyledSingle.js
@@ -34,6 +34,11 @@ const colourStyles = {
           ? chroma.contrast(color, 'white') > 2 ? 'white' : 'black'
           : data.color,
       cursor: isDisabled ? 'not-allowed' : 'default',
+
+      ':active': {
+        ...styles[':active'],
+        backgroundColor: !isDisabled && (isSelected ? data.color : color.alpha(0.3).css()),
+      },
     };
   },
   input: styles => ({ ...styles, ...dot() }),

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -59,7 +59,7 @@ export const optionCSS = ({
 
   // provide some affordance on touch devices
   ':active': {
-    backgroundColor: isSelected ? colors.primary : colors.primary50,
+    backgroundColor: !isDisabled && (isSelected ? colors.primary : colors.primary50),
   },
 });
 


### PR DESCRIPTION
Fix issue with disabled options

When you hold the mouse on the disabled option, you can see that its background color is being redefined by the ":active" selector. Logically, the user should not have any ability to interact with the disabled options.

Add examples with ":active" to the documentation

At first glance, it is not very clear how to customize active options. In my first experience, I began to look for the "isActive" option in the state, but it was not there. Since the current implementation uses the "hardcoded" selector ":active", it would be good to add the appropriate code to the custom styling examples.