### PR TITLE
Add selectProps documentation

### DIFF
--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -106,6 +106,43 @@ export default function Styles() {
           options={...}
         />
       );
+      ~~~ 
+
+    
+    ## Select Props
+    In the second argument \`state\`, you have acces to \`selectProps\` which will allow you to gain acess to
+    your own arguments passed into the \`Select\` body.
+
+    ~~~jsx
+    const customStyles = {
+      menu: (provided, state) => ({
+        ...provided,
+        width: state.selectProps.width,
+        borderBottom: '1px dotted pink',
+        color: state.selectProps.menuColor,
+        padding: 20,
+      }),
+
+      control: (_, { selectProps: { width }}) => ({
+        width: width
+      }),
+
+      singleValue: (provided, state) => {
+        const opacity = state.isDisabled ? 0.5 : 1;
+        const transition = 'opacity 300ms';
+
+        return { ...provided, opacity, transition };
+      }
+    }
+
+      const App = () => (
+        <Select
+          styles={customStyles}
+          width='200px'
+          menuColor='red'
+          options={...}
+        />
+      );
       ~~~
 
       ${(


### PR DESCRIPTION
Add an explanation/example in the documentation on how to use ```customStyles``` in a clear way for building dynamic custom Select components and how to access those props inside the second argument ```state``` .

https://github.com/JedWatson/react-select/issues/3851