### PR TITLE
Fix not focusing the selected value on menu open

### DIFF
--- a/.changeset/angry-cherries-nail.md
+++ b/.changeset/angry-cherries-nail.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix for not focusing the selected value when the menu opens


### PR DESCRIPTION
**Bug**

When opening the react select menu, the focused option is not scrolled into the view:

https://codesandbox.io/s/autumn-wind-l3ed8

**Fix**

The first effort was made in PR #3813, but since the author of the PR is not responding anymore, I decided to have a look myself and try to fix this issue. It turns out that commit 8ee3cea73620b9ddff36f6e57f694c3b19d9f05a in PR #3569 was breaking the autofocus on menu opening, as the `menuOptions` in the `openMenu` was empty, because it was only set **after** `onMenuOpen` was called (and thus `UNSAFE_componentWillReceiveProps`). Now we set the `menuOptions ` in `openMenu` already.

I've made `buildMenuOptions` memoized, so that it does not run the function again if the props that the function uses didn't change.