### PR TITLE
Remove browser alias fields

### DIFF
--- a/.changeset/perfect-pandas-argue.md
+++ b/.changeset/perfect-pandas-argue.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Remove browser alias fields in order to fix SSR apps

--- a/packages/react-select/animated/package.json
+++ b/packages/react-select/animated/package.json
@@ -1,10 +1,6 @@
 {
   "main": "dist/react-select.cjs.js",
   "module": "dist/react-select.esm.js",
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
-  },
   "preconstruct": {
     "source": "../src/animated"
   }

--- a/packages/react-select/async-creatable/package.json
+++ b/packages/react-select/async-creatable/package.json
@@ -1,10 +1,6 @@
 {
   "main": "dist/react-select.cjs.js",
   "module": "dist/react-select.esm.js",
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
-  },
   "preconstruct": {
     "source": "../src/AsyncCreatable"
   }

--- a/packages/react-select/async/package.json
+++ b/packages/react-select/async/package.json
@@ -1,10 +1,6 @@
 {
   "main": "dist/react-select.cjs.js",
   "module": "dist/react-select.esm.js",
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
-  },
   "preconstruct": {
     "source": "../src/Async"
   }

--- a/packages/react-select/base/package.json
+++ b/packages/react-select/base/package.json
@@ -1,10 +1,6 @@
 {
   "main": "dist/react-select.cjs.js",
   "module": "dist/react-select.esm.js",
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
-  },
   "preconstruct": {
     "source": "../src/Select"
   }

--- a/packages/react-select/creatable/package.json
+++ b/packages/react-select/creatable/package.json
@@ -1,10 +1,6 @@
 {
   "main": "dist/react-select.cjs.js",
   "module": "dist/react-select.esm.js",
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
-  },
   "preconstruct": {
     "source": "../src/Creatable"
   }

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -56,9 +56,5 @@
       "creatable",
       "async-creatable"
     ]
-  },
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
   }
 }


### PR DESCRIPTION
Resolves https://github.com/JedWatson/react-select/issues/3802.

The `browser` alias outputs aren't doing much anyway besides causing the bug in SSR (they just remove the `typeof window !== undefined` check in one place), so I think it practically makes sense to remove them even though we're technically doing everything correctly.