### PR TITLE
Update MenuPlacer context usage to the new context API

### DIFF
--- a/.changeset/update-context-api.md
+++ b/.changeset/update-context-api.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Update MenuPlacer context usage in order to the new React Context API


### PR DESCRIPTION
This solves #3916, and partially addresses #3703.

From React 16.3 the old Context API was deprecated and
it's rising warnings when runng in strict-mode.