### PR TITLE
Support for required attribute

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -245,6 +245,8 @@ export type Props = {
   value: ValueType,
   /* Sets the form attribute on the input */
   form?: string,
+  /** Checks if the select has some value */
+  required?: boolean,
 };
 
 export const defaultProps = {
@@ -1411,6 +1413,8 @@ export default class Select extends Component<Props, State> {
       isSearchable,
       inputId,
       inputValue,
+      value,
+      required,
       tabIndex,
       form,
     } = this.props;
@@ -1467,7 +1471,8 @@ export default class Select extends Component<Props, State> {
         form={form}
         theme={theme}
         type="text"
-        value={inputValue}
+        value={value ? value.value : inputValue}
+        required={required}
         {...ariaAttributes}
       />
     );

--- a/packages/react-select/src/components/Input.js
+++ b/packages/react-select/src/components/Input.js
@@ -16,7 +16,11 @@ export type InputProps = PropsWithStyles & {
   isDisabled?: boolean,
   className?: string,
   /** The ID of the form that the input belongs to */
-  form?: string,
+  form ?: string,
+  /** Checks if the select has some value */
+  required ?: boolean,
+  /* The value of the select; reflected by the selected option */
+  value?: string,
 };
 
 export const inputCSS = ({
@@ -28,6 +32,13 @@ export const inputCSS = ({
   paddingTop: spacing.baseUnit / 2,
   visibility: isDisabled ? 'hidden' : 'visible',
   color: colors.neutral80,
+  });
+export const inputRequiredCSS = () => ({
+  position: 'absolute',
+  bottom: 0,
+  left: '1rem',
+  opacity: 0,
+  height: 0,
 });
 const inputStyle = isHidden => ({
   label: 'input',
@@ -49,6 +60,8 @@ const Input = ({
   isDisabled,
   theme,
   selectProps,
+  required,
+  value,
   ...props
 }: InputProps) => (
   <div css={getStyles('input', { theme, ...props })}>
@@ -58,7 +71,14 @@ const Input = ({
       inputStyle={inputStyle(isHidden)}
       disabled={isDisabled}
       {...props}
-    />
+      />
+      {!isDisabled
+        && <input
+            tabIndex={-1}
+            autoComplete="off"
+            style={getStyles('inputRequired', { theme, ...props })}
+            required={required}
+            value={value} />}
   </div>
 );
 

--- a/packages/react-select/src/styles.js
+++ b/packages/react-select/src/styles.js
@@ -13,7 +13,7 @@ import {
   loadingIndicatorCSS,
   indicatorSeparatorCSS,
 } from './components/indicators';
-import { inputCSS } from './components/Input';
+import { inputCSS, inputRequiredCSS } from './components/Input';
 import { placeholderCSS } from './components/Placeholder';
 import { optionCSS } from './components/Option';
 import {
@@ -45,6 +45,7 @@ export type Styles = {
   indicatorsContainer?: StyleFn,
   indicatorSeparator?: StyleFn,
   input?: StyleFn,
+  inputRequired?: StyleFn,
   loadingIndicator?: StyleFn,
   loadingMessage?: StyleFn,
   menu?: StyleFn,
@@ -72,6 +73,7 @@ export const defaultStyles: Styles = {
   indicatorsContainer: indicatorsContainerCSS,
   indicatorSeparator: indicatorSeparatorCSS,
   input: inputCSS,
+  inputRequired: inputRequiredCSS,
   loadingIndicator: loadingIndicatorCSS,
   loadingMessage: loadingMessageCSS,
   menu: menuCSS,


### PR DESCRIPTION
Required prop added to base Select and also to Input component.

At Input, a regular HTML Input was created just to handle the required as the AutosizeInput does not handle it (don't know why). The selected value is sent to that hidden input, if any.

Now native HTML validation works!
