### PR TITLE
Add resultLimit prop limiting the amount of rendered options

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1653,34 +1653,36 @@ export default class Select extends Component<Props, State> {
     let menuUI;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions().slice(0, this.props.resultLimit || undefined).map(item => {
-        if (item.type === 'group') {
-          const { data, options, index: groupIndex } = item;
-          const groupId = `${this.getElementId('group')}-${groupIndex}`;
-          const headingId = `${groupId}-heading`;
+      menuUI = this.getCategorizedOptions()
+        .slice(0, this.props.resultLimit || undefined)
+        .map(item => {
+          if (item.type === 'group') {
+            const { data, options, index: groupIndex } = item;
+            const groupId = `${this.getElementId('group')}-${groupIndex}`;
+            const headingId = `${groupId}-heading`;
 
-          return (
-            <Group
-              {...commonProps}
-              key={groupId}
-              data={data}
-              options={options}
-              Heading={GroupHeading}
-              headingProps={{
-                id: headingId,
-                data: item.data,
-              }}
-              label={this.formatGroupLabel(item.data)}
-            >
-              {item.options.map(option =>
-                render(option, `${groupIndex}-${option.index}`)
-              )}
-            </Group>
-          );
-        } else if (item.type === 'option') {
-          return render(item, `${item.index}`);
-        }
-      });
+            return (
+              <Group
+                {...commonProps}
+                key={groupId}
+                data={data}
+                options={options}
+                Heading={GroupHeading}
+                headingProps={{
+                  id: headingId,
+                  data: item.data,
+                }}
+                label={this.formatGroupLabel(item.data)}
+              >
+                {item.options.map(option =>
+                  render(option, `${groupIndex}-${option.index}`)
+                )}
+              </Group>
+            );
+          } else if (item.type === 'option') {
+            return render(item, `${item.index}`);
+          }
+        });
     } else if (isLoading) {
       const message = loadingMessage({ inputValue });
       if (message === null) return null;

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -225,6 +225,8 @@ export type Props = {
   pageSize: number,
   /* Placeholder for the select value */
   placeholder: Node,
+  /* Limits the number of rendered options in the dropdown */
+  resultLimit?: number,
   /* Status to relay to screen readers */
   screenReaderStatus: ({ count: number }) => string,
   /*
@@ -1651,7 +1653,7 @@ export default class Select extends Component<Props, State> {
     let menuUI;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions().map(item => {
+      menuUI = this.getCategorizedOptions().slice(0, this.props.resultLimit || undefined).map(item => {
         if (item.type === 'group') {
           const { data, options, index: groupIndex } = item;
           const groupId = `${this.getElementId('group')}-${groupIndex}`;

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1654,7 +1654,7 @@ export default class Select extends Component<Props, State> {
 
     if (this.hasOptions()) {
       menuUI = this.getCategorizedOptions();
-      if (this.props.resultLimit > 0) {
+      if (this.props.resultLimit && this.props.resultLimit > 0) {
         menuUI = menuUI.slice(0, this.props.resultLimit);
       }
       menuUI = menuUI.map(item => {

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1653,36 +1653,38 @@ export default class Select extends Component<Props, State> {
     let menuUI;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions()
-        .slice(0, this.props.resultLimit || undefined)
-        .map(item => {
-          if (item.type === 'group') {
-            const { data, options, index: groupIndex } = item;
-            const groupId = `${this.getElementId('group')}-${groupIndex}`;
-            const headingId = `${groupId}-heading`;
+      menuUI = this.getCategorizedOptions();
+      if (this.props.resultLimit > 0) {
+        menuUI = menuUI.slice(0, this.props.resultLimit);
+      }
+      menuUI = menuUI.map(item => {
+        if (item.type === 'group') {
+          const { data, options, index: groupIndex } = item;
+          const groupId = `${this.getElementId('group')}-${groupIndex}`;
+          const headingId = `${groupId}-heading`;
 
-            return (
-              <Group
-                {...commonProps}
-                key={groupId}
-                data={data}
-                options={options}
-                Heading={GroupHeading}
-                headingProps={{
-                  id: headingId,
-                  data: item.data,
-                }}
-                label={this.formatGroupLabel(item.data)}
-              >
-                {item.options.map(option =>
-                  render(option, `${groupIndex}-${option.index}`)
-                )}
-              </Group>
-            );
-          } else if (item.type === 'option') {
-            return render(item, `${item.index}`);
-          }
-        });
+          return (
+            <Group
+              {...commonProps}
+              key={groupId}
+              data={data}
+              options={options}
+              Heading={GroupHeading}
+              headingProps={{
+                id: headingId,
+                data: item.data,
+              }}
+              label={this.formatGroupLabel(item.data)}
+            >
+              {item.options.map(option =>
+                render(option, `${groupIndex}-${option.index}`)
+              )}
+            </Group>
+          );
+        } else if (item.type === 'option') {
+          return render(item, `${item.index}`);
+        }
+      });
     } else if (isLoading) {
       const message = loadingMessage({ inputValue });
       if (message === null) return null;

--- a/packages/react-select/src/__tests__/Select.test.js
+++ b/packages/react-select/src/__tests__/Select.test.js
@@ -2765,3 +2765,25 @@ test('renders with custom theme', () => {
     window.getComputedStyle(firstOption).getPropertyValue('background-color')
   ).toEqual(primary);
 });
+
+test('resultLimit limits number of rendered props', () => {
+  const resultLimit = 5;
+  const { container } = render(
+    <Select {...BASIC_PROPS} resultLimit={resultLimit} menuIsOpen />
+  );
+  expect(container.querySelectorAll('.react-select__option').length).toBe(
+    resultLimit
+  );
+});
+
+test.each([undefined, 0, -10])(
+  'resultLimit negative, undefined or zero should render all options',
+  resultLimit => {
+    const { container } = render(
+      <Select {...BASIC_PROPS} resultLimit={resultLimit} menuIsOpen />
+    );
+    expect(container.querySelectorAll('.react-select__option').length).toBe(
+      OPTIONS.length
+    );
+  }
+);


### PR DESCRIPTION
Add a `resultLimit` prop that prevents rendering too many results. Useful if the number of options are in the thousands.

Indirectly addresses #4504  
Addresses #4516