### PR TITLE
Add instructions for running docs locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,21 @@ changes, feel free to ping @gwyneplaine
 * Please [follow our established coding conventions](https://github.com/keystonejs/keystone/wiki/Coding-Standards)
 (with regards to formatting, etc)
 * All new features and changes need documentation.
+
+## Running the docs website
+
+You can run the website in a local environment using the following steps:
+
+```sh
+git clone https://github.com/JedWatson/react-select
+cd react-select
+yarn
+yarn build
+cd docs
+yarn
+yarn start
+```
+**Note:**
+
+* We recommend using [yarn](https://classic.yarnpkg.com/en/) for setting up the local development environment for this project. Using `npm` might raise unexpected errors.
+* The docs come without a compiled react-select build. You have to run the **build** task in the project's root directory before running the **start** task as shown above. Alternatively, you can run the **watch** task in parallel.


### PR DESCRIPTION
It took me a couple of days to figure out how to run the docs website locally. Hopefully, these changes will make it easier to understand for other people. 

The current CONTRIBUTING file makes no mention that the repository only works with `yarn` and not `npm`. There is also no mention that a local build task needs to be run before starting a local instance of the docs.

Please feel free to suggest any changes if I've gotten something wrong in the instructions but I really think these should be in the CONTRIBUTING file. Many people are used to `npm` and might run into the same errors I did.

Related: #4232 