### PR TITLE
Fix menuplacement context

### DIFF
--- a/.changeset/rotten-sheep-check.md
+++ b/.changeset/rotten-sheep-check.md
@@ -1,0 +1,6 @@
+---
+"react-select": patch
+"@react-select/docs": patch
+---
+
+Fix menuplacement context

--- a/docs/examples/MenuPortal.js
+++ b/docs/examples/MenuPortal.js
@@ -51,6 +51,7 @@ export default class MenuPortal extends Component<*, State> {
               menuPosition={isFixed ? 'fixed' : 'absolute'}
               menuPlacement={portalPlacement}
               options={colourOptions}
+              menuShouldScrollIntoView={false}
             />
             <Note Tag="label">
               <select

--- a/packages/react-select/src/components/Menu.js
+++ b/packages/react-select/src/components/Menu.js
@@ -258,7 +258,9 @@ export const menuCSS = ({
   zIndex: 1,
 });
 
-const PortalPlacementContext = createContext<() => void>(() => { });
+const PortalPlacementContext = createContext<{
+  getPortalPlacement?: (() => void) | null,
+}>({ getPortalPlacement: null });
 
 // NOTE: internal only
 export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
@@ -277,7 +279,6 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
       menuShouldScrollIntoView,
       theme,
     } = this.props;
-    const { getPortalPlacement } = this.context;
 
     if (!ref) return;
 
@@ -295,6 +296,7 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
       theme,
     });
 
+    const { getPortalPlacement } = this.context;
     if (getPortalPlacement) getPortalPlacement(state);
 
     this.setState(state);
@@ -520,7 +522,9 @@ export class MenuPortal extends Component<MenuPortalProps, MenuPortalState> {
     );
 
     return (
-      <PortalPlacementContext.Provider value={this.getPortalPlacement}>
+      <PortalPlacementContext.Provider
+        value={{ getPortalPlacement: this.getPortalPlacement }}
+      >
         {appendTo ? createPortal(menuWrapper, appendTo) : menuWrapper}
       </PortalPlacementContext.Provider>
     );


### PR DESCRIPTION
This PR fixes a regression that was introduced when we merged #3928, where the `getPortalPlacement` function would always be null in the new context.

@bladey and I picked this up when reviewing #4103 - thanks @s-o-r-o-u-s-h for the correct implementation that drew our attention to it.

Thanks also to @ebonow for the real-time pairing as we reviewed this 🎉

This also corrects an issue in the MenuPortal example that lets this be tested using the web inspector, although we've discovered another bug to do with automatic menu placement when using portals which we'll look into further later.

Having merged the bug into master without resolution was blocking the next release, which hopefully we can get on with again now.