### PR TITLE
Fixes #3648 - Not scrolling to the selected group option on menu open

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -611,7 +611,7 @@ export default class Select extends Component<Props, State> {
       this.focusedOptionRef &&
       this.scrollToFocusedOptionOnUpdate
     ) {
-      scrollIntoView(this.menuListRef, this.focusedOptionRef);
+      setTimeout(() => scrollIntoView(this.menuListRef, this.focusedOptionRef), 0);
       this.scrollToFocusedOptionOnUpdate = false;
     }
   }


### PR DESCRIPTION
More of a hack than a fix, but seems to work