### PR TITLE
fix: Remove unused classnames dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "bundlesize": "^0.17.0",
     "chroma-js": "^1.3.6",
     "chrono-node": "^1.3.5",
-    "classnames": "^2.2.5",
     "codesandboxer": "^0.1.1",
     "concurrently": "^3.5.1",
     "copy-webpack-plugin": "^5.0.3",

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -16,7 +16,6 @@
     "@emotion/cache": "^10.0.9",
     "@emotion/core": "^10.0.9",
     "@emotion/css": "^10.0.9",
-    "classnames": "^2.2.5",
     "memoize-one": "^5.0.0",
     "prop-types": "^15.6.0",
     "raf": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,11 +3608,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-  integrity sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=
-
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"


### PR DESCRIPTION
`classnames` isn't used (anymore?) but still listed as a dependency. This might be confusing to people using `clsx` and thinking they pull in (basically) duplicate dependencies.