### PR TITLE
Enable Babel loose mode to improve bundle size

### DIFF
--- a/.changeset/spicy-ads-poke.md
+++ b/.changeset/spicy-ads-poke.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Enable Babel loose mode to improve bundle size

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,11 @@
 module.exports = {
-  plugins: ['emotion', '@babel/plugin-proposal-class-properties'],
-  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-flow'],
+  plugins: [
+    'emotion',
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ],
+  presets: [
+    ['@babel/preset-env', { loose: true }],
+    '@babel/preset-react',
+    '@babel/preset-flow',
+  ],
 };


### PR DESCRIPTION
It's super safe, I use it on Emotion and things. The savings are about 900 bytes.