### PR TITLE
Remove unnecessary dependency on @emotion/css

### DIFF
--- a/.changeset/pretty-carpets-mix.md
+++ b/.changeset/pretty-carpets-mix.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Remove unnecessary dependency on @emotion/css

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@changesets/get-github-info": "^0.2.1",
     "@emotion/babel-plugin": "^11.0.0",
     "@emotion/cache": "^11.0.0",
-    "@emotion/css": "^11.0.0",
     "@emotion/jest": "^11.1.0",
     "@emotion/react": "^11.1.1",
     "@preconstruct/cli": "^1.0.0",

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@emotion/cache": "^11.0.0",
-    "@emotion/css": "^11.0.0",
     "@emotion/react": "^11.1.1",
     "memoize-one": "^5.0.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,17 +1364,6 @@
     "@emotion/memoize" "^0.7.4"
     stylis "^4.0.3"
 
-"@emotion/css@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.0.0.tgz#804dcec7e4990019a08e678c1145d34208923acb"
-  integrity sha512-i7/uzTYcoP0hIW9V4YobD/mYAt6rjNySr9g6CS7JEFsRDfskg4nUczzIehALfacDaHbHaOQYaNDHBGuD/AtW5A==
-  dependencies:
-    "@emotion/babel-plugin" "^11.0.0"
-    "@emotion/cache" "^11.0.0"
-    "@emotion/serialize" "^1.0.0"
-    "@emotion/sheet" "^1.0.0"
-    "@emotion/utils" "^1.0.0"
-
 "@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"


### PR DESCRIPTION
Missed in https://github.com/JedWatson/react-select/pull/4283. We don't need to depend on `@emotion/css`, only `@emotion/react`.