### PR TITLE
tabIndex as number type

### DIFF
--- a/.changeset/six-turtles-beam.md
+++ b/.changeset/six-turtles-beam.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Allow tabIndex prop Type to be number or string

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -230,7 +230,7 @@ export type Props = {
   /* Theme modifier method */
   theme?: ThemeConfig,
   /* Sets the tabIndex attribute on the input */
-  tabIndex: string,
+  tabIndex: number | string,
   /* Select the currently focused option when the user presses tab */
   tabSelectsValue: boolean,
   /* The value of the select; reflected by the selected option */


### PR DESCRIPTION
resolves https://github.com/JedWatson/react-select/issues/3687

### Summary
tabIndex type is set to only be type string. This enforces unnecessary type coercion for end users. More confusingly so, tabIndex is used as a number type in Select.js
https://github.com/JedWatson/react-select/blob/2962385e67e213c61bc62f087426b44895ffa5b8/packages/react-select/src/Select.js#L1764

This change will make it more consistent with user expectations.