### PR TITLE
Bump @emotion/cache to v11.4.0

### DIFF
--- a/.changeset/rich-ligers-breathe.md
+++ b/.changeset/rich-ligers-breathe.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Bump @emotion/cache to v11.4.0 which fixes an issue where different versions of Emotion running at the same time causes styles to disappear in production.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@changesets/cli": "^2.0.3",
     "@changesets/get-github-info": "^0.2.1",
     "@emotion/babel-plugin": "^11.0.0",
-    "@emotion/cache": "^11.0.0",
+    "@emotion/cache": "^11.4.0",
     "@emotion/jest": "^11.1.0",
     "@emotion/react": "^11.1.1",
     "@preconstruct/cli": "^1.0.0",

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/JedWatson/react-select/tree/master/packages/react-select",
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@emotion/cache": "^11.0.0",
+    "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.1.1",
     "@types/react-input-autosize": "^2.2.0",
     "@types/react-transition-group": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,10 +1523,10 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
-  version "11.1.3"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
-  integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
+"@emotion/cache@^11.1.3", "@emotion/cache@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
+  integrity sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==
   dependencies:
     "@emotion/memoize" "^0.7.4"
     "@emotion/sheet" "^1.0.0"


### PR DESCRIPTION
Bumping ```@emotion/cache``` to v11.4.0 which fixes an issue where v10 and v11 running at the same time could cause styles to disappear in production. PR - https://github.com/emotion-js/emotion/pull/2361