### PR TITLE
Update cleanValue() to allow non-object values(string, number, etc.)

### DIFF
--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -2065,7 +2065,7 @@ cases(
     expect(
       container.querySelector('.react-select__placeholder')
     ).not.toBeInTheDocument();
-    rerender(<Select {...props} value="" />);
+    rerender(<Select {...props} value={null} />);
     expect(
       container.querySelector('.react-select__placeholder')
     ).toBeInTheDocument();

--- a/packages/react-select/src/utils.js
+++ b/packages/react-select/src/utils.js
@@ -62,8 +62,8 @@ export function classNames(
 // ==============================
 
 export const cleanValue = (value: ValueType): OptionsType => {
-  if (Array.isArray(value)) return value.filter(Boolean);
-  if (typeof value === 'object' && value !== null) return [value];
+  if (Array.isArray(value)) return value.filter(v => v !== undefined && v !== null);
+  if (value !== undefined && value !== null) return [value];
   return [];
 };
 


### PR DESCRIPTION
React-select is great and easy to use. I had a simple wrapper around react-select to allow non-object options like string, number, etc. for simple use case so that I don't need to construct object with 'label' & 'value' from simple type by overriding getOptionValue() and getOptionLabel(), but found it doesn't work.(display works fine but can't select a value), **it does work for multiple selection**. After looked into code I found it is caused by clearValue() which assuming 'option' is object. cleanValue() is only used for processing 'value' property, so please review if this can be merged.