### PR TITLE
add autoComplete as prop to the Select component

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -51,17 +51,17 @@ import { defaultTheme, type ThemeConfig } from './theme';
 
 import type {
   ActionMeta,
-    ActionTypes,
-    FocusDirection,
-    FocusEventHandler,
-    GroupType,
-    InputActionMeta,
-    KeyboardEventHandler,
-    MenuPlacement,
-    MenuPosition,
-    OptionsType,
-    OptionType,
-    ValueType,
+  ActionTypes,
+  FocusDirection,
+  FocusEventHandler,
+  GroupType,
+  InputActionMeta,
+  KeyboardEventHandler,
+  MenuPlacement,
+  MenuPosition,
+  OptionsType,
+  OptionType,
+  ValueType,
 } from './types';
 
 type MouseOrTouchEvent =
@@ -130,8 +130,8 @@ export type Props = {
   escapeClearsValue: boolean,
   /* Custom method to filter whether an option should be displayed in the menu */
   filterOption:
-  | (({ label: string, value: string, data: OptionType }, string) => boolean)
-  | null,
+    | (({ label: string, value: string, data: OptionType }, string) => boolean)
+    | null,
   /*
     Formats group labels in the menu as React components
 
@@ -1385,19 +1385,19 @@ export default class Select extends Component<Props, State> {
     // An aria live message representing the currently focused value in the select.
     const focusedValueMsg = focusedValue
       ? valueFocusAriaMessage({
-        focusedValue,
-        getOptionLabel: this.getOptionLabel,
-        selectValue,
-      })
+          focusedValue,
+          getOptionLabel: this.getOptionLabel,
+          selectValue,
+        })
       : '';
     // An aria live message representing the currently focused option in the select.
     const focusedOptionMsg =
       focusedOption && menuIsOpen
         ? optionFocusAriaMessage({
-          focusedOption,
-          getOptionLabel: this.getOptionLabel,
-          options,
-        })
+            focusedOption,
+            getOptionLabel: this.getOptionLabel,
+            options,
+          })
         : '';
     // An aria live message representing the set of focusable results and current searchterm/inputvalue.
     const resultsMsg = resultsAriaMessage({
@@ -1778,8 +1778,8 @@ export default class Select extends Component<Props, State> {
         {menuElement}
       </MenuPortal>
     ) : (
-        menuElement
-      );
+      menuElement
+    );
   }
   renderFormField() {
     const { delimiter, isDisabled, isMulti, name } = this.props;
@@ -1805,8 +1805,8 @@ export default class Select extends Component<Props, State> {
               />
             ))
           ) : (
-              <input name={name} type="hidden" />
-            );
+            <input name={name} type="hidden" />
+          );
 
         return <div>{input}</div>;
       }

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -71,11 +71,12 @@ test('isRtl boolean prop sets direction: rtl on container', () => {
 });
 
 test('autoComplete string prop is passed down to the control component', () => {
-  let selectWrapper = mount(
+  let { container } = render(
     <Select {...BASIC_PROPS} value={[OPTIONS[0]]} autoComplete="new-password" />
   );
-  expect(selectWrapper.props().autoComplete).toBe('new-password');
-  expect(selectWrapper.find(Input).props().autoComplete).toBe('new-password');
+  expect(container.querySelector('.react-select__input input').getAttribute('autoComplete')).toBe(
+    'new-password'
+  );
 });
 
 test('isOptionSelected() prop > single select > mark value as isSelected if isOptionSelected returns true for the option', () => {


### PR DESCRIPTION
Based off PR #3666 by @lvl99

Updated tests and other misc changes.

> As mentioned in issue #3500 and #2395 and having my own need to set an explicit autoComplete value (namely to prevent Google Chrome from showing its autofill drop-down on top of the react-select drop-down) I've attempted a quick simple fix.