### PR TITLE
Fix `findDOMNode` deprecation by adding refs to transition components

### DIFF
--- a/.changeset/kind-birds-kiss.md
+++ b/.changeset/kind-birds-kiss.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix findDOMNode deprecation by adding refs to transition components

--- a/packages/react-select/src/animated/transitions.tsx
+++ b/packages/react-select/src/animated/transitions.tsx
@@ -4,6 +4,7 @@ import React, {
   CSSProperties,
   ReactNode,
   RefCallback,
+  useRef,
 } from 'react';
 import { Transition } from 'react-transition-group';
 import {
@@ -28,6 +29,8 @@ export const Fade = <ComponentProps extends {}>({
   onExited,
   ...props
 }: FadeProps<ComponentProps>) => {
+  const nodeRef = useRef<HTMLElement>(null);
+
   const transition: { [K in TransitionStatus]?: CSSProperties } = {
     entering: { opacity: 0 },
     entered: { opacity: 1, transition: `opacity ${duration}ms` },
@@ -36,12 +39,19 @@ export const Fade = <ComponentProps extends {}>({
   };
 
   return (
-    <Transition mountOnEnter unmountOnExit in={inProp} timeout={duration}>
+    <Transition
+      mountOnEnter
+      unmountOnExit
+      in={inProp}
+      timeout={duration}
+      nodeRef={nodeRef}
+    >
       {(state) => {
         const innerProps = {
           style: {
             ...transition[state],
           },
+          ref: nodeRef,
         };
         return <Tag innerProps={innerProps} {...(props as any)} />;
       }}

--- a/packages/react-select/src/animated/transitions.tsx
+++ b/packages/react-select/src/animated/transitions.tsx
@@ -4,7 +4,6 @@ import React, {
   createRef,
   CSSProperties,
   ReactNode,
-  RefCallback,
   useRef,
 } from 'react';
 import { Transition } from 'react-transition-group';

--- a/packages/react-select/src/animated/transitions.tsx
+++ b/packages/react-select/src/animated/transitions.tsx
@@ -94,7 +94,7 @@ export class Collapse extends Component<CollapseProps, CollapseState> {
     /*
       A check on existence of ref should not be necessary at this point,
       but TypeScript demands it.
-    */ 
+    */
     if (ref) {
       /*
         Here we're invoking requestAnimationFrame with a callback invoking our
@@ -110,7 +110,7 @@ export class Collapse extends Component<CollapseProps, CollapseState> {
       });
     }
   }
-  
+
   componentWillUnmount() {
     if (this.rafID) {
       window.cancelAnimationFrame(this.rafID);


### PR DESCRIPTION
This PR adds a reference to the DOM element to the `Fade` and `Collapse` transition components. This reference is then passed to the `Transition` component of `react-transition-group` via the `nodeRef` prop.

Closes #4456 