### PR TITLE
Documentation: Fix code example in CustomNoOptionsMessage.js

### DIFF
--- a/docs/examples/CustomNoOptionsMessage.js
+++ b/docs/examples/CustomNoOptionsMessage.js
@@ -20,7 +20,7 @@ const CustomNoOptionsMessage = () => {
     <Select
       isClearable
       components={{ NoOptionsMessage }}
-      styles={{ NoOptionsMessage: base => ({ ...base, ...msgStyles }) }}
+      styles={{ noOptionsMessage: base => ({ ...base, ...msgStyles }) }}
       isSearchable
       name="color"
       options={[]}


### PR DESCRIPTION
Change incorrectly passed custom component into styles to a styles property.

The custom `msgStyles` added to the `NoOptionsMessage` custom component example [on this page](https://react-select.com/components) are not showing up because the custom styles are added to `NoOptionsMessage` property instead of the correct one `noOptionsMessage`.

This fix will hopefully make the custom styles show up in the example.

P.s. Please note I was unable to run the docs website locally to verify this change. I've opened issue #4232 for this.