### PR TITLE
Add type for CreateOptionActionMeta `option` field

### DIFF
--- a/.changeset/real-carrots-rhyme.md
+++ b/.changeset/real-carrots-rhyme.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Add `option` field to type of `CreateOptionActionMeta`

--- a/packages/react-select/src/types.ts
+++ b/packages/react-select/src/types.ts
@@ -143,7 +143,9 @@ export interface ClearActionMeta<Option> extends ActionMetaBase<Option> {
 export interface CreateOptionActionMeta<Option> extends ActionMetaBase<Option> {
   action: 'create-option';
   name?: string;
+  option: Option;
 }
+
 export interface InitialInputFocusedActionMeta<Option, IsMulti extends boolean>
   extends ActionMetaBase<Option> {
   action: 'initial-input-focus';


### PR DESCRIPTION
`Creatable` sends an `option` in its `create-action` meta data (cf. https://github.com/JedWatson/react-select/blob/b0411ff46bc1ecf45d9bca4fb58fbce1e57f847c/packages/react-select/src/Creatable.js#L172-L176), but the type does not expose it.

Closes: https://github.com/JedWatson/react-select/issues/4755