### PR TITLE
openMenu: Compare option values instead of objects

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -485,11 +485,12 @@ export default class Select extends Component<Props, State> {
   openMenu(focusOption: 'first' | 'last') {
     const { menuOptions, selectValue, isFocused } = this.state;
     const { isMulti } = this.props;
+    const focusableValues = menuOptions.focusable.map(option => this.getOptionValue(option));
     let openAtIndex =
       focusOption === 'first' ? 0 : menuOptions.focusable.length - 1;
 
     if (!isMulti) {
-      const selectedIndex = menuOptions.focusable.indexOf(selectValue[0]);
+      const selectedIndex = focusableValues.indexOf(this.getOptionValue(selectValue[0]));
       if (selectedIndex > -1) {
         openAtIndex = selectedIndex;
       }


### PR DESCRIPTION
When using the Select as controlled, it frequently happens that `value` object's reference is different than the options references, leading to this piece of code at line 493 returning -1, while the objects are identical.