### PR TITLE
Remove src directory from published package

### DIFF
--- a/.changeset/nasty-eagles-suffer.md
+++ b/.changeset/nasty-eagles-suffer.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Remove src directory from published package

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -32,7 +32,6 @@
   },
   "files": [
     "dist",
-    "src",
     "base",
     "animated",
     "async",


### PR DESCRIPTION
We've had a consistent stream of issues relating to people erroneously importing types from `react-select/src`. It seems like the easiest way to prevent this is to not publish the `src` directory.