### PR TITLE
Fix react-select ignoring HTML5 "form" attribute

### DIFF
--- a/.changeset/sixty-forks-fry.md
+++ b/.changeset/sixty-forks-fry.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Fix react-select ignoring HTML5 "form" attribute

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -243,6 +243,8 @@ export type Props = {
   tabSelectsValue: boolean,
   /* The value of the select; reflected by the selected option */
   value: ValueType,
+  /* Sets the form attribute on the input */
+  form: string,
 };
 
 export const defaultProps = {

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -244,7 +244,7 @@ export type Props = {
   /* The value of the select; reflected by the selected option */
   value: ValueType,
   /* Sets the form attribute on the input */
-  form: string,
+  form?: string,
 };
 
 export const defaultProps = {

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1397,6 +1397,7 @@ export default class Select extends Component<Props, State> {
       inputId,
       inputValue,
       tabIndex,
+      form,
     } = this.props;
     const { Input } = this.components;
     const { inputIsHidden } = this.state;
@@ -1422,6 +1423,7 @@ export default class Select extends Component<Props, State> {
           readOnly
           disabled={isDisabled}
           tabIndex={tabIndex}
+          form={form}
           value=""
           {...ariaAttributes}
         />
@@ -1447,6 +1449,7 @@ export default class Select extends Component<Props, State> {
         selectProps={selectProps}
         spellCheck="false"
         tabIndex={tabIndex}
+        form={form}
         theme={theme}
         type="text"
         value={inputValue}

--- a/packages/react-select/src/components/Input.js
+++ b/packages/react-select/src/components/Input.js
@@ -15,6 +15,8 @@ export type InputProps = PropsWithStyles & {
   /** Whether the input is disabled */
   isDisabled?: boolean,
   className?: string,
+  /** The ID of the form that the input belongs to */
+  form?: string,
 };
 
 export const inputCSS = ({


### PR DESCRIPTION
Issue: react-select ignores the HTML5 "form" attribute, which you can use to specify which form element to submit when the user presses "Enter" while the Select has focus.

Repro: https://codesandbox.io/s/jovial-montalcini-7dppv

Steps:
1. Using a modern browser, focus the "Name" field and press "Enter", a green toast should appear.
2. Focus the "Role" field and press "Enter" twice, once to close the menu and again to submit. Nothing happens.
3. Check the checkbox to "fix" the Input component.
4. Repeat step #2, the toast should appear.

Reference for the "form" attribute
https://devdocs.io/html/element/input#form