### PR TITLE
Add renderClearableIndicatorForEmptyValue prop

### DIFF
--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -196,7 +196,7 @@ export default function Components() {
 
         * When \`isClearable\` is false, or when \`isMulti\` is false, and \`isClearable\` is undefined
         * When the select is disabled
-        * When the select has no value
+        * When the select has no value and \`renderClearableIndicatorForEmptyValue\` is not true
         * When the select is loading
 
         See [props docs](/props#clearindicator) for more details

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -168,6 +168,8 @@ export interface Props<
   instanceId?: number | string;
   /** Is the select value clearable */
   isClearable?: boolean;
+  /** is the ClearableIndicator rendered even for empty value */
+  renderClearableIndicatorForEmptyValue?: boolean;
   /** Is the select disabled */
   isDisabled: boolean;
   /** Is the select in a state of loading (async) */
@@ -1700,16 +1702,18 @@ export default class Select<
   renderClearIndicator() {
     const { ClearIndicator } = this.getComponents();
     const { commonProps } = this;
-    const { isDisabled, isLoading } = this.props;
+    const { isDisabled, isLoading, renderClearableIndicatorForEmptyValue } =
+      this.props;
     const { isFocused } = this.state;
 
-    if (
-      !this.isClearable() ||
-      !ClearIndicator ||
-      isDisabled ||
-      !this.hasValue() ||
-      isLoading
-    ) {
+    const needRenderIndicator =
+      this.isClearable() &&
+      ClearIndicator &&
+      !isDisabled &&
+      !isLoading &&
+      (renderClearableIndicatorForEmptyValue || this.hasValue());
+
+    if (!needRenderIndicator) {
       return null;
     }
 

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2890,6 +2890,21 @@ test('not render any groups when there is not a single match when filtering', ()
   expect(container.querySelectorAll('.react-select__group').length).toBe(0);
 });
 
+test('should render ClearableIndicator if renderClearableIndicatorForEmptyValue is true', () => {
+  const { container } = render(
+    <Select
+      {...BASIC_PROPS}
+      isClearable
+      renderClearableIndicatorForEmptyValue
+      value={null}
+    />
+  );
+
+  expect(
+    container.querySelectorAll('.react-select__clear-indicator').length
+  ).toBe(1);
+});
+
 test('multi select > have default value delimiter seperated', () => {
   let { container } = render(
     <Select


### PR DESCRIPTION
Adds a new property called "renderClearableIndicatorForEmptyValue".
Usage example:
```tsx
const hasDifferentValues = props.value === DIFFERENT_VALUES;

return (
    <MultiSelect
        value={hasDifferentValues ? [] : props.value}
        onChange={props.onChange}
        className={hasDifferentValues ? styles.has_different_values : undefined}
        placeholder={hasDifferentValues ? 'There are different values' : ''}
        renderClearableIndicatorForEmptyValue={hasDifferentValues}
    />
);
```