### PR TITLE
add autoComplete as prop to the Select component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ coverage/*
 cypress/plugins/*
 cypress/support/*
 dist/*
+**/dist/*
 flow-typed/*
 lib/*
 node_modules/*

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -79,6 +79,8 @@ export type Props = {
   'aria-label'?: string,
   /* HTML ID of an element that should be used as the label (for assistive tech) */
   'aria-labelledby'?: string,
+  /* Set the key for the browser autocomplete/autofill feature. */
+  autoComplete?: string,
   /* Focus the control when it is mounted */
   autoFocus?: boolean,
   /* Remove the currently focused option when the user presses backspace */
@@ -246,6 +248,7 @@ export type Props = {
 };
 
 export const defaultProps = {
+  autoComplete: "off",
   backspaceRemovesValue: true,
   blurInputOnSelect: isTouchCapable(),
   captureMenuScroll: !isTouchCapable(),
@@ -1386,6 +1389,7 @@ export default class Select extends Component<Props, State> {
 
   renderInput() {
     const {
+      autoComplete,
       isDisabled,
       isSearchable,
       inputId,
@@ -1426,7 +1430,7 @@ export default class Select extends Component<Props, State> {
     return (
       <Input
         autoCapitalize="none"
-        autoComplete="off"
+        autoComplete={autoComplete}
         autoCorrect="off"
         cx={cx}
         getStyles={this.getStyles}

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -51,17 +51,17 @@ import { defaultTheme, type ThemeConfig } from './theme';
 
 import type {
   ActionMeta,
-  ActionTypes,
-  FocusDirection,
-  FocusEventHandler,
-  GroupType,
-  InputActionMeta,
-  KeyboardEventHandler,
-  MenuPlacement,
-  MenuPosition,
-  OptionsType,
-  OptionType,
-  ValueType,
+    ActionTypes,
+    FocusDirection,
+    FocusEventHandler,
+    GroupType,
+    InputActionMeta,
+    KeyboardEventHandler,
+    MenuPlacement,
+    MenuPosition,
+    OptionsType,
+    OptionType,
+    ValueType,
 } from './types';
 
 type MouseOrTouchEvent =
@@ -130,8 +130,8 @@ export type Props = {
   escapeClearsValue: boolean,
   /* Custom method to filter whether an option should be displayed in the menu */
   filterOption:
-    | (({ label: string, value: string, data: OptionType }, string) => boolean)
-    | null,
+  | (({ label: string, value: string, data: OptionType }, string) => boolean)
+  | null,
   /*
     Formats group labels in the menu as React components
 
@@ -248,7 +248,7 @@ export type Props = {
 };
 
 export const defaultProps = {
-  autoComplete: "off",
+  autoComplete: 'off',
   backspaceRemovesValue: true,
   blurInputOnSelect: isTouchCapable(),
   captureMenuScroll: !isTouchCapable(),
@@ -1364,19 +1364,19 @@ export default class Select extends Component<Props, State> {
     // An aria live message representing the currently focused value in the select.
     const focusedValueMsg = focusedValue
       ? valueFocusAriaMessage({
-          focusedValue,
-          getOptionLabel: this.getOptionLabel,
-          selectValue,
-        })
+        focusedValue,
+        getOptionLabel: this.getOptionLabel,
+        selectValue,
+      })
       : '';
     // An aria live message representing the currently focused option in the select.
     const focusedOptionMsg =
       focusedOption && menuIsOpen
         ? optionFocusAriaMessage({
-            focusedOption,
-            getOptionLabel: this.getOptionLabel,
-            options,
-          })
+          focusedOption,
+          getOptionLabel: this.getOptionLabel,
+          options,
+        })
         : '';
     // An aria live message representing the set of focusable results and current searchterm/inputvalue.
     const resultsMsg = resultsAriaMessage({
@@ -1752,8 +1752,8 @@ export default class Select extends Component<Props, State> {
         {menuElement}
       </MenuPortal>
     ) : (
-      menuElement
-    );
+        menuElement
+      );
   }
   renderFormField() {
     const { delimiter, isDisabled, isMulti, name } = this.props;
@@ -1779,8 +1779,8 @@ export default class Select extends Component<Props, State> {
               />
             ))
           ) : (
-            <input name={name} type="hidden" />
-          );
+              <input name={name} type="hidden" />
+            );
 
         return <div>{input}</div>;
       }

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -79,6 +79,14 @@ test('isRtl boolean props is passed down to the control component', () => {
   expect(selectWrapper.props().isRtl).toBe(true);
 });
 
+test('autoComplete string prop is passed down to the control component', () => {
+  let selectWrapper = mount(
+    <Select {...BASIC_PROPS} value={[OPTIONS[0]]} autoComplete="new-password" />
+  );
+  expect(selectWrapper.props().autoComplete).toBe('new-password');
+  expect(selectWrapper.find(Input).props().autoComplete).toBe('new-password');
+});
+
 test('isOptionSelected() prop > single select > mark value as isSelected if isOptionSelected returns true for the option', () => {
   // Select all but option with label '1'
   let isOptionSelected = jest.fn(option => option.label !== '1');

--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.js.snap
@@ -153,6 +153,7 @@ exports[`defaults - snapshot 1`] = `
     options={Array []}
   >
     <Select
+      autoComplete="off"
       backspaceRemovesValue={true}
       blurInputOnSelect={true}
       cacheOptions={false}
@@ -218,6 +219,7 @@ exports[`defaults - snapshot 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoComplete": "off",
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "cacheOptions": false,
@@ -321,6 +323,7 @@ exports[`defaults - snapshot 1`] = `
             selectOption={[Function]}
             selectProps={
               Object {
+                "autoComplete": "off",
                 "backspaceRemovesValue": true,
                 "blurInputOnSelect": true,
                 "cacheOptions": false,
@@ -416,6 +419,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoComplete": "off",
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -511,6 +515,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoComplete": "off",
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -610,6 +615,7 @@ exports[`defaults - snapshot 1`] = `
                     onFocus={[Function]}
                     selectProps={
                       Object {
+                        "autoComplete": "off",
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -793,6 +799,7 @@ exports[`defaults - snapshot 1`] = `
                 selectOption={[Function]}
                 selectProps={
                   Object {
+                    "autoComplete": "off",
                     "backspaceRemovesValue": true,
                     "blurInputOnSelect": true,
                     "cacheOptions": false,
@@ -887,6 +894,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoComplete": "off",
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,
@@ -989,6 +997,7 @@ exports[`defaults - snapshot 1`] = `
                     selectOption={[Function]}
                     selectProps={
                       Object {
+                        "autoComplete": "off",
                         "backspaceRemovesValue": true,
                         "blurInputOnSelect": true,
                         "cacheOptions": false,

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -173,6 +173,7 @@ exports[`defaults - snapshot 1`] = `
     >
       <Select
         allowCreateWhileLoading={false}
+        autoComplete="off"
         backspaceRemovesValue={true}
         blurInputOnSelect={true}
         cacheOptions={false}
@@ -243,6 +244,7 @@ exports[`defaults - snapshot 1`] = `
           selectProps={
             Object {
               "allowCreateWhileLoading": false,
+              "autoComplete": "off",
               "backspaceRemovesValue": true,
               "blurInputOnSelect": true,
               "cacheOptions": false,
@@ -351,6 +353,7 @@ exports[`defaults - snapshot 1`] = `
               selectProps={
                 Object {
                   "allowCreateWhileLoading": false,
+                  "autoComplete": "off",
                   "backspaceRemovesValue": true,
                   "blurInputOnSelect": true,
                   "cacheOptions": false,
@@ -451,6 +454,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoComplete": "off",
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -551,6 +555,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoComplete": "off",
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -655,6 +660,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoComplete": "off",
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -843,6 +849,7 @@ exports[`defaults - snapshot 1`] = `
                   selectProps={
                     Object {
                       "allowCreateWhileLoading": false,
+                      "autoComplete": "off",
                       "backspaceRemovesValue": true,
                       "blurInputOnSelect": true,
                       "cacheOptions": false,
@@ -942,6 +949,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoComplete": "off",
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,
@@ -1049,6 +1057,7 @@ exports[`defaults - snapshot 1`] = `
                       selectProps={
                         Object {
                           "allowCreateWhileLoading": false,
+                          "autoComplete": "off",
                           "backspaceRemovesValue": true,
                           "blurInputOnSelect": true,
                           "cacheOptions": false,

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.js.snap
@@ -21,6 +21,7 @@ exports[`snapshot - defaults 1`] = `
   selectOption={[Function]}
   selectProps={
     Object {
+      "autoComplete": "off",
       "backspaceRemovesValue": true,
       "blurInputOnSelect": true,
       "captureMenuScroll": false,
@@ -112,6 +113,7 @@ exports[`snapshot - defaults 1`] = `
     selectOption={[Function]}
     selectProps={
       Object {
+        "autoComplete": "off",
         "backspaceRemovesValue": true,
         "blurInputOnSelect": true,
         "captureMenuScroll": false,
@@ -194,6 +196,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoComplete": "off",
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -278,6 +281,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoComplete": "off",
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -365,6 +369,7 @@ exports[`snapshot - defaults 1`] = `
         onFocus={[Function]}
         selectProps={
           Object {
+            "autoComplete": "off",
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -450,6 +455,7 @@ exports[`snapshot - defaults 1`] = `
       selectOption={[Function]}
       selectProps={
         Object {
+          "autoComplete": "off",
           "backspaceRemovesValue": true,
           "blurInputOnSelect": true,
           "captureMenuScroll": false,
@@ -533,6 +539,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoComplete": "off",
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,
@@ -623,6 +630,7 @@ exports[`snapshot - defaults 1`] = `
         selectOption={[Function]}
         selectProps={
           Object {
+            "autoComplete": "off",
             "backspaceRemovesValue": true,
             "blurInputOnSelect": true,
             "captureMenuScroll": false,

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`defaults > snapshot 1`] = `
 <Select
+  autoComplete="off"
   backspaceRemovesValue={true}
   blurInputOnSelect={true}
   captureMenuScroll={false}


### PR DESCRIPTION
As mentioned  in issue https://github.com/JedWatson/react-select/issues/3500 and  https://github.com/JedWatson/react-select/pull/2395 and having my own need to set an explicit `autoComplete` value (namely to prevent Google Chrome from showing its autofill drop-down on top of the `react-select` drop-down) I've attempted a quick simple fix.