### PR TITLE
Kashkovsky intl a11y

### DIFF
--- a/docs/examples/FormExample.js
+++ b/docs/examples/FormExample.js
@@ -1,0 +1,33 @@
+// @flow
+import React, { Component } from 'react';
+
+import Select from '../../src';
+import { colourOptions } from '../data';
+
+
+export default class FormExample extends Component<*> {
+  render() {
+    return (
+      <form>
+        <label id="select-label" htmlFor="select-example">
+          Test form label
+        </label>
+
+        <Select
+          aria-labelledby="select-label"
+          accessibility={{
+            optionFocusAriaMessage:
+              ({ focusedOption, getOptionLabel }) => {
+                return `custom aria option focus message: ${getOptionLabel(focusedOption)}`;
+              }
+          }}
+          id="select-example"
+          className="basic-single"
+          classNamePrefix="select"
+          name="color"
+          options={colourOptions}
+        />
+      </form>
+    );
+  }
+}

--- a/src/Select.js
+++ b/src/Select.js
@@ -76,7 +76,7 @@ type FormatOptionLabelMeta = {
 };
 export type Accessibility = {
   valueFocusAriaMessage: (args: {
-    focusedValue?: OptionType,
+    focusedValue: OptionType,
     getOptionLabel: (data: OptionType) => string,
     selectValue: OptionsType | Array<OptionType>
   }) => string,

--- a/src/__tests__/Select.test.js
+++ b/src/__tests__/Select.test.js
@@ -1103,7 +1103,6 @@ cases('Clicking Enter on a focused select', ({ props = BASIC_PROPS, expectedValu
   const selectWrapper = wrapper.find(Select);
   selectWrapper.instance().setState({ focusedOption: OPTIONS[0] });
   selectWrapper.instance().onKeyDown(event);
-  console.log(event.defaultPrevented);
   expect(event.defaultPrevented).toBe(expectedValue);
 }, {
   'while menuIsOpen && focusedOption && !isComposing  > should invoke event.preventDefault': {

--- a/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/src/__tests__/__snapshots__/Async.test.js.snap
@@ -18,6 +18,15 @@ exports[`defaults - snapshot 1`] = `
     options={Array []}
   >
     <Select
+      accessibility={
+        Object {
+          "instructionsAriaMessage": [Function],
+          "optionFocusAriaMessage": [Function],
+          "resultsAriaMessage": [Function],
+          "valueEventAriaMessage": [Function],
+          "valueFocusAriaMessage": [Function],
+        }
+      }
       backspaceRemovesValue={true}
       blurInputOnSelect={true}
       cacheOptions={false}
@@ -83,6 +92,13 @@ exports[`defaults - snapshot 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "accessibility": Object {
+              "instructionsAriaMessage": [Function],
+              "optionFocusAriaMessage": [Function],
+              "resultsAriaMessage": [Function],
+              "valueEventAriaMessage": [Function],
+              "valueFocusAriaMessage": [Function],
+            },
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "cacheOptions": false,
@@ -186,6 +202,13 @@ exports[`defaults - snapshot 1`] = `
             selectOption={[Function]}
             selectProps={
               Object {
+                "accessibility": Object {
+                  "instructionsAriaMessage": [Function],
+                  "optionFocusAriaMessage": [Function],
+                  "resultsAriaMessage": [Function],
+                  "valueEventAriaMessage": [Function],
+                  "valueFocusAriaMessage": [Function],
+                },
                 "backspaceRemovesValue": true,
                 "blurInputOnSelect": true,
                 "cacheOptions": false,
@@ -281,6 +304,13 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "accessibility": Object {
+                      "instructionsAriaMessage": [Function],
+                      "optionFocusAriaMessage": [Function],
+                      "resultsAriaMessage": [Function],
+                      "valueEventAriaMessage": [Function],
+                      "valueFocusAriaMessage": [Function],
+                    },
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -376,6 +406,13 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "accessibility": Object {
+                          "instructionsAriaMessage": [Function],
+                          "optionFocusAriaMessage": [Function],
+                          "resultsAriaMessage": [Function],
+                          "valueEventAriaMessage": [Function],
+                          "valueFocusAriaMessage": [Function],
+                        },
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -475,6 +512,13 @@ exports[`defaults - snapshot 1`] = `
                     onFocus={[Function]}
                     selectProps={
                       Object {
+                        "accessibility": Object {
+                          "instructionsAriaMessage": [Function],
+                          "optionFocusAriaMessage": [Function],
+                          "resultsAriaMessage": [Function],
+                          "valueEventAriaMessage": [Function],
+                          "valueFocusAriaMessage": [Function],
+                        },
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -658,6 +702,13 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "accessibility": Object {
+                      "instructionsAriaMessage": [Function],
+                      "optionFocusAriaMessage": [Function],
+                      "resultsAriaMessage": [Function],
+                      "valueEventAriaMessage": [Function],
+                      "valueFocusAriaMessage": [Function],
+                    },
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -752,6 +803,13 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "accessibility": Object {
+                          "instructionsAriaMessage": [Function],
+                          "optionFocusAriaMessage": [Function],
+                          "resultsAriaMessage": [Function],
+                          "valueEventAriaMessage": [Function],
+                          "valueFocusAriaMessage": [Function],
+                        },
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -854,6 +912,13 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "accessibility": Object {
+                          "instructionsAriaMessage": [Function],
+                          "optionFocusAriaMessage": [Function],
+                          "resultsAriaMessage": [Function],
+                          "valueEventAriaMessage": [Function],
+                          "valueFocusAriaMessage": [Function],
+                        },
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,

--- a/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -37,6 +37,15 @@ exports[`defaults - snapshot 1`] = `
       value={null}
     >
       <Select
+        accessibility={
+          Object {
+            "instructionsAriaMessage": [Function],
+            "optionFocusAriaMessage": [Function],
+            "resultsAriaMessage": [Function],
+            "valueEventAriaMessage": [Function],
+            "valueFocusAriaMessage": [Function],
+          }
+        }
         allowCreateWhileLoading={false}
         backspaceRemovesValue={true}
         blurInputOnSelect={true}
@@ -107,6 +116,13 @@ exports[`defaults - snapshot 1`] = `
           selectOption={[Function]}
           selectProps={
             Object {
+              "accessibility": Object {
+                "instructionsAriaMessage": [Function],
+                "optionFocusAriaMessage": [Function],
+                "resultsAriaMessage": [Function],
+                "valueEventAriaMessage": [Function],
+                "valueFocusAriaMessage": [Function],
+              },
               "allowCreateWhileLoading": false,
               "backspaceRemovesValue": true,
               "blurInputOnSelect": true,
@@ -215,6 +231,13 @@ exports[`defaults - snapshot 1`] = `
               selectOption={[Function]}
               selectProps={
                 Object {
+                  "accessibility": Object {
+                    "instructionsAriaMessage": [Function],
+                    "optionFocusAriaMessage": [Function],
+                    "resultsAriaMessage": [Function],
+                    "valueEventAriaMessage": [Function],
+                    "valueFocusAriaMessage": [Function],
+                  },
                   "allowCreateWhileLoading": false,
                   "backspaceRemovesValue": true,
                   "blurInputOnSelect": true,
@@ -315,6 +338,13 @@ exports[`defaults - snapshot 1`] = `
                   selectOption={[Function]}
                   selectProps={
                     Object {
+                      "accessibility": Object {
+                        "instructionsAriaMessage": [Function],
+                        "optionFocusAriaMessage": [Function],
+                        "resultsAriaMessage": [Function],
+                        "valueEventAriaMessage": [Function],
+                        "valueFocusAriaMessage": [Function],
+                      },
                       "allowCreateWhileLoading": false,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
@@ -415,6 +445,13 @@ exports[`defaults - snapshot 1`] = `
                       selectOption={[Function]}
                       selectProps={
                         Object {
+                          "accessibility": Object {
+                            "instructionsAriaMessage": [Function],
+                            "optionFocusAriaMessage": [Function],
+                            "resultsAriaMessage": [Function],
+                            "valueEventAriaMessage": [Function],
+                            "valueFocusAriaMessage": [Function],
+                          },
                           "allowCreateWhileLoading": false,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
@@ -519,6 +556,13 @@ exports[`defaults - snapshot 1`] = `
                       onFocus={[Function]}
                       selectProps={
                         Object {
+                          "accessibility": Object {
+                            "instructionsAriaMessage": [Function],
+                            "optionFocusAriaMessage": [Function],
+                            "resultsAriaMessage": [Function],
+                            "valueEventAriaMessage": [Function],
+                            "valueFocusAriaMessage": [Function],
+                          },
                           "allowCreateWhileLoading": false,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
@@ -707,6 +751,13 @@ exports[`defaults - snapshot 1`] = `
                   selectOption={[Function]}
                   selectProps={
                     Object {
+                      "accessibility": Object {
+                        "instructionsAriaMessage": [Function],
+                        "optionFocusAriaMessage": [Function],
+                        "resultsAriaMessage": [Function],
+                        "valueEventAriaMessage": [Function],
+                        "valueFocusAriaMessage": [Function],
+                      },
                       "allowCreateWhileLoading": false,
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
@@ -806,6 +857,13 @@ exports[`defaults - snapshot 1`] = `
                       selectOption={[Function]}
                       selectProps={
                         Object {
+                          "accessibility": Object {
+                            "instructionsAriaMessage": [Function],
+                            "optionFocusAriaMessage": [Function],
+                            "resultsAriaMessage": [Function],
+                            "valueEventAriaMessage": [Function],
+                            "valueFocusAriaMessage": [Function],
+                          },
                           "allowCreateWhileLoading": false,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
@@ -913,6 +971,13 @@ exports[`defaults - snapshot 1`] = `
                       selectOption={[Function]}
                       selectProps={
                         Object {
+                          "accessibility": Object {
+                            "instructionsAriaMessage": [Function],
+                            "optionFocusAriaMessage": [Function],
+                            "resultsAriaMessage": [Function],
+                            "valueEventAriaMessage": [Function],
+                            "valueFocusAriaMessage": [Function],
+                          },
                           "allowCreateWhileLoading": false,
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,

--- a/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/__tests__/__snapshots__/Select.test.js.snap
@@ -21,6 +21,13 @@ exports[`snapshot - defaults 1`] = `
   selectOption={[Function]}
   selectProps={
     Object {
+      "accessibility": Object {
+        "instructionsAriaMessage": [Function],
+        "optionFocusAriaMessage": [Function],
+        "resultsAriaMessage": [Function],
+        "valueEventAriaMessage": [Function],
+        "valueFocusAriaMessage": [Function],
+      },
       "backspaceRemovesValue": true,
       "blurInputOnSelect": true,
       "captureMenuScroll": false,
@@ -112,6 +119,13 @@ exports[`snapshot - defaults 1`] = `
     selectOption={[Function]}
     selectProps={
       Object {
+        "accessibility": Object {
+          "instructionsAriaMessage": [Function],
+          "optionFocusAriaMessage": [Function],
+          "resultsAriaMessage": [Function],
+          "valueEventAriaMessage": [Function],
+          "valueFocusAriaMessage": [Function],
+        },
         "backspaceRemovesValue": true,
         "blurInputOnSelect": true,
         "captureMenuScroll": false,
@@ -194,6 +208,13 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "accessibility": Object {
+            "instructionsAriaMessage": [Function],
+            "optionFocusAriaMessage": [Function],
+            "resultsAriaMessage": [Function],
+            "valueEventAriaMessage": [Function],
+            "valueFocusAriaMessage": [Function],
+          },
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -278,6 +299,13 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "accessibility": Object {
+              "instructionsAriaMessage": [Function],
+              "optionFocusAriaMessage": [Function],
+              "resultsAriaMessage": [Function],
+              "valueEventAriaMessage": [Function],
+              "valueFocusAriaMessage": [Function],
+            },
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -365,6 +393,13 @@ exports[`snapshot - defaults 1`] = `
         onFocus={[Function]}
         selectProps={
           Object {
+            "accessibility": Object {
+              "instructionsAriaMessage": [Function],
+              "optionFocusAriaMessage": [Function],
+              "resultsAriaMessage": [Function],
+              "valueEventAriaMessage": [Function],
+              "valueFocusAriaMessage": [Function],
+            },
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -450,6 +485,13 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "accessibility": Object {
+            "instructionsAriaMessage": [Function],
+            "optionFocusAriaMessage": [Function],
+            "resultsAriaMessage": [Function],
+            "valueEventAriaMessage": [Function],
+            "valueFocusAriaMessage": [Function],
+          },
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -533,6 +575,13 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "accessibility": Object {
+              "instructionsAriaMessage": [Function],
+              "optionFocusAriaMessage": [Function],
+              "resultsAriaMessage": [Function],
+              "valueEventAriaMessage": [Function],
+              "valueFocusAriaMessage": [Function],
+            },
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -623,6 +672,13 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "accessibility": Object {
+              "instructionsAriaMessage": [Function],
+              "optionFocusAriaMessage": [Function],
+              "resultsAriaMessage": [Function],
+              "valueEventAriaMessage": [Function],
+              "valueFocusAriaMessage": [Function],
+            },
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,

--- a/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -2,6 +2,15 @@
 
 exports[`defaults > snapshot 1`] = `
 <Select
+  accessibility={
+    Object {
+      "instructionsAriaMessage": [Function],
+      "optionFocusAriaMessage": [Function],
+      "resultsAriaMessage": [Function],
+      "valueEventAriaMessage": [Function],
+      "valueFocusAriaMessage": [Function],
+    }
+  }
   backspaceRemovesValue={true}
   blurInputOnSelect={true}
   captureMenuScroll={false}

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -10,8 +10,10 @@ export type InstructionsContext = {
 };
 export type ValueEventContext = { value: string, isDisabled?: boolean };
 
+export type InstructionEventType = 'menu' | 'input' | 'value';
+
 export const instructionsAriaMessage = (
-  event: string,
+  event: InstructionEventType,
   context?: InstructionsContext = {}
 ) => {
   const { isSearchable, isMulti, label, isDisabled } = context;
@@ -26,15 +28,19 @@ export const instructionsAriaMessage = (
         }`;
     case 'value':
       return 'Use left and right to toggle between focused values, press Backspace to remove the currently focused value';
+    default:
+      return '';
   }
 };
 
+export type ValueEventType = 'deselect-option' | 'pop-value' | 'remove-value' | 'select-option';
+
 export const valueEventAriaMessage = (
-  event: string,
+  event: ValueEventType,
   context: ValueEventContext
 ) => {
   const { value, isDisabled } = context;
-  if (!value) return;
+  if (!value) return '';
   switch (event) {
     case 'deselect-option':
     case 'pop-value':
@@ -42,6 +48,8 @@ export const valueEventAriaMessage = (
       return `option ${value}, deselected.`;
     case 'select-option':
       return isDisabled ? `option ${value} is disabled. Select another option.` : `option ${value}, selected.`;
+    default:
+      return '';
   }
 };
 


### PR DESCRIPTION
Resolves a few bugs in #3358 
Thanks to @kashkovsky for doing most of the heavy lifting. 
This PR makes it so that the accessibility prop is merged with a default accessibility config, instead of being a hard override. 
```
{
 ...this.props.accessibility 
...defaultAccessibilityProps
}
```

As well as minor fixes to flow types around the newly exposed accessibility prop. 