### PR TITLE
fix null value error

### DIFF
--- a/docs/examples/CreatableInputOnly.js
+++ b/docs/examples/CreatableInputOnly.js
@@ -21,7 +21,7 @@ export default class CreatableInputOnly extends Component<*, State> {
     console.log(value);
     console.log(`action: ${actionMeta.action}`);
     console.groupEnd();
-    this.setState({ value });
+    this.setState({ value: value ? value : [] });
   };
   handleInputChange = (inputValue: string) => {
     this.setState({ inputValue });


### PR DESCRIPTION
fix null value error. This example breaks when a user clears all the input and tries to type in a new value. Value is null when input is cleared.
![Screenshot 2020-11-25 at 7 13 36 PM](https://user-images.githubusercontent.com/30773360/100266615-66981a00-2f52-11eb-9bac-717593218ba0.png)
