### PR TITLE
Memoize buildCategorizedOptions

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -386,7 +386,10 @@ let buildCategorizedOptions = memoize(
     // Sometimes we recieve a new instance of an empty array, check for that
     let selectValueEqual =
       newSelectValue === lastSelectValue ||
-      (newSelectValue.length === 0 && lastSelectValue.length === 0);
+      (Array.isArray(newSelectValue) &&
+        Array.isArray(lastSelectValue) &&
+        newSelectValue.length === 0 &&
+        lastSelectValue.length === 0);
 
     return propsEqual && selectValueEqual;
   }

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -342,51 +342,55 @@ function toCategorizedOption(
   };
 }
 
-let buildCategorizedOptions = memoize(function(
-  props: Props,
-  selectValue: OptionsType
-): CategorizedGroupOrOption[] {
-  return (props.options
-    .map((groupOrOption, groupOrOptionIndex) => {
-      if (groupOrOption.options) {
-        const categorizedOptions = groupOrOption.options
-          .map((option, optionIndex) =>
-            toCategorizedOption(props, option, selectValue, optionIndex)
-          )
-          .filter(categorizedOption => isFocusable(props, categorizedOption));
-        return categorizedOptions.length > 0
-          ? {
-              type: 'group',
-              data: groupOrOption,
-              options: categorizedOptions,
-              index: groupOrOptionIndex,
-            }
+let buildCategorizedOptions = memoize(
+  function(props: Props, selectValue: OptionsType): CategorizedGroupOrOption[] {
+    return (props.options
+      .map((groupOrOption, groupOrOptionIndex) => {
+        if (groupOrOption.options) {
+          const categorizedOptions = groupOrOption.options
+            .map((option, optionIndex) =>
+              toCategorizedOption(props, option, selectValue, optionIndex)
+            )
+            .filter(categorizedOption => isFocusable(props, categorizedOption));
+          return categorizedOptions.length > 0
+            ? {
+                type: 'group',
+                data: groupOrOption,
+                options: categorizedOptions,
+                index: groupOrOptionIndex,
+              }
+            : undefined;
+        }
+        const categorizedOption = toCategorizedOption(
+          props,
+          groupOrOption,
+          selectValue,
+          groupOrOptionIndex
+        );
+        return isFocusable(props, categorizedOption)
+          ? categorizedOption
           : undefined;
-      }
-      const categorizedOption = toCategorizedOption(
-        props,
-        groupOrOption,
-        selectValue,
-        groupOrOptionIndex
-      );
-      return isFocusable(props, categorizedOption)
-        ? categorizedOption
-        : undefined;
-    })
-    // Flow limitation (see https://github.com/facebook/flow/issues/1414)
-    .filter(categorizedOption => !!categorizedOption): any[]);
-}, function([newProps, newSelectValue], [lastProps, lastSelectValue]) {
-  // Shallow compare props
-  // ignore menuIsOpen, as it's not used by sub-functions
-  // use find instead of filter(!"menuIsOpen").map(equal).includes(false)
-  // to traverse the properties as few times as possible
-  let propsEqual = !Object.entries(newProps).find(([key, value]) => key !== 'menuIsOpen' && value !== lastProps[key]);
+      })
+      // Flow limitation (see https://github.com/facebook/flow/issues/1414)
+      .filter(categorizedOption => !!categorizedOption): any[]);
+  },
+  function([newProps, newSelectValue], [lastProps, lastSelectValue]) {
+    // Shallow compare props
+    // ignore menuIsOpen, as it's not used by sub-functions
+    // use find instead of filter(!"menuIsOpen").map(equal).includes(false)
+    // to traverse the properties as few times as possible
+    let propsEqual = !Object.entries(newProps).find(
+      ([key, value]) => key !== 'menuIsOpen' && value !== lastProps[key]
+    );
 
-  // Sometimes we recieve a new instance of an empty array, check for that
-  let selectValueEqual = newSelectValue === lastSelectValue || (newSelectValue.length === 0 && lastSelectValue.length === 0);
+    // Sometimes we recieve a new instance of an empty array, check for that
+    let selectValueEqual =
+      newSelectValue === lastSelectValue ||
+      (newSelectValue.length === 0 && lastSelectValue.length === 0);
 
-  return propsEqual && selectValueEqual;
-});
+    return propsEqual && selectValueEqual;
+  }
+);
 
 function buildFocusableOptionsFromCategorizedOptions(
   categorizedOptions: CategorizedGroupOrOption[]

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -376,7 +376,7 @@ let buildCategorizedOptions = memoize(
   },
   function(newArgs: any, lastArgs: any) {
     const [newProps, newSelectValue] = (newArgs: [Props, OptionsType]);
-    const [lastProps, lastSelectValue] = (newArgs: [Props, OptionsType]);
+    const [lastProps, lastSelectValue] = (lastArgs: [Props, OptionsType]);
 
     // Shallow compare props
     // ignore menuIsOpen, as it's not used by sub-functions

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -374,24 +374,25 @@ let buildCategorizedOptions = memoize(
       // Flow limitation (see https://github.com/facebook/flow/issues/1414)
       .filter(categorizedOption => !!categorizedOption): any[]);
   },
-  function([newProps, newSelectValue], [lastProps, lastSelectValue]) {
+  function(newArgs: any, lastArgs: any) {
+    const [newProps, newSelectValue] = (newArgs: [Props, OptionsType]);
+    const [lastProps, lastSelectValue] = (newArgs: [Props, OptionsType]);
+
     // Shallow compare props
     // ignore menuIsOpen, as it's not used by sub-functions
-    // use find instead of filter(!"menuIsOpen").map(equal).includes(false)
-    // to traverse the properties as few times as possible
-    let propsEqual = !Object.entries(newProps).find(
-      ([key, value]) => key !== 'menuIsOpen' && value !== lastProps[key]
-    );
+    for (let key in newProps) {
+      if (key === 'menuIsOpen') continue;
+      if (newProps[key] !== lastProps[key]) return false;
+    }
 
     // Sometimes we recieve a new instance of an empty array, check for that
-    let selectValueEqual =
+    return (
       newSelectValue === lastSelectValue ||
       (Array.isArray(newSelectValue) &&
         Array.isArray(lastSelectValue) &&
         newSelectValue.length === 0 &&
-        lastSelectValue.length === 0);
-
-    return propsEqual && selectValueEqual;
+        lastSelectValue.length === 0)
+    );
   }
 );
 

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -2767,15 +2767,11 @@ test('renders with custom theme', () => {
 });
 
 test('filterOption only called once per option when opening menu', () => {
-  let options = Array(1000)
-    .fill(null)
-    .map((_, i) => ({ label: 'Option', value: i }));
-  let timesCalled = 0;
-  let filterOption = () => timesCalled++;
-  let { rerender } = render(
-    <Select options={options} filterOption={filterOption} />
+  const filterOption = jest.fn();
+  const { rerender } = render(
+    <Select options={OPTIONS} filterOption={filterOption} />
   );
-  rerender(<Select options={options} filterOption={filterOption} menuIsOpen />);
+  rerender(<Select options={OPTIONS} filterOption={filterOption} menuIsOpen />);
 
-  expect(timesCalled).toEqual(options.length);
+  expect(filterOption).toHaveBeenCalledTimes(OPTIONS.length);
 });

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -2765,3 +2765,13 @@ test('renders with custom theme', () => {
     window.getComputedStyle(firstOption).getPropertyValue('background-color')
   ).toEqual(primary);
 });
+
+test('filterOption only called once per option when opening menu', () => {
+  let options = Array(1000).fill(null).map((_, i) => ({ label: 'Option', value: i }));
+  let timesCalled = 0;
+  let filterOption = () => timesCalled++;
+  let { rerender } = render(<Select options={options} filterOption={filterOption} />);
+  rerender(<Select options={options} filterOption={filterOption} menuIsOpen />);
+
+  expect(timesCalled).toEqual(options.length);
+});

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -2767,10 +2767,14 @@ test('renders with custom theme', () => {
 });
 
 test('filterOption only called once per option when opening menu', () => {
-  let options = Array(1000).fill(null).map((_, i) => ({ label: 'Option', value: i }));
+  let options = Array(1000)
+    .fill(null)
+    .map((_, i) => ({ label: 'Option', value: i }));
   let timesCalled = 0;
   let filterOption = () => timesCalled++;
-  let { rerender } = render(<Select options={options} filterOption={filterOption} />);
+  let { rerender } = render(
+    <Select options={options} filterOption={filterOption} />
+  );
   rerender(<Select options={options} filterOption={filterOption} menuIsOpen />);
 
   expect(timesCalled).toEqual(options.length);


### PR DESCRIPTION
Memoize buildCategorizedOptions, as it is called multiple times per render, on option lists possibly containing thousands of options.
Since I mainly tried to solve #4504, I only tweaked it to a point where you could limit the number of rendered options using `filterOption`.