### PR TITLE
feat: add access to portal menu wrapper via classname

### DIFF
--- a/packages/react-select/src/components/Menu.js
+++ b/packages/react-select/src/components/Menu.js
@@ -508,6 +508,8 @@ export class MenuPortal extends Component<MenuPortalProps, MenuPortalState> {
   render() {
     const {
       appendTo,
+      className,
+      cx,
       children,
       controlElement,
       menuPlacement,
@@ -529,7 +531,12 @@ export class MenuPortal extends Component<MenuPortalProps, MenuPortalState> {
 
     // same wrapper element whether fixed or portalled
     const menuWrapper = (
-      <div css={getStyles('menuPortal', state)}>{children}</div>
+      <div
+        css={getStyles('menuPortal', state)}
+        className={cx({ 'menu-portal': true }, className)}
+      >
+        {children}
+      </div>
     );
 
     return (


### PR DESCRIPTION
Currently it's quite tricky to style portal wrapper when using classNamePrefix and classes for styling, this commit adds 'menu-portal' suffix to the content wrapper