### PR TITLE
Prevent ArrowLeft & ArrowRight key action when controlShouldRenderValue=false

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1367,6 +1367,7 @@ export default class Select<
       onKeyDown,
       tabSelectsValue,
       openMenuOnFocus,
+      controlShouldRenderValue,
     } = this.props;
     const { focusedOption, focusedValue, selectValue } = this.state;
 
@@ -1383,11 +1384,11 @@ export default class Select<
     this.blockOptionHover = true;
     switch (event.key) {
       case 'ArrowLeft':
-        if (!isMulti || inputValue) return;
+        if (!isMulti || inputValue || !controlShouldRenderValue) return;
         this.focusValue('previous');
         break;
       case 'ArrowRight':
-        if (!isMulti || inputValue) return;
+        if (!isMulti || inputValue || !controlShouldRenderValue) return;
         this.focusValue('next');
         break;
       case 'Delete':


### PR DESCRIPTION
**Problem**
We are using the select component with `controlShouldRenderValue = false`. And we have defined event handler for `ArrowLeft & ArrowRight` key on the container element. But the event handler here does not return, and go to `event.preventDefault()`, which caused our event handler not work.

**Solution**
Just return when `controlShouldRenderValue = false`, since it does not make sense to `focusValue` when no value rendered.