### PR TITLE
Use combobox

### DIFF
--- a/.changeset/mean-gorillas-kick.md
+++ b/.changeset/mean-gorillas-kick.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Add the role of combobox and the required ARIA attributes to the Input and DummyInput components to allow JAWS support and a better screen reader experience overall.

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -629,8 +629,11 @@ export default class Select<
     props: Props<OptionBase, boolean, GroupBase<OptionBase>>,
     state: State<OptionBase, boolean, GroupBase<OptionBase>>
   ) {
-    const { prevProps, clearFocusValueOnUpdate, inputIsHiddenAfterUpdate } =
-      state;
+    const {
+      prevProps,
+      clearFocusValueOnUpdate,
+      inputIsHiddenAfterUpdate,
+    } = state;
     const { options, value, menuIsOpen, inputValue } = props;
     let newMenuOptionsState = {};
     if (
@@ -1490,8 +1493,15 @@ export default class Select<
   // Renderers
   // ==============================
   renderInput() {
-    const { isDisabled, isSearchable, inputId, inputValue, tabIndex, form } =
-      this.props;
+    const {
+      isDisabled,
+      isSearchable,
+      inputId,
+      inputValue,
+      tabIndex,
+      form,
+      menuIsOpen,
+    } = this.props;
     const { Input } = this.getComponents();
     const { inputIsHidden } = this.state;
     const { commonProps } = this;
@@ -1501,8 +1511,16 @@ export default class Select<
     // aria attributes makes the JSX "noisy", separated for clarity
     const ariaAttributes = {
       'aria-autocomplete': 'list' as const,
+      'aria-expanded': menuIsOpen,
+      'aria-haspopup': true,
+      'aria-controls': this.getElementId('listbox'),
+      'aria-owns': this.getElementId('listbox'),
       'aria-label': this.props['aria-label'],
       'aria-labelledby': this.props['aria-labelledby'],
+      role: 'combobox',
+      ...(!isSearchable && {
+        'aria-readonly': true,
+      }),
     };
 
     if (!isSearchable) {
@@ -1834,6 +1852,7 @@ export default class Select<
             innerProps={{
               onMouseDown: this.onMenuMouseDown,
               onMouseMove: this.onMenuMouseMove,
+              id: this.getElementId('listbox'),
             }}
             isLoading={isLoading}
             placement={placement}
@@ -1942,8 +1961,12 @@ export default class Select<
   }
 
   render() {
-    const { Control, IndicatorsContainer, SelectContainer, ValueContainer } =
-      this.getComponents();
+    const {
+      Control,
+      IndicatorsContainer,
+      SelectContainer,
+      ValueContainer,
+    } = this.getComponents();
 
     const { className, id, isDisabled, menuIsOpen } = this.props;
     const { isFocused } = this.state;

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -633,11 +633,8 @@ export default class Select<
     props: Props<OptionBase, boolean, GroupBase<OptionBase>>,
     state: State<OptionBase, boolean, GroupBase<OptionBase>>
   ) {
-    const {
-      prevProps,
-      clearFocusValueOnUpdate,
-      inputIsHiddenAfterUpdate,
-    } = state;
+    const { prevProps, clearFocusValueOnUpdate, inputIsHiddenAfterUpdate } =
+      state;
     const { options, value, menuIsOpen, inputValue } = props;
     let newMenuOptionsState = {};
     if (
@@ -1967,12 +1964,8 @@ export default class Select<
   }
 
   render() {
-    const {
-      Control,
-      IndicatorsContainer,
-      SelectContainer,
-      ValueContainer,
-    } = this.getComponents();
+    const { Control, IndicatorsContainer, SelectContainer, ValueContainer } =
+      this.getComponents();
 
     const { className, id, isDisabled, menuIsOpen } = this.props;
     const { isFocused } = this.state;

--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
@@ -195,11 +195,16 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
+            aria-controls="react-select-2-listbox"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
             class=""
             id="react-select-2-input"
+            role="combobox"
             spellcheck="false"
             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
             tabindex="0"

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
@@ -195,11 +195,16 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
+            aria-controls="react-select-2-listbox"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
             class=""
             id="react-select-2-input"
+            role="combobox"
             spellcheck="false"
             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
             tabindex="0"

--- a/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
@@ -195,11 +195,16 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
+            aria-controls="react-select-2-listbox"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
             class=""
             id="react-select-2-input"
+            role="combobox"
             spellcheck="false"
             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
             tabindex="0"

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -195,11 +195,16 @@ exports[`snapshot - defaults 1`] = `
         >
           <input
             aria-autocomplete="list"
+            aria-controls="react-select-2-listbox"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
             class=""
             id="react-select-2-input"
+            role="combobox"
             spellcheck="false"
             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
             tabindex="0"

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
@@ -195,11 +195,16 @@ exports[`defaults > snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
+            aria-controls="react-select-2-listbox"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
             class=""
             id="react-select-2-input"
+            role="combobox"
             spellcheck="false"
             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
             tabindex="0"

--- a/packages/react-select/src/components/Option.tsx
+++ b/packages/react-select/src/components/Option.tsx
@@ -105,6 +105,7 @@ const Option = <
         className
       )}
       ref={innerRef}
+      aria-disabled={isDisabled}
       {...innerProps}
     >
       {children}

--- a/packages/react-select/src/internal/DummyInput.tsx
+++ b/packages/react-select/src/internal/DummyInput.tsx
@@ -32,7 +32,7 @@ export default function DummyInput({
         left: -100,
         opacity: 0,
         position: 'relative',
-        transform: 'scale(0)',
+        transform: 'scale(.01)',
       }}
     />
   );


### PR DESCRIPTION
Add the role of `combobox` and the required ARIA attributes to the `Input` and `DummyInput` components to allow JAWS support and a better screen reader experience overall.

Linked to this proposal: #4695 