### PR TITLE
Fixes #3335 - removes the call to onMenuOpen within handleInputChange

### DIFF
--- a/.changeset/thick-eyes-walk.md
+++ b/.changeset/thick-eyes-walk.md
@@ -1,0 +1,8 @@
+---
+'react-select': patch
+---
+
+Removes the call to `onMenuOpen` on every input change
+
+If you were relying on this undesired behavior it may be a breaking change.
+Please upgrade accordingly.

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1089,6 +1089,9 @@ export default class Select extends Component<Props, State> {
     const inputValue = event.currentTarget.value;
     this.inputIsHiddenAfterUpdate = false;
     this.onInputChange(inputValue, { action: 'input-change' });
+    if (!this.props.menuIsOpen) {
+      this.onMenuOpen();
+    }
   };
   onInputFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     const { isSearchable, isMulti } = this.props;

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1089,7 +1089,6 @@ export default class Select extends Component<Props, State> {
     const inputValue = event.currentTarget.value;
     this.inputIsHiddenAfterUpdate = false;
     this.onInputChange(inputValue, { action: 'input-change' });
-    this.onMenuOpen();
   };
   onInputFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     const { isSearchable, isMulti } = this.props;


### PR DESCRIPTION
As discussed in https://github.com/JedWatson/react-select/issues/3335 and https://github.com/JedWatson/react-select/issues/3620 , the expected behavior of `onMenuOpen` is to be triggered when the Menu opens.
Currently it is called on every input change as well which is quite confusing.

Removing the call of `onMenuOpen` within `handleInputChange` gives us the expected behavior.