### PR TITLE
Add `required` prop

### DIFF
--- a/.changeset/violet-readers-listen.md
+++ b/.changeset/violet-readers-listen.md
@@ -1,0 +1,5 @@
+---
+'react-select': minor
+---
+
+Add `required` prop

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1588,6 +1588,7 @@ export default class Select<
       tabIndex,
       form,
       menuIsOpen,
+      required
     } = this.props;
     const { Input } = this.getComponents();
     const { inputIsHidden, ariaSelection } = this.state;
@@ -1604,6 +1605,7 @@ export default class Select<
       'aria-invalid': this.props['aria-invalid'],
       'aria-label': this.props['aria-label'],
       'aria-labelledby': this.props['aria-labelledby'],
+      'aria-required': required,
       role: 'combobox',
       ...(menuIsOpen && {
         'aria-controls': this.getElementId('listbox'),

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -262,8 +262,6 @@ export interface Props<
   value: PropsValue<Option>;
   /** Sets the form attribute on the input */
   form?: string;
-  /** Text to display if the component fails the `required` validation  */
-  requiredMessage: () => string;
   /** Marks the value-holding input as required for form validation */
   required?: boolean;
 }
@@ -1588,7 +1586,7 @@ export default class Select<
       tabIndex,
       form,
       menuIsOpen,
-      required
+      required,
     } = this.props;
     const { Input } = this.getComponents();
     const { inputIsHidden, ariaSelection } = this.state;
@@ -2002,20 +2000,13 @@ export default class Select<
     );
   }
   renderFormField() {
-    const { delimiter, isDisabled, isMulti, name, required, requiredMessage } =
-      this.props;
+    const { delimiter, isDisabled, isMulti, name, required } = this.props;
     const { selectValue } = this.state;
 
     if (!name || isDisabled) return;
 
     if (required && !this.hasValue()) {
-      return (
-        <RequiredInput
-          name={name}
-          onFocus={this.onValueInputFocus}
-          requiredMessage={requiredMessage}
-        />
-      );
+      return <RequiredInput name={name} onFocus={this.onValueInputFocus} />;
     }
 
     if (isMulti) {

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -305,7 +305,6 @@ export const defaultProps = {
   styles: {},
   tabIndex: 0,
   tabSelectsValue: true,
-  requiredMessage: () => 'Please select an item from the list.',
 };
 
 interface State<

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -2006,7 +2006,7 @@ export default class Select<
 
     if (!name || isDisabled) return;
 
-    if (required && !this.hasValue())
+    if (required && !this.hasValue()) {
       return (
         <RequiredInput
           name={name}
@@ -2014,6 +2014,7 @@ export default class Select<
           requiredMessage={requiredMessage}
         />
       );
+    }
 
     if (isMulti) {
       if (delimiter) {

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -3120,20 +3120,42 @@ test('renders with custom theme', () => {
   ).toEqual(primary);
 });
 
-test('form validation with `required` prop', () => {
-  const components = (value?: Option) => (
-    <form id="formTest">
-      <Select {...BASIC_PROPS} required value={value || null} />
-    </form>
-  );
+cases(
+  '`required` prop',
+  ({ props = BASIC_PROPS }) => {
+    const components = (value: Option | null | undefined = null) => (
+      <form id="formTest">
+        <Select {...props} required value={value} />
+      </form>
+    );
 
-  const { container, rerender } = render(components());
+    const { container, rerender } = render(components());
 
-  expect(
-    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
-  ).toEqual(false);
-  rerender(components(BASIC_PROPS.options[0]));
-  expect(
-    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
-  ).toEqual(true);
-});
+    expect(
+      container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+    ).toEqual(false);
+    rerender(components(props.options[0]));
+    expect(
+      container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+    ).toEqual(true);
+  },
+  {
+    'single select > should validate with value': {
+      props: {
+        ...BASIC_PROPS,
+      },
+    },
+    'single select (isSearchable is false) > should validate with value': {
+      props: {
+        ...BASIC_PROPS,
+        isSearchable: false,
+      },
+    },
+    'multi select > should validate with value': {
+      props: {
+        ...BASIC_PROPS,
+        isMulti: true,
+      },
+    },
+  }
+);

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -3119,3 +3119,21 @@ test('renders with custom theme', () => {
     window.getComputedStyle(firstOption!).getPropertyValue('background-color')
   ).toEqual(primary);
 });
+
+test('form validation with `required` prop', () => {
+  const components = (value?: Option) => (
+    <form id="formTest">
+      <Select {...BASIC_PROPS} required value={value || null} />
+    </form>
+  );
+
+  const { container, rerender } = render(components());
+
+  expect(
+    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+  ).toEqual(false);
+  rerender(components(BASIC_PROPS.options[0]));
+  expect(
+    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+  ).toEqual(true);
+});

--- a/packages/react-select/src/__tests__/StateManaged.test.tsx
+++ b/packages/react-select/src/__tests__/StateManaged.test.tsx
@@ -475,3 +475,23 @@ cases<KeyboardInteractionOpts>(
       },
   }
 );
+
+test('`required` prop > should validate', () => {
+  const { container } = render(
+    <form id="formTest">
+      <Select {...BASIC_PROPS} menuIsOpen required />
+    </form>
+  );
+
+  expect(
+    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+  ).toEqual(false);
+
+  let selectOption = container.querySelectorAll('div.react-select__option')[3];
+
+  userEvent.click(selectOption);
+
+  expect(
+    container.querySelector<HTMLFormElement>('#formTest')?.checkValidity()
+  ).toEqual(true);
+});

--- a/packages/react-select/src/internal/RequiredInput.tsx
+++ b/packages/react-select/src/internal/RequiredInput.tsx
@@ -1,65 +1,30 @@
 /** @jsx jsx */
-import {
-  FocusEventHandler,
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import { FocusEventHandler, FunctionComponent } from 'react';
 import { jsx } from '@emotion/react';
 
-interface Props {
+const RequiredInput: FunctionComponent<{
   readonly name: string;
-  readonly requiredMessage: () => string;
   readonly onFocus: FocusEventHandler<HTMLInputElement>;
-}
-
-const RequiredInput: FunctionComponent<Props> = ({
-  name,
-  requiredMessage,
-  onFocus,
-}) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(
-    () => () => {
-      // Reset validity on unmount
-      inputRef.current?.setCustomValidity('');
-    },
-    []
-  );
-
-  const onInvalid = useCallback(() => {
-    inputRef.current?.setCustomValidity(requiredMessage());
-  }, [requiredMessage]);
-
-  useEffect(() => {
-    onInvalid();
-  }, [onInvalid]);
-
-  return (
-    <input
-      required
-      name={name}
-      tabIndex={-1}
-      ref={inputRef}
-      onFocus={onFocus}
-      onInvalid={onInvalid}
-      css={{
-        label: 'requiredInput',
-        opacity: 0,
-        pointerEvents: 'none',
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        width: '100%',
-      }}
-      // Prevent `Switching from uncontrolled to controlled` error
-      value=""
-      onChange={() => {}}
-    />
-  );
-};
+}> = ({ name, onFocus }) => (
+  <input
+    required
+    name={name}
+    tabIndex={-1}
+    onFocus={onFocus}
+    css={{
+      label: 'requiredInput',
+      opacity: 0,
+      pointerEvents: 'none',
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      width: '100%',
+    }}
+    // Prevent `Switching from uncontrolled to controlled` error
+    value=""
+    onChange={() => {}}
+  />
+);
 
 export default RequiredInput;

--- a/packages/react-select/src/internal/RequiredInput.tsx
+++ b/packages/react-select/src/internal/RequiredInput.tsx
@@ -1,0 +1,65 @@
+/** @jsx jsx */
+import {
+  FocusEventHandler,
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import { jsx } from '@emotion/react';
+
+interface Props {
+  readonly name: string;
+  readonly requiredMessage: () => string;
+  readonly onFocus: FocusEventHandler<HTMLInputElement>;
+}
+
+const RequiredInput: FunctionComponent<Props> = ({
+  name,
+  requiredMessage,
+  onFocus,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(
+    () => () => {
+      // Reset validity on unmount
+      inputRef.current?.setCustomValidity('');
+    },
+    []
+  );
+
+  const onInvalid = useCallback(() => {
+    inputRef.current?.setCustomValidity(requiredMessage());
+  }, [requiredMessage]);
+
+  useEffect(() => {
+    onInvalid();
+  }, [onInvalid]);
+
+  return (
+    <input
+      required
+      name={name}
+      tabIndex={-1}
+      ref={inputRef}
+      onFocus={onFocus}
+      onInvalid={onInvalid}
+      css={{
+        label: 'requiredInput',
+        opacity: 0,
+        pointerEvents: 'none',
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: '100%',
+      }}
+      // Prevent `Switching from uncontrolled to controlled` error
+      value=""
+      onChange={() => {}}
+    />
+  );
+};
+
+export default RequiredInput;

--- a/packages/react-select/src/internal/index.ts
+++ b/packages/react-select/src/internal/index.ts
@@ -1,3 +1,4 @@
 export { default as A11yText } from './A11yText';
 export { default as DummyInput } from './DummyInput';
 export { default as ScrollManager } from './ScrollManager';
+export { default as RequiredInput } from './RequiredInput';


### PR DESCRIPTION
This PR adds the new `required` prop to allow for required validation in forms.

This also adds a new prop `requiredMessage` to customize the content of the HTML5 validation message. I would have wanted to use a default browser message, but there is no API to get them, and the default for `<input type='text'>` is imo not applicable for a dropdown component.

@ebonow I don't know if and how this should be implemented into our `LiveRegion` component. Maybe you can find a solution.