### PR TITLE
Add prop for disable focus on `Input `after click on `MultiValueRemove `component

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ export default function App() {
 Common props you may want to specify include:
 
 - `autoFocus` - focus the control when it mounts
+- `autoFocusAfterRemoveValue` - focus the control when removed value in multi select
 - `className` - apply a className to the control
 - `classNamePrefix` - apply classNames to inner elements with the given prefix
 - `isDisabled` - disable the control

--- a/packages/react-select/README.md
+++ b/packages/react-select/README.md
@@ -74,6 +74,7 @@ class App extends React.Component {
 Common props you may want to specify include:
 
 - `autoFocus` - focus the control when it mounts
+- `autoFocusAfterRemoveValue` - focus the control when removed value in multi select
 - `className` - apply a className to the control
 - `classNamePrefix` - apply classNames to inner elements with the given prefix
 - `isDisabled` - disable the control

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -73,6 +73,8 @@ export type Props = {
   'aria-labelledby'?: string,
   /* Focus the control when it is mounted */
   autoFocus?: boolean,
+  /* Focus the control when removed value in multi select */
+  autoFocusAfterRemoveValue?: boolean,
   /* Remove the currently focused option when the user presses backspace when Select isClearable or isMulti */
   backspaceRemovesValue: boolean,
   /* Remove focus from the input when the user selects an option (handy for dismissing the keyboard on touch devices) */
@@ -277,6 +279,7 @@ export const defaultProps = {
   styles: {},
   tabIndex: '0',
   tabSelectsValue: true,
+  autoFocusAfterRemoveValue: true
 };
 
 type State = {
@@ -869,7 +872,12 @@ export default class Select extends Component<Props, State> {
         value: removedValue ? this.getOptionLabel(removedValue) : '',
       },
     });
-    this.focusInput();
+
+    if (isMulti) {
+      this.props.autoFocusAfterRemoveValue && this.focusInput();
+    } else {
+      this.focusInput();
+    }
   };
   clearValue = () => {
     this.onChange(this.props.isMulti ? [] : null, { action: 'clear' });

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -629,7 +629,6 @@ cases(
       menuIsOpen: true,
       hideSelectedOptions: false,
       isMulti: true,
-      menuIsOpen: true,
     };
     let { container } = render(<Select {...props} />);
 
@@ -1939,6 +1938,71 @@ cases(
         ...BASIC_PROPS,
         isMulti: true,
         autoFocus: true,
+      },
+    },
+  }
+);
+
+cases(
+  'autoFocusAfterRemoveValue',
+  ({ props }) => {
+    console.log('props', props);
+    let onChangeSpy = jest.fn();
+
+    let { container } = render(
+      <Select
+        {...BASIC_PROPS}
+        {...props}
+        isMulti
+        onChange={onChangeSpy}
+        value={[OPTIONS[0], OPTIONS[2], OPTIONS[4]]}
+      />
+    );
+
+    // there are 3 values in select
+    expect(container.querySelectorAll('.react-select__multi-value').length).toBe(3);
+
+    const selectValueElement = [
+      ...container.querySelectorAll('.react-select__multi-value'),
+    ].find(multiValue => multiValue.textContent === '4');
+
+    userEvent.click(
+      selectValueElement.querySelector('div.react-select__multi-value__remove')
+    );
+
+    expect(onChangeSpy).toHaveBeenCalledWith(
+      [
+        { label: '0', value: 'zero' },
+        { label: '2', value: 'two' },
+      ],
+      {
+        action: 'remove-value',
+        removedValue: { label: '4', value: 'four' },
+        name: BASIC_PROPS.name,
+      }
+    );
+
+    if (props === undefined || props.autoFocusAfterRemoveValue) {
+      expect(container.querySelector('.react-select__input input')).toBe(
+        document.activeElement
+      );
+    }  else {
+      expect(container.querySelector('.react-select__input input')).not.toBe(
+        document.activeElement
+      );
+    }
+
+  },
+  {
+    'multi select > should focus select after remove value without autoFocusAfterRemoveValue props': {},
+    'multi select > should focus select after remove value': {
+      props: {
+        autoFocusAfterRemoveValue: true
+      }
+    },
+    'multi select > shouldn not focus select after remove value': {
+      props: {
+        autoFocusAfterRemoveValue: false
       },
     },
   }


### PR DESCRIPTION
Add prop `autoFocusAfterRemoveValue` for disable focus on `Input `after click on `MultiValueRemove `component;
Based on [issue#4410](https://github.com/JedWatson/react-select/issues/4410)