### PR TITLE
#4146 Add menu position recalculation after async data is loaded

### DIFF
--- a/packages/react-select/src/Async.js
+++ b/packages/react-select/src/Async.js
@@ -127,7 +127,7 @@ export const makeAsyncSelect = <C: {}>(
       this.select.blur();
     }
     recalculateMenuPlacement = () => {
-      if (this.select?.select?.menuPlacerRef) {
+      if (this.select.select && this.select.select.menuPlacerRef) {
         this.select.select.menuPlacerRef.recalculatePlacement();
       }
     }

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -520,7 +520,10 @@ export default class Select extends Component<Props, State> {
   getInputRef = (ref: ?HTMLElement) => {
     this.inputRef = ref;
   };
-
+  menuPlacerRef: ElRef = null;
+  getMenuPlacerRef = (ref: ?HTMLElement) => {
+    this.menuPlacerRef = ref;
+  };
   // Lifecycle
   // ------------------------------
 
@@ -1697,7 +1700,7 @@ export default class Select extends Component<Props, State> {
     };
 
     const menuElement = (
-      <MenuPlacer {...commonProps} {...menuPlacementProps}>
+      <MenuPlacer innerRef={this.getMenuPlacerRef} {...commonProps} {...menuPlacementProps}>
         {({ ref, placerProps: { placement, maxHeight } }) => (
           <Menu
             {...commonProps}

--- a/packages/react-select/src/__tests__/Async.test.js
+++ b/packages/react-select/src/__tests__/Async.test.js
@@ -205,6 +205,57 @@ test('in case of callbacks display the most recently-requested loaded options (i
   );
 });
 
+cases('on data load menu position should', async ({ preventRecalculation, loader, recalculationCount }) => {
+  const ref = React.createRef();
+
+  const loaderSpy = jest.fn(loader);
+  let { container } = render(
+    <Async
+      className="react-select"
+      classNamePrefix="react-select"
+      loadOptions={loaderSpy}
+      preventMenuPositionRecalculation={preventRecalculation}
+      ref={ref}
+    />
+  );
+
+  let input = container.querySelector('div.react-select__input input');
+
+  ref.current.recalculateMenuPlacement = jest.fn(ref.current.recalculateMenuPlacement);
+
+  expect(ref.current.recalculateMenuPlacement).toHaveBeenCalledTimes(0);
+  fireEvent.input(input, {
+    target: {
+      value: 'foo',
+    },
+    bubbles: true,
+    cancelable: true,
+  });
+
+  await waitFor(() => expect(ref.current.recalculateMenuPlacement).toHaveBeenCalledTimes(recalculationCount));
+}, {
+  'promise => should be recalculated': {
+    preventRecalculation: false,
+    loader: () => new Promise((resolve) => resolve(OPTIONS)),
+    recalculationCount: 1,
+  },
+  'promise => should not be recalculated when preventMenuPositionRecalculation is used': {
+    preventRecalculation: true,
+    loader: () => new Promise((resolve) => resolve(OPTIONS)),
+    recalculationCount: 0
+  },
+  'callback => should be recalculated': {
+    preventRecalculation: false,
+    loader: (input, callback) => callback(OPTIONS),
+    recalculationCount: 1
+  },
+  'callback => should not be recalculated when preventMenuPositionRecalculation is used': {
+    preventRecalculation: true,
+    loader: (input, callback) => callback(OPTIONS),
+    recalculationCount: 0
+  }
+});
+
 // QUESTION: we currently do not do this, do we want to?
 test.skip('in case of callbacks should handle an error by setting options to an empty array', () => {
   const loadOptions = (inputValue, callback) => {

--- a/packages/react-select/src/components/Menu.js
+++ b/packages/react-select/src/components/Menu.js
@@ -233,6 +233,8 @@ export type MenuProps = MenuAndPlacerCommon & {
   children: ReactElement<*>,
 };
 export type MenuPlacerProps = MenuAndPlacerCommon & {
+  /** Reference to the internal element, consumed by the MenuPlacer component */
+  innerRef: ElementRef<*>;
   /** The children to be rendered. */
   children: ({}) => Node,
 };
@@ -267,12 +269,22 @@ const PortalPlacementContext = createContext<{
 
 // NOTE: internal only
 export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
+  menuRef = null;
   state = {
     maxHeight: this.props.maxMenuHeight,
     placement: null,
   };
   static contextType = PortalPlacementContext;
+  constructor(props) {
+    super(props);
 
+    props.innerRef(this);
+  }
+  recalculatePlacement = () => {
+    if(this.menuRef !== null) {
+      this.getPlacement(this.menuRef);
+    }
+  }
   getPlacement = (ref: ElementRef<*>) => {
     const {
       minMenuHeight,
@@ -284,6 +296,8 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
     } = this.props;
 
     if (!ref) return;
+
+    this.menuRef = ref;
 
     // DO NOT scroll if position is fixed
     const isFixedPosition = menuPosition === 'fixed';

--- a/packages/react-select/src/components/Menu.js
+++ b/packages/react-select/src/components/Menu.js
@@ -275,7 +275,7 @@ export class MenuPlacer extends Component<MenuPlacerProps, MenuState> {
     placement: null,
   };
   static contextType = PortalPlacementContext;
-  constructor(props) {
+  constructor(props:MenuPlacerProps) {
     super(props);
 
     props.innerRef(this);


### PR DESCRIPTION
Fixes #4146 by calling `getPlacement` function in `MenuPlacer` once async call is finished (both promise and callback approach).