### PR TITLE
noOptionsMessage

### DIFF
--- a/.changeset/old-radios-hug.md
+++ b/.changeset/old-radios-hug.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Fix `loadingMessage` and `noOptionsMessage` properties in `Styles` flow type

--- a/packages/react-select/src/styles.js
+++ b/packages/react-select/src/styles.js
@@ -53,7 +53,7 @@ export type Styles = {
   multiValue?: StyleFn,
   multiValueLabel?: StyleFn,
   multiValueRemove?: StyleFn,
-  noOptionsMessageCSS?: StyleFn,
+  noOptionsMessage?: StyleFn,
   option?: StyleFn,
   placeholder?: StyleFn,
   singleValue?: StyleFn,

--- a/packages/react-select/src/styles.js
+++ b/packages/react-select/src/styles.js
@@ -46,7 +46,7 @@ export type Styles = {
   indicatorSeparator?: StyleFn,
   input?: StyleFn,
   loadingIndicator?: StyleFn,
-  loadingMessageCSS?: StyleFn,
+  loadingMessage?: StyleFn,
   menu?: StyleFn,
   menuList?: StyleFn,
   menuPortal?: StyleFn,


### PR DESCRIPTION
It should be `noOptionsMessage`, not `noOptionsMessageCSS`, because otherwise it throws Flow error:
```Cannot create `Select` element because property `noOptionsMessage` is missing in  `StylesConfig` [1] but exists in  object literal [2] in property `styles`.```