### PR TITLE
Add `searchInMenu` property

### DIFF
--- a/docs/examples/SearchInMenu.tsx
+++ b/docs/examples/SearchInMenu.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Select from 'react-select';
+import { colourOptions } from '../data';
+
+export default () => (
+  <Select
+    defaultValue={[colourOptions[2]]}
+    isMulti
+    searchInMenu
+    name="colors"
+    options={colourOptions}
+  />
+);

--- a/docs/examples/index.tsx
+++ b/docs/examples/index.tsx
@@ -42,6 +42,7 @@ export { default as CustomIsOptionDisabled } from './CustomIsOptionDisabled';
 export { default as DefaultOptions } from './DefaultOptions';
 export { default as Experimental } from './Experimental';
 export { default as FixedOptions } from './FixedOptions';
+export { default as SearchInMenu } from './SearchInMenu';
 export { default as MultiSelectSort } from './MultiSelectSort';
 export { default as Popout } from './Popout';
 export { default as StyledMulti } from './StyledMulti';

--- a/docs/pages/home/index.tsx
+++ b/docs/pages/home/index.tsx
@@ -10,6 +10,7 @@ import {
   BasicMulti,
   CreatableSingle,
   FixedOptions,
+  SearchInMenu,
   StyledMulti,
   StyledSingle,
 } from '../../examples';
@@ -193,6 +194,20 @@ export default function Home() {
       raw={require('!!raw-loader!../../examples/FixedOptions.tsx')}
     >
       <FixedOptions />
+    </ExampleWrapper>
+  )}
+
+  # Search in menu
+
+  The search input is placed in the menu along with the options instead of in the input.
+
+  ${(
+    <ExampleWrapper
+      label="Search in menu"
+      urlPath="docs/home/examples/SearchInMenu.tsx"
+      raw={require('!!raw-loader!../../examples/SearchInMenu.tsx')}
+    >
+      <SearchInMenu />
     </ExampleWrapper>
   )}
 `;

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -1887,6 +1887,32 @@ test('multi select > clicking on X next to option will call onChange with all op
   );
 });
 
+cases(
+  'searchInMenu prop',
+  ({ props = BASIC_PROPS }) => {
+    let { container, rerender } = render(<Select {...props} />);
+    expect(
+      container.querySelector('.react-select__menu .react-select__input')
+    ).toBeFalsy();
+    expect(container.querySelector('.search-in-menu')).toBeFalsy();
+
+    rerender(<Select {...props} searchInMenu menuIsOpen />);
+    expect(
+      container.querySelector('.react-select__menu .react-select__input')
+    ).toBeTruthy();
+    expect(container.querySelector('.search-in-menu')).toBeTruthy();
+  },
+  {
+    'single select > should show search input in menu if searchInMenu is true and hide search input in control if searchInMenu prop is false': {},
+    'multi select > should show search input in menu if searchInMenu is true and hide search input in control if searchInMenu prop is false': {
+      props: {
+        ...BASIC_PROPS,
+        isMulti: true,
+      },
+    },
+  }
+);
+
 /**
  * TODO: Need to get hightlight a menu option and then match value with aria-activedescendant prop
  */

--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
@@ -89,6 +89,8 @@ exports[`defaults - snapshot 1`] = `
 }
 
 .emotion-5 {
+  border-top: 0;
+  border-bottom: 0;
   margin: 2px;
   padding-bottom: 2px;
   padding-top: 2px;
@@ -175,7 +177,7 @@ exports[`defaults - snapshot 1`] = `
           class="emotion-5"
         >
           <div
-            class=""
+            class="search-in-input"
             style="display: inline-block;"
           >
             <input

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
@@ -89,6 +89,8 @@ exports[`defaults - snapshot 1`] = `
 }
 
 .emotion-5 {
+  border-top: 0;
+  border-bottom: 0;
   margin: 2px;
   padding-bottom: 2px;
   padding-top: 2px;
@@ -175,7 +177,7 @@ exports[`defaults - snapshot 1`] = `
           class="emotion-5"
         >
           <div
-            class=""
+            class="search-in-input"
             style="display: inline-block;"
           >
             <input

--- a/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
@@ -89,6 +89,8 @@ exports[`defaults - snapshot 1`] = `
 }
 
 .emotion-5 {
+  border-top: 0;
+  border-bottom: 0;
   margin: 2px;
   padding-bottom: 2px;
   padding-top: 2px;
@@ -175,7 +177,7 @@ exports[`defaults - snapshot 1`] = `
           class="emotion-5"
         >
           <div
-            class=""
+            class="search-in-input"
             style="display: inline-block;"
           >
             <input

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -89,6 +89,8 @@ exports[`snapshot - defaults 1`] = `
 }
 
 .emotion-5 {
+  border-top: 0;
+  border-bottom: 0;
   margin: 2px;
   padding-bottom: 2px;
   padding-top: 2px;
@@ -175,7 +177,7 @@ exports[`snapshot - defaults 1`] = `
           class="emotion-5"
         >
           <div
-            class=""
+            class="search-in-input"
             style="display: inline-block;"
           >
             <input

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
@@ -89,6 +89,8 @@ exports[`defaults > snapshot 1`] = `
 }
 
 .emotion-5 {
+  border-top: 0;
+  border-bottom: 0;
   margin: 2px;
   padding-bottom: 2px;
   padding-top: 2px;
@@ -175,7 +177,7 @@ exports[`defaults > snapshot 1`] = `
           class="emotion-5"
         >
           <div
-            class=""
+            class="search-in-input"
             style="display: inline-block;"
           >
             <input

--- a/packages/react-select/src/components/Input.tsx
+++ b/packages/react-select/src/components/Input.tsx
@@ -23,6 +23,10 @@ export interface InputSpecificProps<
   isDisabled?: boolean;
   /** The ID of the form that the input belongs to */
   form?: string;
+  /** The input is rendered in the menu */
+  searchInMenu?: boolean;
+  /** The menu is placed either at the top or at the bottom */
+  menuPlacement?: string;
 }
 
 export type InputProps<
@@ -38,22 +42,38 @@ export const inputCSS = <
   Group extends GroupBase<Option>
 >({
   isDisabled,
+  searchInMenu,
+  menuPlacement,
   theme: { spacing, colors },
 }: InputProps<Option, IsMulti, Group>): CSSObjectWithLabel => ({
-  margin: spacing.baseUnit / 2,
-  paddingBottom: spacing.baseUnit / 2,
-  paddingTop: spacing.baseUnit / 2,
+  borderTop:
+    searchInMenu && menuPlacement === 'top'
+      ? '1px solid hsla(0, 0%, 0%, 0.1)'
+      : 0,
+  borderBottom:
+    searchInMenu && menuPlacement === 'bottom'
+      ? '1px solid hsla(0, 0%, 0%, 0.1)'
+      : 0,
+  margin: searchInMenu ? `${spacing.baseUnit / 2}px 0` : spacing.baseUnit / 2,
+  paddingBottom: searchInMenu ? spacing.baseUnit : spacing.baseUnit / 2,
+  paddingTop: searchInMenu ? spacing.baseUnit : spacing.baseUnit / 2,
   visibility: isDisabled ? 'hidden' : 'visible',
   color: colors.neutral80,
 });
-const inputStyle = (isHidden: boolean) => ({
+const inputStyle = ({
+  isHidden,
+  searchInMenu,
+}: {
+  isHidden: boolean;
+  searchInMenu?: boolean;
+}) => ({
   label: 'input',
   background: 0,
   border: 0,
   fontSize: 'inherit',
   opacity: isHidden ? 0 : 1,
   outline: 0,
-  padding: 0,
+  padding: searchInMenu ? '0 0 0 8px' : 0,
   color: 'inherit',
 });
 
@@ -65,16 +85,24 @@ const Input = <
   props: InputProps<Option, IsMulti, Group>
 ) => {
   const { className, cx, getStyles } = props;
-  const { innerRef, isDisabled, isHidden, ...innerProps } = cleanCommonProps(
-    props
-  );
+  const {
+    innerRef,
+    isDisabled,
+    isHidden,
+    searchInMenu,
+    menuPlacement,
+    ...innerProps
+  } = cleanCommonProps(props);
 
   return (
     <div css={getStyles('input', props)}>
       <AutosizeInput
-        className={cx({ input: true }, className)}
+        className={cx(
+          { input: true },
+          `${className || ''} search-in-${searchInMenu ? 'menu' : 'input'}`
+        )}
         inputRef={innerRef}
-        inputStyle={inputStyle(isHidden)}
+        inputStyle={inputStyle({ isHidden, searchInMenu })}
         disabled={isDisabled}
         {...innerProps}
       />

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -45,6 +45,7 @@ interface PlacementArgs {
   menuEl: HTMLDivElement | null;
   minHeight: number;
   placement: MenuPlacement;
+  searchInMenu?: boolean;
   shouldScroll: boolean;
   isFixedPosition: boolean;
   theme: Theme;
@@ -55,6 +56,7 @@ export function getMenuPlacement({
   menuEl,
   minHeight,
   placement,
+  searchInMenu,
   shouldScroll,
   isFixedPosition,
   theme,
@@ -75,12 +77,18 @@ export function getMenuPlacement({
     top: menuTop,
   } = menuEl.getBoundingClientRect();
 
+  const searchHeight = searchInMenu
+    ? menuEl.querySelector('.search-in-menu')?.parentElement?.offsetHeight || 0
+    : 0;
+
   const { top: containerTop } = menuEl.offsetParent.getBoundingClientRect();
   const viewHeight = window.innerHeight;
   const scrollTop = getScrollTop(scrollParent);
 
-  const marginBottom = parseInt(getComputedStyle(menuEl).marginBottom, 10);
-  const marginTop = parseInt(getComputedStyle(menuEl).marginTop, 10);
+  const marginBottom =
+    parseInt(getComputedStyle(menuEl).marginBottom, 10) + searchHeight;
+  const marginTop =
+    parseInt(getComputedStyle(menuEl).marginTop, 10) + searchHeight;
   const viewSpaceAbove = containerTop - marginTop;
   const viewSpaceBelow = viewHeight - menuTop;
   const scrollSpaceAbove = viewSpaceAbove + scrollTop;
@@ -257,6 +265,8 @@ export interface MenuPlacerProps<
     MenuPlacementProps {
   /** The children to be rendered. */
   children: (childrenProps: ChildrenProps) => ReactNode;
+  /** The input is rendered in the menu */
+  searchInMenu?: boolean;
 }
 
 function alignToControl(placement: CoercedMenuPlacement) {
@@ -309,6 +319,7 @@ export class MenuPlacer<
       menuPlacement,
       menuPosition,
       menuShouldScrollIntoView,
+      searchInMenu,
       theme,
     } = this.props;
 
@@ -323,6 +334,7 @@ export class MenuPlacer<
       menuEl: ref,
       minHeight: minMenuHeight,
       placement: menuPlacement,
+      searchInMenu,
       shouldScroll,
       isFixedPosition,
       theme,


### PR DESCRIPTION
Hello, I open this PR because I needed to display the search input as part of the menu instead of as part of the control.

You can see a sample in the samples file:

![image](https://user-images.githubusercontent.com/2640252/118679242-021d8f80-b7fe-11eb-87ae-a590059fa460.png)

Sample code:

```html
<Select
  defaultValue={[colourOptions[2]]}
  isMulti
  searchInMenu
  name="colors"
  options={colourOptions}
/>
```

I was searching for workarounds to do this without modifying the package source code before doing the changes, but, unfortunately, the available workarounds did not work well.

I hope you can analyze and validate the changes.

Thank you, regards.