### PR TITLE
Double-tap is needed to select an option in mobile

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1296,6 +1296,7 @@ export default class Select extends Component<Props, State> {
         innerProps: {
           id: optionId,
           onClick: onSelect,
+          onTouchEnd: () => {!_this3.userIsDragging && onSelect()},
           onMouseMove: onHover,
           onMouseOver: onHover,
           tabIndex: -1,


### PR DESCRIPTION
Thanks for building great things. With react-select, I can reduce a lot of works.
In react-select@3.0.4, I found that double tab is needed on mobile to select an option.
I used fastclick.js to resolve this issue, but there's some side-effect with fastclick.
So I added onTouchEnd event handler just the same as onClick event except it is disabled when a user is dragging. It resolved my issue.