### PR TITLE
MultiValue key - made more unique by adding a hyphen

### DIFF
--- a/.changeset/gold-tomatoes-smoke.md
+++ b/.changeset/gold-tomatoes-smoke.md
@@ -1,5 +1,5 @@
 ---
-"react-select": patch
+'react-select': patch
 ---
 
 MultiValue key now includes a hyphen between the value and the index to prevent edge cases where you could get a duplicate key error

--- a/.changeset/gold-tomatoes-smoke.md
+++ b/.changeset/gold-tomatoes-smoke.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+MultiValue key now includes a hyphen between the value and the index to prevent edge cases where you could get a duplicate key error

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1664,7 +1664,7 @@ export default class Select<
             }}
             isFocused={isOptionFocused}
             isDisabled={isDisabled}
-            key={`${this.getOptionValue(opt)}${index}`}
+            key={`${this.getOptionValue(opt)}-${index}`}
             index={index}
             removeProps={{
               onClick: () => this.removeValue(opt),


### PR DESCRIPTION
The key for MultiValue in Select.tsx is not unique enough and can have some edge cases where there are duplicated keys.

For example, if the value is 32 and the index is 6 and another value is 3 and the index is 26.  In that case both keys will be 326.

I propose we just add a hyphen between the value and the index.  That way the keys will be `32-6` and `3-26` in this instance.