### PR TITLE
fixed issue there menu scrolls into view even though menuShouldScroll…

### DIFF
--- a/packages/react-select/src/components/Menu.js
+++ b/packages/react-select/src/components/Menu.js
@@ -145,7 +145,9 @@ export function getMenuPlacement({
 
       // BOTTOM: allow browser to increase scrollable area and immediately set scroll
       if (placement === 'bottom') {
-        scrollTo(scrollParent, scrollDown);
+        if (shouldScroll) {
+          scrollTo(scrollParent, scrollDown);
+        }
         return { placement: 'bottom', maxHeight };
       }
       break;


### PR DESCRIPTION
…IntoView is false, happens when parent container is a scrollable div further down the page. The bug casues the menu bottom to be scrolled into view so that the select input/search is not visible