### PR TITLE
Marked deprecated react lifecycles as UNSAFE_*

### DIFF
--- a/docs/App/Header.js
+++ b/docs/App/Header.js
@@ -117,7 +117,7 @@ class Header extends Component<HeaderProps, HeaderState> {
   componentDidMount() {
     this.getStarCount();
   }
-  componentWillReceiveProps({ location }: HeaderProps) {
+  UNSAFE_componentWillReceiveProps({ location }: HeaderProps) {
     const valid = ['/', '/home'];
     const shouldCollapse = !valid.includes(this.props.location.pathname);
     if (location.pathname !== this.props.location.pathname && shouldCollapse) {

--- a/packages/react-select/src/Async.js
+++ b/packages/react-select/src/Async.js
@@ -76,7 +76,7 @@ export const makeAsyncSelect = <C: {}>(
         });
       }
     }
-    componentWillReceiveProps(nextProps: C & AsyncProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: C & AsyncProps) {
       // if the cacheOptions prop changes, clear the cache
       if (nextProps.cacheOptions !== this.props.cacheOptions) {
         this.optionsCache = {};

--- a/packages/react-select/src/Creatable.js
+++ b/packages/react-select/src/Creatable.js
@@ -93,7 +93,7 @@ export const makeCreatableSelect = <C: {}>(
         options: options,
       };
     }
-    componentWillReceiveProps(nextProps: CreatableProps & C) {
+    UNSAFE_componentWillReceiveProps(nextProps: CreatableProps & C) {
       const {
         allowCreateWhileLoading,
         createOptionPosition,

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -387,7 +387,7 @@ export default class Select extends Component<Props, State> {
       this.focusInput();
     }
   }
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { options, value, menuIsOpen, inputValue } = this.props;
     // re-cache custom components
     this.cacheComponents(nextProps.components);


### PR DESCRIPTION
As a quick fix to remove the warnings starting react 16.9.0, this marked the deprecated react lifecycles as UNSAFE_*

(Note that this is just to remove the warning. There is still a need to refactor this code to move the code from the deprecated lifecycles to the correct lifecycles - and maybe change some logic)