### PR TITLE
Remove bolt config

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,12 +141,6 @@
     "packages/*",
     "docs"
   ],
-  "bolt": {
-    "workspaces": [
-      "packages/*",
-      "docs"
-    ]
-  },
   "preconstruct": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
This isn't necessary now that we're using the new version of changesets that works with yarn workspaces