### PR TITLE
feature/always-focus-first-menu-option

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -74,6 +74,8 @@ export interface Props<
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
+  /** Always focus first option on menu list */
+  alwaysFocusFirstMenuOption: boolean;
   /** HTML ID of an element containing an error message related to the input**/
   'aria-errormessage'?: string;
   /** Indicate if the value entered in the field is invalid **/
@@ -268,6 +270,7 @@ export interface Props<
 }
 
 export const defaultProps = {
+  alwaysFocusFirstMenuOption: false,
   'aria-live': 'polite',
   backspaceRemovesValue: true,
   blurInputOnSelect: isTouchCapable(),
@@ -484,8 +487,21 @@ function getNextFocusedOption<
   Option extends OptionBase,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
->(state: State<Option, IsMulti, Group>, options: Options<Option>) {
+>(
+  state: State<Option, IsMulti, Group>,
+  options: Options<Option>,
+  props?: Props<Option, IsMulti, Group>
+) {
   const { focusedOption: lastFocusedOption } = state;
+
+  if (props) {
+    const { alwaysFocusFirstMenuOption } = props;
+
+    if (alwaysFocusFirstMenuOption) {
+      return options[0];
+    }
+  }
+
   return lastFocusedOption && options.indexOf(lastFocusedOption) > -1
     ? lastFocusedOption
     : options[0];
@@ -651,7 +667,11 @@ export default class Select<
       const focusedValue = clearFocusValueOnUpdate
         ? getNextFocusedValue(state, selectValue)
         : null;
-      const focusedOption = getNextFocusedOption(state, focusableOptions);
+      const focusedOption = getNextFocusedOption(
+        state,
+        focusableOptions,
+        prevProps
+      );
       newMenuOptionsState = {
         selectValue,
         focusedOption,


### PR DESCRIPTION
Adds a new property called "alwaysFocusFirstMenuOption" that makes it possible to keep focus on the first item when the list of options is changed. An example can be seen below:

- Without prop:
   ![ezgif com-gif-maker](https://user-images.githubusercontent.com/66845464/126387537-0cf3a259-73bd-4bcb-9153-7c329e4e4785.gif)


- With prop:
   ![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/66845464/126387387-531f5194-7255-4fce-bfda-4dd72a550650.gif)


