### PR TITLE
Use pointer cursor for dropdown and options

### DIFF
--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.js.snap
@@ -38,6 +38,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-7:hover {
   border-color: hsl(0,0%,70%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -126,6 +127,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-5:hover {
   color: hsl(0,0%,60%);
+  cursor: pointer;
 }
 
 .emotion-4 {

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.js.snap
@@ -38,6 +38,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-7:hover {
   border-color: hsl(0,0%,70%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -126,6 +127,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-5:hover {
   color: hsl(0,0%,60%);
+  cursor: pointer;
 }
 
 .emotion-4 {

--- a/packages/react-select/src/__tests__/__snapshots__/Creatable.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Creatable.test.js.snap
@@ -38,6 +38,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-7:hover {
   border-color: hsl(0,0%,70%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -126,6 +127,7 @@ exports[`defaults - snapshot 1`] = `
 
 .emotion-5:hover {
   color: hsl(0,0%,60%);
+  cursor: pointer;
 }
 
 .emotion-4 {

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.js.snap
@@ -38,6 +38,7 @@ exports[`snapshot - defaults 1`] = `
 
 .emotion-7:hover {
   border-color: hsl(0,0%,70%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -126,6 +127,7 @@ exports[`snapshot - defaults 1`] = `
 
 .emotion-5:hover {
   color: hsl(0,0%,60%);
+  cursor: pointer;
 }
 
 .emotion-4 {

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.js.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.js.snap
@@ -38,6 +38,7 @@ exports[`defaults > snapshot 1`] = `
 
 .emotion-7:hover {
   border-color: hsl(0,0%,70%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -126,6 +127,7 @@ exports[`defaults > snapshot 1`] = `
 
 .emotion-5:hover {
   color: hsl(0,0%,60%);
+  cursor: pointer;
 }
 
 .emotion-4 {

--- a/packages/react-select/src/components/Control.js
+++ b/packages/react-select/src/components/Control.js
@@ -54,6 +54,7 @@ export const css = ({
 
   '&:hover': {
     borderColor: isFocused ? colors.primary : colors.neutral30,
+    cursor: isDisabled ? 'default' : 'pointer',
   },
 });
 

--- a/packages/react-select/src/components/Option.js
+++ b/packages/react-select/src/components/Option.js
@@ -55,7 +55,7 @@ export const optionCSS = ({
     : isSelected
     ? colors.neutral0
     : 'inherit',
-  cursor: 'default',
+  cursor: isFocused ? 'pointer' : 'default',
   display: 'block',
   fontSize: 'inherit',
   padding: `${spacing.baseUnit * 2}px ${spacing.baseUnit * 3}px`,

--- a/packages/react-select/src/components/indicators.js
+++ b/packages/react-select/src/components/indicators.js
@@ -68,6 +68,7 @@ const baseCSS = ({
 
   ':hover': {
     color: isFocused ? colors.neutral80 : colors.neutral40,
+    cursor: 'pointer',
   },
 });
 


### PR DESCRIPTION
 Issue: #3831 

This PR adds `cursor: pointer` CSS to the indicator icons, the option items (that are not disabled), and the container wrapping the select to indicate to the user that all of these items are clickable. 