### PR TITLE
A11yText DOM structure fix (breaking W3C validation)

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1798,8 +1798,8 @@ export default class Select extends Component<Props, State> {
     if (!this.state.isFocused) return null;
     return (
       <A11yText aria-live="polite">
-        <p id="aria-selection-event">&nbsp;{this.state.ariaLiveSelection}</p>
-        <p id="aria-context">&nbsp;{this.constructAriaLiveMessage()}</p>
+        <span id="aria-selection-event">&nbsp;{this.state.ariaLiveSelection}</span>
+        <span id="aria-context">&nbsp;{this.constructAriaLiveMessage()}</span>
       </A11yText>
     );
   }


### PR DESCRIPTION
Step to reproduce : 

- Open this simple example : https://bzuy9.csb.app (taken from https://codesandbox.io/s/bzuy9?module=/example.js)
- Display the menu list 
- W3C validate that

W3C errors output : 

```
Error: Element p not allowed as child of element span in this context. (Suppressing further errors from this subtree.)

From line 286, column 54071; to line 286, column 54099

a11yText"><p id="aria-selection-event">&nbsp;

Contexts in which element p may be used:
Where flow content is expected.
Content model for element span:
Phrasing content.
Error: Element p not allowed as child of element span in this context. (Suppressing further errors from this subtree.)

From line 286, column 54134; to line 286, column 54154

ected.</p><p id="aria-context">&nbsp;
```

W3C is breaking because of A11yText of type span wrapping p elements.