### PR TITLE
Ability to pass input font-weight

### DIFF
--- a/packages/react-select/src/components/Input.js
+++ b/packages/react-select/src/components/Input.js
@@ -34,6 +34,7 @@ const inputStyle = isHidden => ({
   background: 0,
   border: 0,
   fontSize: 'inherit',
+  fontWeight: 'inherit',
   opacity: isHidden ? 0 : 1,
   outline: 0,
   padding: 0,


### PR DESCRIPTION
This change makes it possible to set font-weight by setting it in the `input` style.