### PR TITLE
Ensure window exists in passive events polyfill

### DIFF
--- a/.changeset/plenty-keys-agree.md
+++ b/.changeset/plenty-keys-agree.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Check passive events polyfill for the existence of window for SSR

--- a/packages/react-select/src/utils.js
+++ b/packages/react-select/src/utils.js
@@ -306,10 +306,11 @@ const options = {
     return (passiveOptionAccessed = true);
   },
 };
-
-if (document.addEventListener && document.removeEventListener) {
-  document.addEventListener('p', noop, options);
-  document.removeEventListener('p', noop, false);
+// check for SSR
+const w = typeof window !== 'undefined' ? window : {};
+if (w.addEventListener && w.removeEventListener) {
+  w.addEventListener('p', noop, options);
+  w.removeEventListener('p', noop, false);
 }
 
 export const supportsPassiveEvents: boolean = passiveOptionAccessed;


### PR DESCRIPTION
When using SSR, there is no window or document element so the passive events polyfill breaks. 

This should resolve the issue by checking for the existence of window.