### PR TITLE
Fix IME composition for non-Chrome browsers

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -296,7 +296,6 @@ type State = {
   ariaLiveContext: string,
   inputIsHidden: boolean,
   isFocused: boolean,
-  isComposing: boolean,
   focusedOption: OptionType | null,
   focusedValue: OptionType | null,
   menuOptions: MenuOptions,
@@ -316,7 +315,6 @@ export default class Select extends Component<Props, State> {
     focusedValue: null,
     inputIsHidden: false,
     isFocused: false,
-    isComposing: false,
     menuOptions: { render: [], focusable: [] },
     selectValue: [],
   };
@@ -325,6 +323,7 @@ export default class Select extends Component<Props, State> {
   // ------------------------------
 
   blockOptionHover: boolean = false;
+  isComposing: boolean = false;
   clearFocusValueOnUpdate: boolean = false;
   commonProps: any; // TODO
   components: SelectComponents;
@@ -984,14 +983,10 @@ export default class Select extends Component<Props, State> {
     }
   }
   onCompositionStart = () => {
-    this.setState({
-      isComposing: true,
-    });
+    this.isComposing = true;
   };
   onCompositionEnd = () => {
-    this.setState({
-      isComposing: false,
-    });
+    this.isComposing = false;
   };
 
   // ==============================
@@ -1141,7 +1136,6 @@ export default class Select extends Component<Props, State> {
       openMenuOnFocus,
     } = this.props;
     const {
-      isComposing,
       focusedOption,
       focusedValue,
       selectValue,
@@ -1182,7 +1176,7 @@ export default class Select extends Component<Props, State> {
         }
         break;
       case 'Tab':
-        if (isComposing) return;
+        if (this.isComposing) return;
 
         if (
           event.shiftKey ||
@@ -1205,7 +1199,7 @@ export default class Select extends Component<Props, State> {
         }
         if (menuIsOpen) {
           if (!focusedOption) return;
-          if (isComposing) return;
+          if (this.isComposing) return;
           this.selectOption(focusedOption);
           break;
         }


### PR DESCRIPTION
When composition starts the component's state was being updated to indicate that composition was occuring. This seemed to be causing either unnecessary renders or re-calculation that would affect the composition of CJK characters in the input box, resulting in characters or words not matching the input entered by the user on non-Chrome browsers. The fix is to not use component state to track `isComposing` preventing attempts at re-rendering when the composition starts and ends. This is also the proper way to store such data as it is not used in the rendering of the component.

You can reproduce the issue by changing your keyboard to be Korean on Windows and using IE11 to type `gkwjd` into a react-select input. The correct result should be `하정`.

Fixes https://github.com/JedWatson/react-select/issues/3559