### PR TITLE
Add meaningful CSS class to AutosizeInput wrapper div

### DIFF
--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`defaults - snapshot 1`] = `
           Select...
         </div>
         <div
-          class="emotion-5"
+          class=" emotion-5"
         >
           <div
             class=""

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`defaults - snapshot 1`] = `
           Select...
         </div>
         <div
-          class="emotion-5"
+          class=" emotion-5"
         >
           <div
             class=""

--- a/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`defaults - snapshot 1`] = `
           Select...
         </div>
         <div
-          class="emotion-5"
+          class=" emotion-5"
         >
           <div
             class=""

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`snapshot - defaults 1`] = `
           Select...
         </div>
         <div
-          class="emotion-5"
+          class=" emotion-5"
         >
           <div
             class=""

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`defaults > snapshot 1`] = `
           Select...
         </div>
         <div
-          class="emotion-5"
+          class=" emotion-5"
         >
           <div
             class=""

--- a/packages/react-select/src/components/Input.tsx
+++ b/packages/react-select/src/components/Input.tsx
@@ -70,7 +70,10 @@ const Input = <
   );
 
   return (
-    <div css={getStyles('input', props)}>
+    <div
+      css={getStyles('input', props)}
+      className={cx({ 'input-container': true }, className)}
+    >
       <AutosizeInput
         className={cx({ input: true }, className)}
         inputRef={innerRef}


### PR DESCRIPTION
This little div:

```html
<div
  class="select__value-container select__value-container--has-value css-g1d714-ValueContainer"
>
  <div class="select__single-value css-1uccc91-singleValue">Ocean</div>

  <!-- This one right here below -->
  <div class="css-b8ldur-Input">

    <div class="select__input" style="display: inline-block">
      <input [...] />
      [...]
    </div>
  </div>
</div>
```

bears some CSS rules that would be much easier to customize (via class name / styled-components) if it had a proper, meaningful, fixed class name.

This little PR adds that class name:

```html
<div
  class="select__value-container select__value-container--has-value css-g1d714-ValueContainer"
>
  <div class="select__single-value css-1uccc91-singleValue">Ocean</div>

  <!-- This one right here below -->
  <div class="css-b8ldur-Input select__input-wrapper">

    <div class="select__input" style="display: inline-block">
      <input [...] />
      [...]
    </div>
  </div>
</div>
```

Without it, I'm having to do this:

```css
    /*
      This is the parent of the div that hides the real HTML input element.
      The problem is that this element causes unwanted margin, height, padding but
      it has no proper name / class while its direct child has a proper name / class but at the time
      of writing we can't target a parent by its child in CSS (https://caniuse.com/css-has)

      So, I guess I'll just 🤞
    */
    div:nth-child(2) {
      margin: 0;
      padding: 0;
    }
```

but I would rather not :D