### PR TITLE
Fix makeCreatableSelect(...) for uncontrolled inputValue

### DIFF
--- a/.changeset/seven-mayflies-brush.md
+++ b/.changeset/seven-mayflies-brush.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fixed `makeCreatableSelect(...)` for uncontrolled `inputValue` prop

--- a/packages/react-select/src/Creatable.js
+++ b/packages/react-select/src/Creatable.js
@@ -11,6 +11,7 @@ import React, {
 import Select, { type Props as SelectProps } from './Select';
 import type { OptionType, OptionsType, ValueType, ActionMeta, InputActionMeta } from './types';
 import { cleanValue } from './utils';
+import manageState from './stateManager';
 
 export type DefaultCreatableProps = {|
   /* Allow options to be created while the `isLoading` prop is true. Useful to
@@ -170,8 +171,12 @@ export const makeCreatableSelect = <C: {}>(
   };
 
 // TODO: do this in package entrypoint
-export default makeCreatableSelect<ElementConfig<typeof Select>>(
+const SelectCreatable = makeCreatableSelect<ElementConfig<typeof Select>>(
   Select
+);
+
+export default manageState<ElementConfig<typeof SelectCreatable>>(
+  SelectCreatable
 );
 
 const inputIsControlled = (props: CreatableProps): boolean => typeof props.inputValue === 'string';

--- a/packages/react-select/src/Creatable.js
+++ b/packages/react-select/src/Creatable.js
@@ -94,16 +94,16 @@ export const makeCreatableSelect = <C: {}>(
     select: ElementRef<*>;
     buildOptions = createMemoizedOptionsBuilder();
     state = {
-      inputValue: ''
+      inputValue: '',
     };
     static getDerivedStateFromProps(props: CreatableProps, state: State) {
       if (inputIsControlled(props) && props.inputValue !== state.inputValue) {
         return {
           inputValue: props.inputValue
-        }
+        };
       }
 
-      return null
+      return null;
     }
     onChange = (newValue: ValueType, actionMeta: ActionMeta) => {
       const {

--- a/packages/react-select/src/__tests__/Creatable.test.js
+++ b/packages/react-select/src/__tests__/Creatable.test.js
@@ -104,6 +104,33 @@ const executeTests = (Creatable: any) => {
   );
 
   cases(
+    'uncontrolled inputValue does not match any option after filter',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+
+      const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
+      const input = container.querySelector('input')
+      fireEvent.change(input, { target: { value: 'option not is list'} })
+      rerender(
+        <Creatable menuIsOpen {...props} />
+      );
+
+      expect(container.querySelector('.react-select__menu').textContent).toBe(
+        'Create "option not is list"'
+      );
+    },
+    {
+      'single select > should show a placeholder "create..." prompt': {},
+      'multi select > should show a placeholder "create..." prompt': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+
+  cases(
     'isValidNewOption() prop',
     ({ props }) => {
       props = { ...BASIC_PROPS, ...props };

--- a/packages/react-select/src/__tests__/Creatable.test.js
+++ b/packages/react-select/src/__tests__/Creatable.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import cases from 'jest-in-case';
 
-import Creatable from '../Creatable';
+import Select from '../Select';
+import Creatable, { makeCreatableSelect } from '../Creatable';
 import { OPTIONS } from './constants';
 
 const BASIC_PROPS = {
@@ -21,236 +22,243 @@ test('defaults - snapshot', () => {
   expect(container).toMatchSnapshot();
 });
 
-cases(
-  'filtered option is an exact match for an existing option',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-    const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
-    rerender(<Creatable inputValue="one" menuIsOpen {...props} />);
-    expect(
-      container.querySelector('.react-select__menu').textContent
-    ).not.toEqual(expect.stringContaining('create'));
-  },
-  {
-    'single select > should not show "create..." prompt"': {},
-    'multi select > should not show "create..." prompt"': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
+const executeTests = (Creatable: any) => {
+  cases(
+    'filtered option is an exact match for an existing option',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+      const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
+      rerender(<Creatable inputValue="one" menuIsOpen {...props} />);
+      expect(
+        container.querySelector('.react-select__menu').textContent
+      ).not.toEqual(expect.stringContaining('create'));
     },
-  }
-);
-
-cases(
-  'filterOptions returns invalid value ( null )',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-    let filterOptionSpy = jest.fn().mockReturnValue(null);
-
-    const { container, rerender } = render(
-      <Creatable filterOption={filterOptionSpy} menuIsOpen {...props} />
-    );
-    rerender(
-      <Creatable
-        filterOption={filterOptionSpy}
-        menuIsOpen
-        inputValue="one"
-        {...props}
-      />
-    );
-
-    expect(
-      container.querySelector('.react-select__menu-notice--no-options')
-        .textContent
-    ).toEqual(expect.stringContaining('No options'));
-  },
-  {
-    'single select > should not show "create..." prompt"': {},
-    'multi select > should not show "create..." prompt"': {
-      props: {
-        isMulti: true,
-        option: OPTIONS,
+    {
+      'single select > should not show "create..." prompt"': {},
+      'multi select > should not show "create..." prompt"': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
       },
-    },
-  }
-);
-
-cases(
-  'inputValue does not match any option after filter',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-
-    const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
-    rerender(
-      <Creatable menuIsOpen {...props} inputValue="option not is list" />
-    );
-
-    expect(container.querySelector('.react-select__menu').textContent).toBe(
-      'Create "option not is list"'
-    );
-  },
-  {
-    'single select > should show a placeholder "create..." prompt': {},
-    'multi select > should show a placeholder "create..." prompt': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
-    },
-  }
-);
-
-cases(
-  'isValidNewOption() prop',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-    let isValidNewOption = jest.fn(options => options === 'new Option');
-
-    const { container, rerender } = render(
-      <Creatable menuIsOpen isValidNewOption={isValidNewOption} {...props} />
-    );
-
-    rerender(
-      <Creatable
-        menuIsOpen
-        isValidNewOption={isValidNewOption}
-        {...props}
-        inputValue="new Option"
-      />
-    );
-
-    expect(container.querySelector('.react-select__menu').textContent).toEqual(
-      'Create "new Option"'
-    );
-
-    expect(
-      container.querySelector('.react-select__menu-notice--no-options')
-    ).toBeFalsy();
-
-    rerender(
-      <Creatable
-        menuIsOpen
-        isValidNewOption={isValidNewOption}
-        inputValue="invalid new Option"
-        {...props}
-      />
-    );
-    expect(
-      container.querySelector('.react-select__menu').textContent
-    ).not.toEqual('Create "invalid new Option"');
-
-    expect(
-      container.querySelector('.react-select__menu-notice--no-options')
-    ).toBeTruthy();
-  },
-  {
-    'single select > should show "create..." prompt only if isValidNewOption returns thruthy value': {},
-    'multi select > should show "create..." prompt only if isValidNewOption returns thruthy value': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
-    },
-  }
-);
-
-cases(
-  'close by hitting escape with search text present',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-    const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
-    rerender(<Creatable menuIsOpen inputValue="new Option" {...props} />);
-    fireEvent.keyDown(container, { keyCode: 27, key: 'Escape' });
-    expect(container.querySelector('input').textContent).toEqual('');
-  },
-  {
-    'single select > should remove the search text': {},
-    'multi select > should remove the search text': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
-    },
-  }
-);
-
-test('should remove the new option after closing on blur', () => {
-  const { container, rerender } = render(
-    <Creatable menuIsOpen options={OPTIONS} />
+    }
   );
-  rerender(<Creatable menuIsOpen options={OPTIONS} inputValue="new Option" />);
-  fireEvent.blur(container);
-  expect(container.querySelector('input').textContent).toEqual('');
+
+  cases(
+    'filterOptions returns invalid value ( null )',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+      let filterOptionSpy = jest.fn().mockReturnValue(null);
+
+      const { container, rerender } = render(
+        <Creatable filterOption={filterOptionSpy} menuIsOpen {...props} />
+      );
+      rerender(
+        <Creatable
+          filterOption={filterOptionSpy}
+          menuIsOpen
+          inputValue="one"
+          {...props}
+        />
+      );
+
+      expect(
+        container.querySelector('.react-select__menu-notice--no-options')
+          .textContent
+      ).toEqual(expect.stringContaining('No options'));
+    },
+    {
+      'single select > should not show "create..." prompt"': {},
+      'multi select > should not show "create..." prompt"': {
+        props: {
+          isMulti: true,
+          option: OPTIONS,
+        },
+      },
+    }
+  );
+
+  cases(
+    'inputValue does not match any option after filter',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+
+      const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
+      rerender(
+        <Creatable menuIsOpen {...props} inputValue="option not is list" />
+      );
+
+      expect(container.querySelector('.react-select__menu').textContent).toBe(
+        'Create "option not is list"'
+      );
+    },
+    {
+      'single select > should show a placeholder "create..." prompt': {},
+      'multi select > should show a placeholder "create..." prompt': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+
+  cases(
+    'isValidNewOption() prop',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+      let isValidNewOption = jest.fn(options => options === 'new Option');
+
+      const { container, rerender } = render(
+        <Creatable menuIsOpen isValidNewOption={isValidNewOption} {...props} />
+      );
+
+      rerender(
+        <Creatable
+          menuIsOpen
+          isValidNewOption={isValidNewOption}
+          {...props}
+          inputValue="new Option"
+        />
+      );
+
+      expect(container.querySelector('.react-select__menu').textContent).toEqual(
+        'Create "new Option"'
+      );
+
+      expect(
+        container.querySelector('.react-select__menu-notice--no-options')
+      ).toBeFalsy();
+
+      rerender(
+        <Creatable
+          menuIsOpen
+          isValidNewOption={isValidNewOption}
+          inputValue="invalid new Option"
+          {...props}
+        />
+      );
+      expect(
+        container.querySelector('.react-select__menu').textContent
+      ).not.toEqual('Create "invalid new Option"');
+
+      expect(
+        container.querySelector('.react-select__menu-notice--no-options')
+      ).toBeTruthy();
+    },
+    {
+      'single select > should show "create..." prompt only if isValidNewOption returns thruthy value': {},
+      'multi select > should show "create..." prompt only if isValidNewOption returns thruthy value': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+
+  cases(
+    'close by hitting escape with search text present',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+      const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
+      rerender(<Creatable menuIsOpen inputValue="new Option" {...props} />);
+      fireEvent.keyDown(container, { keyCode: 27, key: 'Escape' });
+      expect(container.querySelector('input').textContent).toEqual('');
+    },
+    {
+      'single select > should remove the search text': {},
+      'multi select > should remove the search text': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+
+  test('should remove the new option after closing on blur', () => {
+    const { container, rerender } = render(
+      <Creatable menuIsOpen options={OPTIONS} />
+    );
+    rerender(<Creatable menuIsOpen options={OPTIONS} inputValue="new Option" />);
+    fireEvent.blur(container);
+    expect(container.querySelector('input').textContent).toEqual('');
+  });
+
+  cases(
+    'getNewOptionData() prop',
+    ({ props }) => {
+      props = { ...BASIC_PROPS, ...props };
+      let getNewOptionDataSpy = jest.fn(label => ({
+        label: `custom text ${label}`,
+        value: label,
+      }));
+      const { container, rerender } = render(
+        <Creatable menuIsOpen getNewOptionData={getNewOptionDataSpy} {...props} />
+      );
+      rerender(
+        <Creatable
+          menuIsOpen
+          getNewOptionData={getNewOptionDataSpy}
+          inputValue="new Option"
+          {...props}
+        />
+      );
+
+      expect(container.querySelector('.react-select__menu').textContent).toEqual(
+        'custom text new Option'
+      );
+    },
+    {
+      'single select > should create option as per label returned from getNewOptionData': {},
+      'multi select > should create option as per label returned from getNewOptionData': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+
+  cases(
+    'formatCreateLabel() prop',
+    ({ props = { options: OPTIONS } }) => {
+      props = { ...BASIC_PROPS, ...props };
+      let formatCreateLabelSpy = jest.fn(label => `custom label "${label}"`);
+      const { container, rerender } = render(
+        <Creatable
+          menuIsOpen
+          formatCreateLabel={formatCreateLabelSpy}
+          {...props}
+        />
+      );
+
+      rerender(
+        <Creatable
+          menuIsOpen
+          formatCreateLabel={formatCreateLabelSpy}
+          inputValue="new Option"
+          {...props}
+        />
+      );
+      expect(container.querySelector('.react-select__menu').textContent).toEqual(
+        'custom label "new Option"'
+      );
+    },
+    {
+      'single select > should show label of custom option as per text returned from formatCreateLabel': {},
+      'multi select > should show label of custom option as per text returned from formatCreateLabel': {
+        props: {
+          isMulti: true,
+          options: OPTIONS,
+        },
+      },
+    }
+  );
+};
+
+executeTests(Creatable);
+describe('makeCreatableSelect(Select)', () => {
+  executeTests(makeCreatableSelect(Select));
 });
-
-cases(
-  'getNewOptionData() prop',
-  ({ props }) => {
-    props = { ...BASIC_PROPS, ...props };
-    let getNewOptionDataSpy = jest.fn(label => ({
-      label: `custom text ${label}`,
-      value: label,
-    }));
-    const { container, rerender } = render(
-      <Creatable menuIsOpen getNewOptionData={getNewOptionDataSpy} {...props} />
-    );
-    rerender(
-      <Creatable
-        menuIsOpen
-        getNewOptionData={getNewOptionDataSpy}
-        inputValue="new Option"
-        {...props}
-      />
-    );
-
-    expect(container.querySelector('.react-select__menu').textContent).toEqual(
-      'custom text new Option'
-    );
-  },
-  {
-    'single select > should create option as per label returned from getNewOptionData': {},
-    'multi select > should create option as per label returned from getNewOptionData': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
-    },
-  }
-);
-
-cases(
-  'formatCreateLabel() prop',
-  ({ props = { options: OPTIONS } }) => {
-    props = { ...BASIC_PROPS, ...props };
-    let formatCreateLabelSpy = jest.fn(label => `custom label "${label}"`);
-    const { container, rerender } = render(
-      <Creatable
-        menuIsOpen
-        formatCreateLabel={formatCreateLabelSpy}
-        {...props}
-      />
-    );
-
-    rerender(
-      <Creatable
-        menuIsOpen
-        formatCreateLabel={formatCreateLabelSpy}
-        inputValue="new Option"
-        {...props}
-      />
-    );
-    expect(container.querySelector('.react-select__menu').textContent).toEqual(
-      'custom label "new Option"'
-    );
-  },
-  {
-    'single select > should show label of custom option as per text returned from formatCreateLabel': {},
-    'multi select > should show label of custom option as per text returned from formatCreateLabel': {
-      props: {
-        isMulti: true,
-        options: OPTIONS,
-      },
-    },
-  }
-);

--- a/packages/react-select/src/__tests__/Creatable.test.js
+++ b/packages/react-select/src/__tests__/Creatable.test.js
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import cases from 'jest-in-case';
 
 import Select from '../Select';
-import Creatable, { makeCreatableSelect } from '../Creatable';
+import CreatableSelect, { makeCreatableSelect } from '../Creatable';
 import { OPTIONS } from './constants';
 
 const BASIC_PROPS = {
@@ -18,7 +18,7 @@ const BASIC_PROPS = {
 };
 
 test('defaults - snapshot', () => {
-  const { container } = render(<Creatable />);
+  const { container } = render(<CreatableSelect />);
   expect(container).toMatchSnapshot();
 });
 
@@ -108,12 +108,9 @@ const executeTests = (Creatable: any) => {
     ({ props }) => {
       props = { ...BASIC_PROPS, ...props };
 
-      const { container, rerender } = render(<Creatable menuIsOpen {...props} />);
-      const input = container.querySelector('input')
-      fireEvent.change(input, { target: { value: 'option not is list'} })
-      rerender(
-        <Creatable menuIsOpen {...props} />
-      );
+      const { container } = render(<Creatable menuIsOpen {...props} />);
+      const input = container.querySelector('input');
+      fireEvent.change(input, { target: { value: 'option not is list' } });
 
       expect(container.querySelector('.react-select__menu').textContent).toBe(
         'Create "option not is list"'
@@ -285,7 +282,7 @@ const executeTests = (Creatable: any) => {
   );
 };
 
-executeTests(Creatable);
+executeTests(CreatableSelect);
 describe('makeCreatableSelect(Select)', () => {
   executeTests(makeCreatableSelect(Select));
 });


### PR DESCRIPTION
Hey,

currently it is not possible to use `makeCreatableSelect(...)` without controlling the `inputValue` property, as filed in #4206.
This is also why the default export was wrapped in `manageState(...)`, which I was able to remove after fixing the mentioned issue.

I also added a Jest test case for the described behavior and refactored `makeCreatableSelect(...)` to not use `UNSAFE_componentWillReceiveProps(...)` anymore and improved its memoization of the generated `options`.

@JedWatson this is a pure bugfix, I'd be very happy about a timely merge. In case anything is missing/faulty, you have questions or something else comes up, just ping me.

Thanks in advance.