### PR TITLE
Add listeners to ScrollCaptor, even when no scroll is available on mount

### DIFF
--- a/packages/react-select/src/internal/ScrollCaptor.js
+++ b/packages/react-select/src/internal/ScrollCaptor.js
@@ -27,7 +27,6 @@ class ScrollCaptor extends Component<CaptorProps> {
   startListening(el: HTMLElement) {
     // bail early if no scroll available
     if (!el) return;
-    if (el.scrollHeight <= el.clientHeight) return;
 
     // all the if statements are to appease Flow 😢
     if (typeof el.addEventListener === 'function') {
@@ -41,8 +40,6 @@ class ScrollCaptor extends Component<CaptorProps> {
     }
   }
   stopListening(el: HTMLElement) {
-    // bail early if no scroll available
-    if (el.scrollHeight <= el.clientHeight) return;
 
     // all the if statements are to appease Flow 😢
     if (typeof el.removeEventListener === 'function') {

--- a/packages/react-select/src/internal/ScrollCaptor.js
+++ b/packages/react-select/src/internal/ScrollCaptor.js
@@ -25,7 +25,7 @@ class ScrollCaptor extends Component<CaptorProps> {
     this.stopListening(this.scrollTarget);
   }
   startListening(el: HTMLElement) {
-    // bail early if no scroll available
+    // bail early if no element is available to attach to
     if (!el) return;
 
     // all the if statements are to appease Flow 😢


### PR DESCRIPTION
This is the same PR as #2861.

The issue is that when you work with async data, when opening the list of options, the options list might be empty and data may arrive later. This results in the `onMenuScrollToBottom` listener not firing, or being attached.