### PR TITLE
Fix focus disable option when menu open

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1326,7 +1326,7 @@ export default class Select extends Component<Props, State> {
           const children = items
             .map((child, i) => {
               const option = toOption(child, `${itemIndex}-${i}`);
-              if (option) acc.focusable.push(child);
+              if (option && !option.isDisabled) acc.focusable.push(child);
               return option;
             })
             .filter(Boolean);
@@ -1342,7 +1342,9 @@ export default class Select extends Component<Props, State> {
         } else {
           const option = toOption(item, `${itemIndex}`);
           if (option) {
-            acc.render.push(option);
+            if (!option.isDisabled) {
+              acc.render.push(option);
+            }
             acc.focusable.push(item);
           }
         }


### PR DESCRIPTION
Hello!

I fix a bug(may be).
when I open the Select, Select focus a first option.
But I don't this work, if a first option is `isDisabled`.
Because, `isDisabled option` can't be hovered and selected on default setting.
`isDisabled option` is disable but, we see that enabled option.(Please see gif ↓↓↓↓)
So, I omit disabled option from `options.focusable`.

Let me apologize for my poor English. 

---

|before|after|
|-----|-----|
|![before](https://user-images.githubusercontent.com/46431932/76530387-0130f580-64b7-11ea-8812-b89b282e0ddc.gif)|![after](https://user-images.githubusercontent.com/46431932/76529798-21ac8000-64b6-11ea-9f61-3c45101aa8f3.gif)|

※ I custom style 