### PR TITLE
Fix path typo in type-generation script for documentation

### DIFF
--- a/docs/generate-magical-types/src/generate.ts
+++ b/docs/generate-magical-types/src/generate.ts
@@ -26,11 +26,11 @@ if (process.env.NODE_ENV === 'test') {
       let pkgExports: MagicalNodesForPackage = {};
       obj[`${name}`] = pkgExports;
       let sourceFile = project.getSourceFile(
-        path.join(__dirname, '../../Proptypes', `${name}.ts`)
+        path.join(__dirname, '../../PropTypes', `${name}.ts`)
       );
       if (!sourceFile) {
         sourceFile = project.getSourceFile(
-          path.join(__dirname, '../../Proptypes', `${name}.tsx`)
+          path.join(__dirname, '../../PropTypes', `${name}.tsx`)
         );
       }
       if (!sourceFile) {


### PR DESCRIPTION
There seems to be a typo in [docs/generate-magical-types/src/generate.ts](/JedWatson/react-select/tree/master/docs/generate-magical-types/src/generate.ts#L29) preventing the documentation from being built on a case-sensitive file-system.

This PR fixed this typo.