### PR TITLE
Update babel runtime

### DIFF
--- a/.changeset/strange-islands-press.md
+++ b/.changeset/strange-islands-press.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Update babel runtime to fix issues caused by strict mode on ESM imports which has been enabled in Webpack 5

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "https://github.com/JedWatson/react-select/tree/master/packages/react-select",
   "dependencies": {
-    "@babel/runtime": "^7.4.4",
+    "@babel/runtime": "^7.12.1",
     "@emotion/cache": "^10.0.9",
     "@emotion/core": "^10.0.9",
     "@emotion/css": "^10.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"


### PR DESCRIPTION
Fixes #4253 
Update `@babel/runtime` to fix issues with strict mode on the ESM modules imports
