### PR TITLE
Apply reset for box shadow

### DIFF
--- a/packages/react-select/src/components/Input.js
+++ b/packages/react-select/src/components/Input.js
@@ -25,6 +25,7 @@ export const inputCSS = ({
   margin: spacing.baseUnit / 2,
   paddingBottom: spacing.baseUnit / 2,
   paddingTop: spacing.baseUnit / 2,
+  boxShadow: 'none',
   visibility: isDisabled ? 'hidden' : 'visible',
   color: colors.neutral80,
 });


### PR DESCRIPTION
Hello!

I ran into an issue with Tailwind's forms plugin, where a box shadow is applied on focus. This might also be a general issue wherever a box shadow is used for the input box. 

This patch resolves the issue for me. Let me know if I should change anything.