### PR TITLE
Remove OptionBase type

### DIFF
--- a/.changeset/tame-suits-lick.md
+++ b/.changeset/tame-suits-lick.md
@@ -1,0 +1,6 @@
+---
+"react-select": patch
+"@react-select/docs": patch
+---
+
+The Option generic is no longer required to extend the OptionBase type

--- a/.changeset/tame-suits-lick.md
+++ b/.changeset/tame-suits-lick.md
@@ -1,6 +1,6 @@
 ---
-"react-select": patch
-"@react-select/docs": patch
+'react-select': patch
+'@react-select/docs': patch
 ---
 
 The Option generic is no longer required to extend the OptionBase type

--- a/docs/PropTypes/Select.ts
+++ b/docs/PropTypes/Select.ts
@@ -1,10 +1,10 @@
 import { Component } from 'react';
 
 import { Props, defaultProps } from 'react-select/src/Select';
-import { GroupBase, OptionBase } from 'react-select';
+import { GroupBase } from 'react-select';
 
 export default class Select extends Component<
-  Props<OptionBase, boolean, GroupBase<OptionBase>>
+  Props<unknown, boolean, GroupBase<unknown>>
 > {
   defaultProps = defaultProps;
 }

--- a/docs/PropTypes/components/ClearIndicator.ts
+++ b/docs/PropTypes/components/ClearIndicator.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, ClearIndicatorProps, OptionBase } from 'react-select';
+import { GroupBase, ClearIndicatorProps } from 'react-select';
 
 export default class ClearIndicator<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<ClearIndicatorProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Control.ts
+++ b/docs/PropTypes/components/Control.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { ControlProps, GroupBase, OptionBase } from 'react-select';
+import { ControlProps, GroupBase } from 'react-select';
 
 export default class Control<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<ControlProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/DropdownIndicator.ts
+++ b/docs/PropTypes/components/DropdownIndicator.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, DropdownIndicatorProps, OptionBase } from 'react-select';
+import { GroupBase, DropdownIndicatorProps } from 'react-select';
 
 export default class DropdownIndicator<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<DropdownIndicatorProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Group.ts
+++ b/docs/PropTypes/components/Group.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, GroupProps, OptionBase } from 'react-select';
+import { GroupBase, GroupProps } from 'react-select';
 
 export default class Group<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<GroupProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/IndicatorsContainer.ts
+++ b/docs/PropTypes/components/IndicatorsContainer.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, IndicatorsContainerProps, OptionBase } from 'react-select';
+import { GroupBase, IndicatorsContainerProps } from 'react-select';
 
 export default class IndicatorsContainer<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<IndicatorsContainerProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/IndicatorsSeparator.ts
+++ b/docs/PropTypes/components/IndicatorsSeparator.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { DropdownIndicatorProps, GroupBase, OptionBase } from 'react-select';
+import { DropdownIndicatorProps, GroupBase } from 'react-select';
 
 export default class DropdownIndicator<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<DropdownIndicatorProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Input.ts
+++ b/docs/PropTypes/components/Input.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, InputProps, OptionBase } from 'react-select';
+import { GroupBase, InputProps } from 'react-select';
 
 export default class Input<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<InputProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/LoadingIndicator.ts
+++ b/docs/PropTypes/components/LoadingIndicator.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, LoadingIndicatorProps, OptionBase } from 'react-select';
+import { GroupBase, LoadingIndicatorProps } from 'react-select';
 
 export default class LoadingIndicator<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<LoadingIndicatorProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/LoadingMessage.ts
+++ b/docs/PropTypes/components/LoadingMessage.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, NoticeProps, OptionBase } from 'react-select';
+import { GroupBase, NoticeProps } from 'react-select';
 
 export default class LoadingMessage<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<NoticeProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Menu.ts
+++ b/docs/PropTypes/components/Menu.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MenuProps, OptionBase } from 'react-select';
+import { GroupBase, MenuProps } from 'react-select';
 
 export default class Menu<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MenuProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/MenuList.ts
+++ b/docs/PropTypes/components/MenuList.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MenuListProps, OptionBase } from 'react-select';
+import { GroupBase, MenuListProps } from 'react-select';
 
 export default class MenuList<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MenuListProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/MultiValue.ts
+++ b/docs/PropTypes/components/MultiValue.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MultiValueProps, OptionBase } from 'react-select';
+import { GroupBase, MultiValueProps } from 'react-select';
 
 export default class MultiValue<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MultiValueProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/MultiValueContainer.ts
+++ b/docs/PropTypes/components/MultiValueContainer.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MultiValueGenericProps, OptionBase } from 'react-select';
+import { GroupBase, MultiValueGenericProps } from 'react-select';
 
 export default class MultiValueContainer<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MultiValueGenericProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/MultiValueLabel.ts
+++ b/docs/PropTypes/components/MultiValueLabel.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MultiValueGenericProps, OptionBase } from 'react-select';
+import { GroupBase, MultiValueGenericProps } from 'react-select';
 
 export default class MultiValueLabel<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MultiValueGenericProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/MultiValueRemove.ts
+++ b/docs/PropTypes/components/MultiValueRemove.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, MultiValueGenericProps, OptionBase } from 'react-select';
+import { GroupBase, MultiValueGenericProps } from 'react-select';
 
 export default class MultiValueRemove<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MultiValueGenericProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/NoOptionsMessage.ts
+++ b/docs/PropTypes/components/NoOptionsMessage.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, NoticeProps, OptionBase } from 'react-select';
+import { GroupBase, NoticeProps } from 'react-select';
 
 export default class NoOptionsMessage<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<NoticeProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Option.ts
+++ b/docs/PropTypes/components/Option.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, OptionBase, OptionProps } from 'react-select';
+import { GroupBase, OptionProps } from 'react-select';
 
 export default class Option<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<OptionProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/Placeholder.ts
+++ b/docs/PropTypes/components/Placeholder.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, OptionBase, PlaceholderProps } from 'react-select';
+import { GroupBase, PlaceholderProps } from 'react-select';
 
 export default class Placeholder<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<PlaceholderProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/SelectContainer.ts
+++ b/docs/PropTypes/components/SelectContainer.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { ContainerProps, GroupBase, OptionBase } from 'react-select';
+import { ContainerProps, GroupBase } from 'react-select';
 
 export default class SelectContainer<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<ContainerProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/SingleValue.ts
+++ b/docs/PropTypes/components/SingleValue.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, OptionBase, SingleValueProps } from 'react-select';
+import { GroupBase, SingleValueProps } from 'react-select';
 
 export default class SingleValue<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<SingleValueProps<Option, IsMulti, Group>> {}

--- a/docs/PropTypes/components/ValueContainer.ts
+++ b/docs/PropTypes/components/ValueContainer.ts
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { GroupBase, OptionBase, ValueContainerProps } from 'react-select';
+import { GroupBase, ValueContainerProps } from 'react-select';
 
 export default class ValueContainer<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<ValueContainerProps<Option, IsMulti, Group>> {}

--- a/docs/pages/upgradeGuide/props.tsx
+++ b/docs/pages/upgradeGuide/props.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { jsx } from '@emotion/react';
 
-import Select, { components, OptionBase, OptionProps } from 'react-select';
+import Select, { components, OptionProps } from 'react-select';
 import md from '../../markdown/renderer';
 
 const Code: FunctionComponent = ({ children }) => <code>{children}</code>;
@@ -242,7 +242,7 @@ interface InputOptionState {
   readonly isActive: boolean;
 }
 
-class InputOption extends Component<OptionProps<OptionBase>, InputOptionState> {
+class InputOption extends Component<OptionProps, InputOptionState> {
   state: InputOptionState = { isActive: false };
   onMouseDown = () => this.setState({ isActive: true });
   onMouseUp = () => this.setState({ isActive: false });

--- a/packages/react-select/src/Async.tsx
+++ b/packages/react-select/src/Async.tsx
@@ -1,13 +1,13 @@
 import React, { MutableRefObject, ReactElement, RefAttributes } from 'react';
 import Select from './Select';
-import { OptionBase, GroupBase } from './types';
+import { GroupBase } from './types';
 import useStateManager from './useStateManager';
 import useAsync from './useAsync';
 import type { AsyncProps } from './useAsync';
 export type { AsyncProps };
 
 type AsyncSelect = <
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -16,11 +16,7 @@ type AsyncSelect = <
 ) => ReactElement;
 
 const AsyncSelect = React.forwardRef(
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: AsyncProps<Option, IsMulti, Group>,
     ref:
       | ((instance: Select<Option, IsMulti, Group> | null) => void)

--- a/packages/react-select/src/AsyncCreatable.tsx
+++ b/packages/react-select/src/AsyncCreatable.tsx
@@ -1,12 +1,12 @@
 import Select from './Select';
-import { GroupBase, OptionBase } from './types';
+import { GroupBase } from './types';
 import React, { MutableRefObject, ReactElement, RefAttributes } from 'react';
 import useAsync, { AsyncAdditionalProps } from './useAsync';
 import useStateManager, { StateManagerProps } from './useStateManager';
 import useCreatable, { CreatableAdditionalProps } from './useCreatable';
 
 type AsyncCreatableProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = StateManagerProps<Option, IsMulti, Group> &
@@ -14,7 +14,7 @@ type AsyncCreatableProps<
   AsyncAdditionalProps<Option, Group>;
 
 type AsyncCreatableSelect = <
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -23,11 +23,7 @@ type AsyncCreatableSelect = <
 ) => ReactElement;
 
 const AsyncCreatableSelect = React.forwardRef(
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: AsyncCreatableProps<Option, IsMulti, Group>,
     ref:
       | ((instance: Select<Option, IsMulti, Group> | null) => void)

--- a/packages/react-select/src/Creatable.tsx
+++ b/packages/react-select/src/Creatable.tsx
@@ -1,18 +1,18 @@
 import React, { MutableRefObject, ReactElement, RefAttributes } from 'react';
 import Select from './Select';
-import { OptionBase, GroupBase } from './types';
+import { GroupBase } from './types';
 import useStateManager, { StateManagerProps } from './useStateManager';
 import useCreatable, { CreatableAdditionalProps } from './useCreatable';
 
 export type CreatableProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = StateManagerProps<Option, IsMulti, Group> &
   CreatableAdditionalProps<Option, Group>;
 
 type CreatableSelect = <
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -21,11 +21,7 @@ type CreatableSelect = <
 ) => ReactElement;
 
 const CreatableSelect = React.forwardRef(
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: CreatableProps<Option, IsMulti, Group>,
     ref:
       | ((instance: Select<Option, IsMulti, Group> | null) => void)

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -55,7 +55,6 @@ import {
   MenuPlacement,
   MenuPosition,
   OnChangeValue,
-  OptionBase,
   Options,
   OptionsOrGroups,
   PropsValue,
@@ -63,14 +62,14 @@ import {
 } from './types';
 
 export type FormatOptionLabelContext = 'menu' | 'value';
-export interface FormatOptionLabelMeta<Option extends OptionBase> {
+export interface FormatOptionLabelMeta<Option> {
   context: FormatOptionLabelContext;
   inputValue: string;
   selectValue: Options<Option>;
 }
 
 export interface Props<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -309,7 +308,7 @@ export const defaultProps = {
 };
 
 interface State<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -324,7 +323,7 @@ interface State<
   prevProps: Props<Option, IsMulti, Group> | void;
 }
 
-interface CategorizedOption<Option extends OptionBase> {
+interface CategorizedOption<Option> {
   type: 'option';
   data: Option;
   isDisabled: boolean;
@@ -334,23 +333,19 @@ interface CategorizedOption<Option extends OptionBase> {
   index: number;
 }
 
-interface CategorizedGroup<
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
-> {
+interface CategorizedGroup<Option, Group extends GroupBase<Option>> {
   type: 'group';
   data: Group;
   options: readonly CategorizedOption<Option>[];
   index: number;
 }
 
-type CategorizedGroupOrOption<
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
-> = CategorizedGroup<Option, Group> | CategorizedOption<Option>;
+type CategorizedGroupOrOption<Option, Group extends GroupBase<Option>> =
+  | CategorizedGroup<Option, Group>
+  | CategorizedOption<Option>;
 
 function toCategorizedOption<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -376,7 +371,7 @@ function toCategorizedOption<
 }
 
 function buildCategorizedOptions<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -414,7 +409,7 @@ function buildCategorizedOptions<
 }
 
 function buildFocusableOptionsFromCategorizedOptions<
-  Option extends OptionBase,
+  Option,
   Group extends GroupBase<Option>
 >(categorizedOptions: readonly CategorizedGroupOrOption<Option, Group>[]) {
   return categorizedOptions.reduce<Option[]>(
@@ -433,7 +428,7 @@ function buildFocusableOptionsFromCategorizedOptions<
 }
 
 function buildFocusableOptions<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(props: Props<Option, IsMulti, Group>, selectValue: Options<Option>) {
@@ -443,7 +438,7 @@ function buildFocusableOptions<
 }
 
 function isFocusable<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -460,7 +455,7 @@ function isFocusable<
 }
 
 function getNextFocusedValue<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(state: State<Option, IsMulti, Group>, nextSelectValue: Options<Option>) {
@@ -481,7 +476,7 @@ function getNextFocusedValue<
 }
 
 function getNextFocusedOption<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(state: State<Option, IsMulti, Group>, options: Options<Option>) {
@@ -491,7 +486,7 @@ function getNextFocusedOption<
     : options[0];
 }
 const getOptionLabel = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -501,7 +496,7 @@ const getOptionLabel = <
   return props.getOptionLabel(data);
 };
 const getOptionValue = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -512,7 +507,7 @@ const getOptionValue = <
 };
 
 function isOptionDisabled<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -525,7 +520,7 @@ function isOptionDisabled<
     : false;
 }
 function isOptionSelected<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -541,7 +536,7 @@ function isOptionSelected<
   return selectValue.some((i) => getOptionValue(props, i) === candidate);
 }
 function filterOption<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -553,7 +548,7 @@ function filterOption<
 }
 
 const shouldHideSelectedOptions = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -567,7 +562,7 @@ const shouldHideSelectedOptions = <
 let instanceId = 1;
 
 export default class Select<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends Component<
@@ -630,8 +625,8 @@ export default class Select<
     this.state.selectValue = cleanValue(props.value);
   }
   static getDerivedStateFromProps(
-    props: Props<OptionBase, boolean, GroupBase<OptionBase>>,
-    state: State<OptionBase, boolean, GroupBase<OptionBase>>
+    props: Props<unknown, boolean, GroupBase<unknown>>,
+    state: State<unknown, boolean, GroupBase<unknown>>
   ) {
     const { prevProps, clearFocusValueOnUpdate, inputIsHiddenAfterUpdate } =
       state;
@@ -1997,7 +1992,7 @@ export default class Select<
 }
 
 export type PublicBaseSelectProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>>;

--- a/packages/react-select/src/__tests__/Creatable.test.tsx
+++ b/packages/react-select/src/__tests__/Creatable.test.tsx
@@ -4,7 +4,6 @@ import cases from 'jest-in-case';
 
 import Creatable from '../Creatable';
 import { Option, OPTIONS } from './constants';
-import { OptionBase } from '../types';
 
 interface BasicProps {
   readonly className: string;
@@ -281,7 +280,7 @@ cases<Opts>(
   }
 );
 
-interface CustomOption extends OptionBase {
+interface CustomOption {
   readonly key: string;
   readonly title: string;
 }

--- a/packages/react-select/src/accessibility/index.ts
+++ b/packages/react-select/src/accessibility/index.ts
@@ -67,7 +67,7 @@ export interface AriaOnFocusProps<Option, Group extends GroupBase<Option>> {
 }
 
 export type AriaGuidance = (props: AriaGuidanceProps) => string;
-export type AriaOnChange<Option, IsMulti extends boolean = boolean> = (
+export type AriaOnChange<Option, IsMulti extends boolean> = (
   props: AriaOnChangeProps<Option, IsMulti>
 ) => string;
 export type AriaOnFilter = (props: AriaOnFilterProps) => string;

--- a/packages/react-select/src/accessibility/index.ts
+++ b/packages/react-select/src/accessibility/index.ts
@@ -2,7 +2,6 @@ import {
   ActionMeta,
   GroupBase,
   OnChangeValue,
-  OptionBase,
   Options,
   OptionsOrGroups,
 } from '../types';
@@ -13,7 +12,7 @@ export type GuidanceContext = 'menu' | 'input' | 'value';
 
 export type AriaLive = 'polite' | 'off' | 'assertive';
 
-export type AriaSelection<Option extends OptionBase, IsMulti extends boolean> =
+export type AriaSelection<Option, IsMulti extends boolean> =
   ActionMeta<Option> & {
     value: OnChangeValue<Option, IsMulti>;
   };
@@ -33,10 +32,10 @@ export interface AriaGuidanceProps {
   tabSelectsValue: boolean;
 }
 
-export type AriaOnChangeProps<
-  Option extends OptionBase,
-  IsMulti extends boolean
-> = AriaSelection<Option, IsMulti> & {
+export type AriaOnChangeProps<Option, IsMulti extends boolean> = AriaSelection<
+  Option,
+  IsMulti
+> & {
   /** String derived label from selected or removed option/value */
   label: string;
   /** Boolean indicating if the selected menu option is disabled */
@@ -50,10 +49,7 @@ export interface AriaOnFilterProps {
   resultsMessage: string;
 }
 
-export interface AriaOnFocusProps<
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
-> {
+export interface AriaOnFocusProps<Option, Group extends GroupBase<Option>> {
   /** String indicating whether the option was focused in the menu or as (multi-) value */
   context: OptionContext;
   /** Option that is being focused */
@@ -71,18 +67,17 @@ export interface AriaOnFocusProps<
 }
 
 export type AriaGuidance = (props: AriaGuidanceProps) => string;
-export type AriaOnChange<
-  Option extends OptionBase = OptionBase,
-  IsMulti extends boolean = boolean
-> = (props: AriaOnChangeProps<Option, IsMulti>) => string;
+export type AriaOnChange<Option, IsMulti extends boolean = boolean> = (
+  props: AriaOnChangeProps<Option, IsMulti>
+) => string;
 export type AriaOnFilter = (props: AriaOnFilterProps) => string;
 export type AriaOnFocus<
-  Option extends OptionBase = OptionBase,
+  Option,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = (props: AriaOnFocusProps<Option, Group>) => string;
 
 export interface AriaLiveMessages<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -124,7 +119,7 @@ export const defaultAriaLiveMessages = {
     }
   },
 
-  onChange: <Option extends OptionBase, IsMulti extends boolean>(
+  onChange: <Option, IsMulti extends boolean>(
     props: AriaOnChangeProps<Option, IsMulti>
   ) => {
     const { action, label = '', isDisabled } = props;
@@ -142,7 +137,7 @@ export const defaultAriaLiveMessages = {
     }
   },
 
-  onFocus: <Option extends OptionBase, Group extends GroupBase<Option>>(
+  onFocus: <Option, Group extends GroupBase<Option>>(
     props: AriaOnFocusProps<Option, Group>
   ) => {
     const {

--- a/packages/react-select/src/animated/Input.tsx
+++ b/packages/react-select/src/animated/Input.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import { TransitionProps } from 'react-transition-group/Transition';
 import { InputProps } from '../components/Input';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export type InputComponent = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -12,18 +12,14 @@ export type InputComponent = <
 ) => ReactElement;
 
 export type AnimatedInputProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = InputProps<Option, IsMulti, Group> & Partial<TransitionProps>;
 
 // strip transition props off before spreading onto select component
 const AnimatedInput = (WrappedComponent: InputComponent): InputComponent => {
-  return <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >({
+  return <Option, IsMulti extends boolean, Group extends GroupBase<Option>>({
     in: inProp,
     onExited,
     appear,

--- a/packages/react-select/src/animated/MultiValue.tsx
+++ b/packages/react-select/src/animated/MultiValue.tsx
@@ -2,10 +2,10 @@ import React, { ReactElement } from 'react';
 import { TransitionProps } from 'react-transition-group/Transition';
 import { MultiValueProps } from '../components/MultiValue';
 import { Collapse } from './transitions';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export type MultiValueComponent = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -13,7 +13,7 @@ export type MultiValueComponent = <
 ) => ReactElement;
 
 export type AnimatedMultiValueProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = MultiValueProps<Option, IsMulti, Group> & Partial<TransitionProps>;
@@ -21,11 +21,7 @@ export type AnimatedMultiValueProps<
 // strip transition props off before spreading onto actual component
 
 const AnimatedMultiValue = (WrappedComponent: MultiValueComponent) => {
-  return <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >({
+  return <Option, IsMulti extends boolean, Group extends GroupBase<Option>>({
     in: inProp,
     onExited,
     ...props

--- a/packages/react-select/src/animated/Placeholder.tsx
+++ b/packages/react-select/src/animated/Placeholder.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import { PlaceholderProps } from '../components/Placeholder';
 import { Fade, collapseDuration } from './transitions';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export type PlaceholderComponent = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -14,11 +14,7 @@ export type PlaceholderComponent = <
 // fade in when last multi-value removed, otherwise instant
 const AnimatedPlaceholder =
   (WrappedComponent: PlaceholderComponent) =>
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: PlaceholderProps<Option, IsMulti, Group>
   ) =>
     (

--- a/packages/react-select/src/animated/SingleValue.tsx
+++ b/packages/react-select/src/animated/SingleValue.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import { SingleValueProps } from '../components/SingleValue';
 import { Fade } from './transitions';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export type SingleValueComponent = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -15,11 +15,7 @@ export type SingleValueComponent = <
 
 const AnimatedSingleValue =
   (WrappedComponent: SingleValueComponent) =>
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: SingleValueProps<Option, IsMulti, Group>
   ) =>
     (

--- a/packages/react-select/src/animated/ValueContainer.tsx
+++ b/packages/react-select/src/animated/ValueContainer.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import { ValueContainerProps } from '../components/containers';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export type ValueContainerComponent = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -14,11 +14,7 @@ export type ValueContainerComponent = <
 // make ValueContainer a transition group
 const AnimatedValueContainer =
   (WrappedComponent: ValueContainerComponent) =>
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: ValueContainerProps<Option, IsMulti, Group>
   ) =>
     <TransitionGroup component={WrappedComponent} {...(props as any)} />;

--- a/packages/react-select/src/builtins.ts
+++ b/packages/react-select/src/builtins.ts
@@ -1,20 +1,14 @@
-import { GroupBase, OptionBase } from './types';
+import { GroupBase } from './types';
 
-export const formatGroupLabel = <
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
->(
+export const formatGroupLabel = <Option, Group extends GroupBase<Option>>(
   group: Group
 ): string => group.label as string;
 
-export const getOptionLabel = <Option extends OptionBase>(
-  option: Option
-): string => option.label as string;
+export const getOptionLabel = <Option>(option: Option): string =>
+  (option as { label?: unknown }).label as string;
 
-export const getOptionValue = <Option extends OptionBase>(
-  option: Option
-): string => option.value as string;
+export const getOptionValue = <Option>(option: Option): string =>
+  (option as { value?: unknown }).value as string;
 
-export const isOptionDisabled = <Option extends OptionBase>(
-  option: Option
-): boolean => !!option.isDisabled;
+export const isOptionDisabled = <Option>(option: Option): boolean =>
+  !!(option as { isDisabled?: unknown }).isDisabled;

--- a/packages/react-select/src/components/Control.tsx
+++ b/packages/react-select/src/components/Control.tsx
@@ -6,11 +6,10 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 export interface ControlProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -28,7 +27,7 @@ export interface ControlProps<
 }
 
 export const css = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -63,7 +62,7 @@ export const css = <
 });
 
 const Control = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/Group.tsx
+++ b/packages/react-select/src/components/Group.tsx
@@ -9,14 +9,13 @@ import {
   CX,
   GetStyles,
   GroupBase,
-  OptionBase,
   Options,
   Theme,
 } from '../types';
 import { Props } from '../Select';
 
 export interface ForwardedHeadingProps<
-  Option extends OptionBase,
+  Option,
   Group extends GroupBase<Option>
 > {
   id: string;
@@ -24,7 +23,7 @@ export interface ForwardedHeadingProps<
 }
 
 export interface GroupProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -44,7 +43,7 @@ export interface GroupProps<
 }
 
 export const groupCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -55,7 +54,7 @@ export const groupCSS = <
 });
 
 const Group = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -94,7 +93,7 @@ const Group = <
 };
 
 interface GroupHeadingPropsDefinedProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends ForwardedHeadingProps<Option, Group> {
@@ -106,14 +105,14 @@ interface GroupHeadingPropsDefinedProps<
 }
 
 export type GroupHeadingProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = GroupHeadingPropsDefinedProps<Option, IsMulti, Group> &
   JSX.IntrinsicElements['div'];
 
 export const groupHeadingCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -132,7 +131,7 @@ export const groupHeadingCSS = <
 });
 
 export const GroupHeading = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/Input.tsx
+++ b/packages/react-select/src/components/Input.tsx
@@ -6,12 +6,11 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 import { cleanCommonProps } from '../utils';
 
 export interface InputSpecificProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends InputHTMLAttributes<HTMLInputElement>,
@@ -29,13 +28,13 @@ export interface InputSpecificProps<
 }
 
 export type InputProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = InputSpecificProps<Option, IsMulti, Group>;
 
 export const inputCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -83,7 +82,7 @@ const inputStyle = (isHidden: boolean) => ({
 });
 
 const Input = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/LiveRegion.tsx
+++ b/packages/react-select/src/components/LiveRegion.tsx
@@ -4,20 +4,14 @@ import { jsx } from '@emotion/react';
 import A11yText from '../internal/A11yText';
 import { defaultAriaLiveMessages, AriaSelection } from '../accessibility';
 
-import {
-  CommonProps,
-  GroupBase,
-  OnChangeValue,
-  OptionBase,
-  Options,
-} from '../types';
+import { CommonProps, GroupBase, OnChangeValue, Options } from '../types';
 
 // ==============================
 // Root Container
 // ==============================
 
 export interface LiveRegionProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends CommonProps<Option, IsMulti, Group> {
@@ -33,7 +27,7 @@ export interface LiveRegionProps<
 }
 
 const LiveRegion = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -22,7 +22,6 @@ import {
   MenuPosition,
   CommonProps,
   Theme,
-  OptionBase,
   GroupBase,
   CommonPropsAndClassName,
   CoercedMenuPlacement,
@@ -225,7 +224,7 @@ export interface MenuPlacementProps {
 }
 
 export interface MenuProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group>,
@@ -250,7 +249,7 @@ interface ChildrenProps {
 }
 
 export interface MenuPlacerProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends CommonProps<Option, IsMulti, Group>,
@@ -266,7 +265,7 @@ function alignToControl(placement: CoercedMenuPlacement) {
 const coercePlacement = (p: MenuPlacement) => (p === 'auto' ? 'bottom' : p);
 
 export const menuCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -291,7 +290,7 @@ const PortalPlacementContext = createContext<{
 
 // NOTE: internal only
 export class MenuPlacer<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MenuPlacerProps<Option, IsMulti, Group>, MenuState> {
@@ -349,11 +348,7 @@ export class MenuPlacer<
   }
 }
 
-const Menu = <
-  Option extends OptionBase,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>
->(
+const Menu = <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
   props: MenuProps<Option, IsMulti, Group>
 ) => {
   const { children, className, cx, getStyles, innerRef, innerProps } = props;
@@ -377,7 +372,7 @@ export default Menu;
 // ==============================
 
 export interface MenuListProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -393,7 +388,7 @@ export interface MenuListProps<
   innerProps: JSX.IntrinsicElements['div'];
 }
 export const menuListCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -410,7 +405,7 @@ export const menuListCSS = <
   WebkitOverflowScrolling: 'touch',
 });
 export const MenuList = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -441,7 +436,7 @@ export const MenuList = <
 // ==============================
 
 const noticeCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -458,7 +453,7 @@ export const noOptionsMessageCSS = noticeCSS;
 export const loadingMessageCSS = noticeCSS;
 
 export interface NoticeProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -469,7 +464,7 @@ export interface NoticeProps<
 }
 
 export const NoOptionsMessage = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -497,7 +492,7 @@ NoOptionsMessage.defaultProps = {
 };
 
 export const LoadingMessage = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -529,7 +524,7 @@ LoadingMessage.defaultProps = {
 // ==============================
 
 export interface MenuPortalProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -564,7 +559,7 @@ export const menuPortalCSS = ({
 });
 
 export class MenuPortal<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends Component<MenuPortalProps<Option, IsMulti, Group>, MenuPortalState> {

--- a/packages/react-select/src/components/MultiValue.tsx
+++ b/packages/react-select/src/components/MultiValue.tsx
@@ -20,7 +20,7 @@ interface MultiValueComponents<
 }
 
 export interface MultiValueProps<
-  Option,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -112,7 +112,7 @@ export const MultiValueGeneric = <
 export const MultiValueContainer = MultiValueGeneric;
 export const MultiValueLabel = MultiValueGeneric;
 export interface MultiValueRemoveProps<
-  Option,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > {

--- a/packages/react-select/src/components/MultiValue.tsx
+++ b/packages/react-select/src/components/MultiValue.tsx
@@ -6,12 +6,11 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 import { Props } from '../Select';
 
 interface MultiValueComponents<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -21,7 +20,7 @@ interface MultiValueComponents<
 }
 
 export interface MultiValueProps<
-  Option extends OptionBase = OptionBase,
+  Option,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -36,7 +35,7 @@ export interface MultiValueProps<
 }
 
 export const multiValueCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -51,7 +50,7 @@ export const multiValueCSS = <
 });
 
 export const multiValueLabelCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -70,7 +69,7 @@ export const multiValueLabelCSS = <
 });
 
 export const multiValueRemoveCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -90,7 +89,7 @@ export const multiValueRemoveCSS = <
 });
 
 export interface MultiValueGenericProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > {
@@ -100,7 +99,7 @@ export interface MultiValueGenericProps<
   selectProps: Props<Option, IsMulti, Group>;
 }
 export const MultiValueGeneric = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -113,7 +112,7 @@ export const MultiValueGeneric = <
 export const MultiValueContainer = MultiValueGeneric;
 export const MultiValueLabel = MultiValueGeneric;
 export interface MultiValueRemoveProps<
-  Option extends OptionBase = OptionBase,
+  Option,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > {
@@ -123,7 +122,7 @@ export interface MultiValueRemoveProps<
   selectProps: Props<Option, IsMulti, Group>;
 }
 export function MultiValueRemove<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({ children, innerProps }: MultiValueRemoveProps<Option, IsMulti, Group>) {
@@ -131,7 +130,7 @@ export function MultiValueRemove<
 }
 
 const MultiValue = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/Option.tsx
+++ b/packages/react-select/src/components/Option.tsx
@@ -6,11 +6,10 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 export interface OptionProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -36,7 +35,7 @@ export interface OptionProps<
 }
 
 export const optionCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -75,7 +74,7 @@ export const optionCSS = <
 });
 
 const Option = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/Placeholder.tsx
+++ b/packages/react-select/src/components/Placeholder.tsx
@@ -5,11 +5,10 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 export interface PlaceholderProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -22,7 +21,7 @@ export interface PlaceholderProps<
 }
 
 export const placeholderCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -38,7 +37,7 @@ export const placeholderCSS = <
 });
 
 const Placeholder = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/SingleValue.tsx
+++ b/packages/react-select/src/components/SingleValue.tsx
@@ -5,11 +5,10 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 export interface SingleValueProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -24,7 +23,7 @@ export interface SingleValueProps<
 }
 
 export const css = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -45,7 +44,7 @@ export const css = <
 });
 
 const SingleValue = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/containers.tsx
+++ b/packages/react-select/src/components/containers.tsx
@@ -5,7 +5,6 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 // ==============================
@@ -13,7 +12,7 @@ import {
 // ==============================
 
 export interface ContainerProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -26,7 +25,7 @@ export interface ContainerProps<
   innerProps: JSX.IntrinsicElements['div'];
 }
 export const containerCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -39,7 +38,7 @@ export const containerCSS = <
   position: 'relative',
 });
 export const SelectContainer = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -69,7 +68,7 @@ export const SelectContainer = <
 // ==============================
 
 export interface ValueContainerProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -80,7 +79,7 @@ export interface ValueContainerProps<
   isDisabled: boolean;
 }
 export const valueContainerCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -96,7 +95,7 @@ export const valueContainerCSS = <
   overflow: 'hidden',
 });
 export const ValueContainer = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -128,7 +127,7 @@ export const ValueContainer = <
 // ==============================
 
 export interface IndicatorsContainerProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -146,7 +145,7 @@ export const indicatorsContainerCSS = (): CSSObjectWithLabel => ({
   flexShrink: 0,
 });
 export const IndicatorsContainer = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/index.ts
+++ b/packages/react-select/src/components/index.ts
@@ -46,10 +46,10 @@ import MultiValue, {
 import Option, { OptionProps } from './Option';
 import Placeholder, { PlaceholderProps } from './Placeholder';
 import SingleValue, { SingleValueProps } from './SingleValue';
-import { GroupBase, OptionBase } from '../types';
+import { GroupBase } from '../types';
 
 export interface SelectComponents<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -95,7 +95,7 @@ export interface SelectComponents<
 }
 
 export type SelectComponentsConfig<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = Partial<SelectComponents<Option, IsMulti, Group>>;
@@ -131,7 +131,7 @@ export const components = {
 export type SelectComponentsGeneric = typeof components;
 
 interface Props<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -139,7 +139,7 @@ interface Props<
 }
 
 export const defaultComponents = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/components/indicators.tsx
+++ b/packages/react-select/src/components/indicators.tsx
@@ -6,7 +6,6 @@ import {
   CommonPropsAndClassName,
   CSSObjectWithLabel,
   GroupBase,
-  OptionBase,
 } from '../types';
 
 // ==============================
@@ -52,7 +51,7 @@ export const DownChevron = (props: DownChevronProps) => (
 // ==============================
 
 export interface DropdownIndicatorProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -66,7 +65,7 @@ export interface DropdownIndicatorProps<
 }
 
 const baseCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -91,7 +90,7 @@ const baseCSS = <
 
 export const dropdownIndicatorCSS = baseCSS;
 export const DropdownIndicator = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -116,7 +115,7 @@ export const DropdownIndicator = <
 };
 
 export interface ClearIndicatorProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -130,7 +129,7 @@ export interface ClearIndicatorProps<
 
 export const clearIndicatorCSS = baseCSS;
 export const ClearIndicator = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -159,7 +158,7 @@ export const ClearIndicator = <
 // ==============================
 
 export interface IndicatorSeparatorProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -169,7 +168,7 @@ export interface IndicatorSeparatorProps<
 }
 
 export const indicatorSeparatorCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -188,7 +187,7 @@ export const indicatorSeparatorCSS = <
 });
 
 export const IndicatorSeparator = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
@@ -214,7 +213,7 @@ const loadingDotAnimations = keyframes`
 `;
 
 export const loadingIndicatorCSS = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({
@@ -258,7 +257,7 @@ const LoadingDot = ({ delay, offset }: LoadingDotProps) => (
 );
 
 export interface LoadingIndicatorProps<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends CommonPropsAndClassName<Option, IsMulti, Group> {
@@ -271,7 +270,7 @@ export interface LoadingIndicatorProps<
   size: number;
 }
 export const LoadingIndicator = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/filters.ts
+++ b/packages/react-select/src/filters.ts
@@ -1,14 +1,13 @@
 import memoizeOne from 'memoize-one';
 import { stripDiacritics } from './diacritics';
-import { OptionBase } from './types';
 
-export interface FilterOptionOption<Option extends OptionBase> {
+export interface FilterOptionOption<Option> {
   readonly label: string;
   readonly value: string;
   readonly data: Option;
 }
 
-interface Config<Option extends OptionBase> {
+interface Config<Option> {
   readonly ignoreCase?: boolean;
   readonly ignoreAccents?: boolean;
   readonly stringify?: (option: FilterOptionOption<Option>) => string;
@@ -19,15 +18,14 @@ interface Config<Option extends OptionBase> {
 const memoizedStripDiacriticsForInput = memoizeOne(stripDiacritics);
 
 const trimString = (str: string) => str.replace(/^\s+|\s+$/g, '');
-const defaultStringify = <Option extends OptionBase>(
-  option: FilterOptionOption<Option>
-) => `${option.label} ${option.value}`;
+const defaultStringify = <Option>(option: FilterOptionOption<Option>) =>
+  `${option.label} ${option.value}`;
 
 export const createFilter =
-  <Option extends OptionBase>(config?: Config<Option>) =>
+  <Option>(config?: Config<Option>) =>
   (option: FilterOptionOption<Option>, rawInput: string): boolean => {
     // eslint-disable-next-line no-underscore-dangle
-    if (option.data.__isNew__) return true;
+    if ((option.data as { __isNew__?: unknown }).__isNew__) return true;
     const { ignoreCase, ignoreAccents, stringify, trim, matchFrom } = {
       ignoreCase: true,
       ignoreAccents: true,

--- a/packages/react-select/src/index.ts
+++ b/packages/react-select/src/index.ts
@@ -1,5 +1,5 @@
 import Select from './Select';
-import { GroupBase, OptionBase } from './types';
+import { GroupBase } from './types';
 
 export { default } from './stateManager';
 export { default as NonceProvider } from './NonceProvider';
@@ -8,7 +8,7 @@ export { defaultTheme } from './theme';
 export { createFilter } from './filters';
 export { components } from './components';
 export type SelectInstance<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = Select<Option, IsMulti, Group>;

--- a/packages/react-select/src/stateManager.tsx
+++ b/packages/react-select/src/stateManager.tsx
@@ -1,13 +1,13 @@
 import React, { MutableRefObject, ReactElement, RefAttributes } from 'react';
 
-import { GroupBase, OptionBase } from './types';
+import { GroupBase } from './types';
 import Select from './Select';
 import useStateManager from './useStateManager';
 import type { StateManagerProps } from './useStateManager';
 export type { StateManagerProps };
 
 type StateManagedSelect = <
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -16,11 +16,7 @@ type StateManagedSelect = <
 ) => ReactElement;
 
 const StateManagedSelect = React.forwardRef(
-  <
-    Option extends OptionBase,
-    IsMulti extends boolean,
-    Group extends GroupBase<Option>
-  >(
+  <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
     props: StateManagerProps<Option, IsMulti, Group>,
     ref:
       | ((instance: Select<Option, IsMulti, Group> | null) => void)

--- a/packages/react-select/src/styles.ts
+++ b/packages/react-select/src/styles.ts
@@ -47,10 +47,10 @@ import {
   MultiValueProps,
   multiValueRemoveCSS,
 } from './components/MultiValue';
-import { CSSObjectWithLabel, GroupBase, OptionBase } from './types';
+import { CSSObjectWithLabel, GroupBase } from './types';
 
 export interface StylesProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -80,7 +80,7 @@ export interface StylesProps<
 
 type StylesFunction<Props> = (props: Props) => CSSObjectWithLabel;
 export type StylesFunctions<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = {
@@ -94,7 +94,7 @@ export type StylesConfigFunction<Props> = (
   props: Props
 ) => CSSObjectWithLabel;
 export type StylesConfig<
-  Option extends OptionBase = OptionBase,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = {
@@ -104,9 +104,9 @@ export type StylesConfig<
 };
 
 export const defaultStyles: StylesFunctions<
-  OptionBase,
+  unknown,
   boolean,
-  GroupBase<OptionBase>
+  GroupBase<unknown>
 > = {
   clearIndicator: clearIndicatorCSS,
   container: containerCSS,
@@ -136,7 +136,7 @@ export const defaultStyles: StylesFunctions<
 // Allows consumers to extend a base Select with additional styles
 
 export function mergeStyles<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(

--- a/packages/react-select/src/types.ts
+++ b/packages/react-select/src/types.ts
@@ -7,10 +7,8 @@ export interface GroupBase<Option> {
   readonly label?: string;
 }
 
-export type OptionsOrGroups<
-  Option,
-  Group extends GroupBase<Option>
-> = readonly (Option | Group)[];
+export type OptionsOrGroups<Option, Group extends GroupBase<Option>> =
+  readonly (Option | Group)[];
 
 export type Options<Option> = readonly Option[];
 
@@ -19,10 +17,8 @@ export type MultiValue<Option> = readonly Option[];
 
 export type PropsValue<Option> = MultiValue<Option> | SingleValue<Option>;
 
-export type OnChangeValue<
-  Option,
-  IsMulti extends boolean
-> = IsMulti extends true ? MultiValue<Option> : SingleValue<Option>;
+export type OnChangeValue<Option, IsMulti extends boolean> =
+  IsMulti extends true ? MultiValue<Option> : SingleValue<Option>;
 
 interface Colors {
   primary: string;

--- a/packages/react-select/src/types.ts
+++ b/packages/react-select/src/types.ts
@@ -7,8 +7,10 @@ export interface GroupBase<Option> {
   readonly label?: string;
 }
 
-export type OptionsOrGroups<Option, Group extends GroupBase<Option>> =
-  readonly (Option | Group)[];
+export type OptionsOrGroups<
+  Option,
+  Group extends GroupBase<Option>
+> = readonly (Option | Group)[];
 
 export type Options<Option> = readonly Option[];
 
@@ -17,8 +19,10 @@ export type MultiValue<Option> = readonly Option[];
 
 export type PropsValue<Option> = MultiValue<Option> | SingleValue<Option>;
 
-export type OnChangeValue<Option, IsMulti extends boolean> =
-  IsMulti extends true ? MultiValue<Option> : SingleValue<Option>;
+export type OnChangeValue<
+  Option,
+  IsMulti extends boolean
+> = IsMulti extends true ? MultiValue<Option> : SingleValue<Option>;
 
 interface Colors {
   primary: string;
@@ -144,10 +148,8 @@ export interface CreateOptionActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'create-option';
   name?: string;
 }
-export interface InitialInputFocusedActionMeta<
-  Option extends OptionBase,
-  IsMulti extends boolean
-> extends ActionMetaBase<Option> {
+export interface InitialInputFocusedActionMeta<Option, IsMulti extends boolean>
+  extends ActionMetaBase<Option> {
   action: 'initial-input-focus';
   value: OnChangeValue<Option, IsMulti>;
   options?: Options<Option>;

--- a/packages/react-select/src/types.ts
+++ b/packages/react-select/src/types.ts
@@ -2,33 +2,22 @@ import { CSSObject } from '@emotion/serialize';
 import { Props } from './Select';
 import { StylesProps } from './styles';
 
-export interface OptionBase {
-  readonly label?: string;
-  readonly value?: unknown;
-  readonly isDisabled?: boolean;
-  readonly __isNew__?: true;
-}
-
-export interface GroupBase<Option extends OptionBase> {
+export interface GroupBase<Option> {
   readonly options: readonly Option[];
   readonly label?: string;
 }
 
-export type OptionsOrGroups<
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
-> = readonly (Option | Group)[];
+export type OptionsOrGroups<Option, Group extends GroupBase<Option>> =
+  readonly (Option | Group)[];
 
-export type Options<Option extends OptionBase> = readonly Option[];
+export type Options<Option> = readonly Option[];
 
-export type SingleValue<Option extends OptionBase> = Option | null;
-export type MultiValue<Option extends OptionBase> = readonly Option[];
+export type SingleValue<Option> = Option | null;
+export type MultiValue<Option> = readonly Option[];
 
-export type PropsValue<Option extends OptionBase> =
-  | MultiValue<Option>
-  | SingleValue<Option>;
+export type PropsValue<Option> = MultiValue<Option> | SingleValue<Option>;
 
-export type OnChangeValue<Option extends OptionBase, IsMulti extends boolean> =
+export type OnChangeValue<Option, IsMulti extends boolean> =
   IsMulti extends true ? MultiValue<Option> : SingleValue<Option>;
 
 interface Colors {
@@ -69,7 +58,7 @@ export type ClassNamesState = { [key: string]: boolean };
 
 export type CX = (state: ClassNamesState, className?: string) => string;
 export type GetStyles<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = <Key extends keyof StylesProps<Option, IsMulti, Group>>(
@@ -78,7 +67,7 @@ export type GetStyles<
 ) => CSSObjectWithLabel;
 
 export interface CommonProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
@@ -106,62 +95,57 @@ export interface CommonProps<
 }
 
 export interface CommonPropsAndClassName<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > extends CommonProps<Option, IsMulti, Group> {
   className?: string | undefined;
 }
 
-export interface ActionMetaBase<Option extends OptionBase> {
+export interface ActionMetaBase<Option> {
   option?: Option | undefined;
   removedValue?: Option;
   removedValues?: Options<Option>;
   name?: string;
 }
 
-export interface SelectOptionActionMeta<Option extends OptionBase>
-  extends ActionMetaBase<Option> {
+export interface SelectOptionActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'select-option';
   option: Option | undefined;
   name?: string;
 }
 
-export interface DeselectOptionActionMeta<Option extends OptionBase>
+export interface DeselectOptionActionMeta<Option>
   extends ActionMetaBase<Option> {
   action: 'deselect-option';
   option: Option | undefined;
   name?: string;
 }
 
-export interface RemoveValueActionMeta<Option extends OptionBase>
-  extends ActionMetaBase<Option> {
+export interface RemoveValueActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'remove-value';
   removedValue: Option;
   name?: string;
 }
 
-export interface PopValueActionMeta<Option extends OptionBase>
-  extends ActionMetaBase<Option> {
+export interface PopValueActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'pop-value';
   removedValue: Option;
   name?: string;
 }
 
-export interface ClearActionMeta<Option extends OptionBase>
-  extends ActionMetaBase<Option> {
+export interface ClearActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'clear';
   removedValues: Options<Option>;
   name?: string;
 }
 
-export interface CreateOptionActionMeta<Option extends OptionBase>
-  extends ActionMetaBase<Option> {
+export interface CreateOptionActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'create-option';
   name?: string;
 }
 
-export type ActionMeta<Option extends OptionBase> =
+export type ActionMeta<Option> =
   | SelectOptionActionMeta<Option>
   | DeselectOptionActionMeta<Option>
   | RemoveValueActionMeta<Option>
@@ -193,11 +177,7 @@ export type FocusDirection =
   | 'first'
   | 'last';
 
-export type GetOptionLabel<Option extends OptionBase> = (
-  option: Option
-) => string;
-export type GetOptionValue<Option extends OptionBase> = (
-  option: Option
-) => string;
+export type GetOptionLabel<Option> = (option: Option) => string;
+export type GetOptionValue<Option> = (option: Option) => string;
 
 export type CSSObjectWithLabel = CSSObject & { label?: string };

--- a/packages/react-select/src/useAsync.ts
+++ b/packages/react-select/src/useAsync.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { handleInputChange } from './utils';
 import { StateManagerProps } from './useStateManager';
-import {
-  GroupBase,
-  InputActionMeta,
-  OptionBase,
-  OptionsOrGroups,
-} from './types';
+import { GroupBase, InputActionMeta, OptionsOrGroups } from './types';
 
 type AsyncManagedPropKeys =
   | 'options'
@@ -14,10 +9,7 @@ type AsyncManagedPropKeys =
   | 'onInputChange'
   | 'filterOption';
 
-export interface AsyncAdditionalProps<
-  Option extends OptionBase,
-  Group extends GroupBase<Option>
-> {
+export interface AsyncAdditionalProps<Option, Group extends GroupBase<Option>> {
   /**
    * The default set of options to show before the user starts searching. When
    * set to `true`, the results for loadOptions('') will be autoloaded.
@@ -46,14 +38,14 @@ export interface AsyncAdditionalProps<
 }
 
 export type AsyncProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = StateManagerProps<Option, IsMulti, Group> &
   AsyncAdditionalProps<Option, Group>;
 
 export default function useAsync<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>,
   AdditionalProps

--- a/packages/react-select/src/useCreatable.ts
+++ b/packages/react-select/src/useCreatable.ts
@@ -6,7 +6,6 @@ import {
   GetOptionValue,
   GroupBase,
   OnChangeValue,
-  OptionBase,
   Options,
   OptionsOrGroups,
 } from './types';
@@ -16,13 +15,13 @@ import {
   getOptionLabel as baseGetOptionLabel,
 } from './builtins';
 
-export interface Accessors<Option extends OptionBase> {
+export interface Accessors<Option> {
   getOptionValue: GetOptionValue<Option>;
   getOptionLabel: GetOptionLabel<Option>;
 }
 
 export interface CreatableAdditionalProps<
-  Option extends OptionBase,
+  Option,
   Group extends GroupBase<Option>
 > {
   /**
@@ -62,13 +61,13 @@ export interface CreatableAdditionalProps<
 }
 
 type BaseCreatableProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = PublicBaseSelectProps<Option, IsMulti, Group> &
   CreatableAdditionalProps<Option, Group>;
 
-const compareOption = <Option extends OptionBase>(
+const compareOption = <Option>(
   inputValue = '',
   option: Option,
   accessors: Accessors<Option>
@@ -81,10 +80,7 @@ const compareOption = <Option extends OptionBase>(
 
 const builtins = {
   formatCreateLabel: (inputValue: string) => `Create "${inputValue}"`,
-  isValidNewOption: <
-    Option extends OptionBase,
-    Group extends GroupBase<Option>
-  >(
+  isValidNewOption: <Option, Group extends GroupBase<Option>>(
     inputValue: string,
     selectValue: Options<Option>,
     selectOptions: OptionsOrGroups<Option, Group>,
@@ -107,7 +103,7 @@ const builtins = {
 };
 
 export default function useCreatable<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >({

--- a/packages/react-select/src/useStateManager.ts
+++ b/packages/react-select/src/useStateManager.ts
@@ -3,7 +3,6 @@ import {
   GroupBase,
   InputActionMeta,
   OnChangeValue,
-  OptionBase,
   PropsValue,
 } from './types';
 import { PublicBaseSelectProps } from './Select';
@@ -19,27 +18,27 @@ type StateManagedPropKeys =
   | 'value';
 
 type SelectPropsWithOptionalStateManagedProps<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > = Omit<PublicBaseSelectProps<Option, IsMulti, Group>, StateManagedPropKeys> &
   Partial<PublicBaseSelectProps<Option, IsMulti, Group>>;
 
-export interface StateManagerAdditionalProps<Option extends OptionBase> {
+export interface StateManagerAdditionalProps<Option> {
   defaultInputValue?: string;
   defaultMenuIsOpen?: boolean;
   defaultValue?: PropsValue<Option>;
 }
 
 export type StateManagerProps<
-  Option extends OptionBase = OptionBase,
+  Option,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = SelectPropsWithOptionalStateManagedProps<Option, IsMulti, Group> &
   StateManagerAdditionalProps<Option>;
 
 export default function useStateManager<
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>,
   AdditionalProps

--- a/packages/react-select/src/useStateManager.ts
+++ b/packages/react-select/src/useStateManager.ts
@@ -31,7 +31,7 @@ export interface StateManagerAdditionalProps<Option> {
 }
 
 export type StateManagerProps<
-  Option,
+  Option = unknown,
   IsMulti extends boolean = boolean,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = SelectPropsWithOptionalStateManagedProps<Option, IsMulti, Group> &

--- a/packages/react-select/src/utils.ts
+++ b/packages/react-select/src/utils.ts
@@ -5,7 +5,6 @@ import {
   InputActionMeta,
   MultiValue,
   OnChangeValue,
-  OptionBase,
   Options,
   PropsValue,
   SingleValue,
@@ -64,7 +63,7 @@ export function classNames(
 // Clean Value
 // ==============================
 
-export const cleanValue = <Option extends OptionBase>(
+export const cleanValue = <Option>(
   value: PropsValue<Option>
 ): Options<Option> => {
   if (isArray(value)) return value.filter(Boolean);
@@ -77,7 +76,7 @@ export const cleanValue = <Option extends OptionBase>(
 // ==============================
 
 export const cleanCommonProps = <
-  Option extends OptionBase,
+  Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>,
   AdditionalProps
@@ -349,10 +348,7 @@ export function isArray<T>(arg: unknown): arg is readonly T[] {
   return Array.isArray(arg);
 }
 
-export function valueTernary<
-  Option extends OptionBase,
-  IsMulti extends boolean
->(
+export function valueTernary<Option, IsMulti extends boolean>(
   isMulti: IsMulti | undefined,
   multiValue: MultiValue<Option>,
   singleValue: SingleValue<Option>
@@ -360,16 +356,14 @@ export function valueTernary<
   return (isMulti ? multiValue : singleValue) as OnChangeValue<Option, IsMulti>;
 }
 
-export function singleValueAsValue<
-  Option extends OptionBase,
-  IsMulti extends boolean
->(singleValue: SingleValue<Option>): OnChangeValue<Option, IsMulti> {
+export function singleValueAsValue<Option, IsMulti extends boolean>(
+  singleValue: SingleValue<Option>
+): OnChangeValue<Option, IsMulti> {
   return singleValue as OnChangeValue<Option, IsMulti>;
 }
 
-export function multiValueAsValue<
-  Option extends OptionBase,
-  IsMulti extends boolean
->(multiValue: MultiValue<Option>): OnChangeValue<Option, IsMulti> {
+export function multiValueAsValue<Option, IsMulti extends boolean>(
+  multiValue: MultiValue<Option>
+): OnChangeValue<Option, IsMulti> {
   return multiValue as OnChangeValue<Option, IsMulti>;
 }


### PR DESCRIPTION
Resolves https://github.com/JedWatson/react-select/issues/4696.

Unfortunately due to [weak type detection](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html#weak-type-detection), it doesn't work to have an `Option` generic type that doesn't have any properties in common with `OptionBase` since all of the properties on `OptionBase` are optional. See the attached issue for a more concrete example that causes issues.

```
export interface OptionBase {
  readonly label?: string;
  readonly value?: unknown;
  readonly isDisabled?: boolean;
  readonly __isNew__?: true;
}
```