### PR TITLE
Confine group type, prevent confusion of group and option

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1312,7 +1312,7 @@ export default class Select extends Component<Props, State> {
 
     return options.reduce(
       (acc, item, itemIndex) => {
-        if (item.options) {
+        if (item.options && item.label) {
           // TODO needs a tidier implementation
           if (!this.hasGroups) this.hasGroups = true;
 

--- a/packages/react-select/src/types.js
+++ b/packages/react-select/src/types.js
@@ -9,6 +9,7 @@ export type OptionsType = Array<OptionType>;
 
 export type GroupType = {
   options: OptionsType,
+  label: string,
   [string]: any,
 };
 


### PR DESCRIPTION
- Problem
When I use data like 
`
tempOptions: [
    id: number
    ...
    options: { id: number, type: 'temp', ... }
]
`

Function 'bulidMenuOption' in src/Select.js confuse my 'option' as 'group' data.'
'bulidMenuOption' detects tempOptions's attribute 'options' and it regard tempOptions as 'group' not as 'option'
So it maps tempOptions.options and raise Error 'items.map is not a function'

- Reproduce of error
https://codesandbox.io/s/react-codesandboxer-example-e62ro

- Suggestion
I think it's because GroupType is subset of OptionType
So Confining GroupType with 'label' attibute can would make it more safe.
