### PR TITLE
Make 3rd argument of CommonProps['setValue'] optional

### DIFF
--- a/.changeset/stale-baboons-float.md
+++ b/.changeset/stale-baboons-float.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Make 3rd argument of CommonProps['setValue'] optional.

--- a/packages/react-select/src/types.ts
+++ b/packages/react-select/src/types.ts
@@ -89,7 +89,7 @@ export interface CommonProps<
   setValue: (
     newValue: OnChangeValue<Option, IsMulti>,
     action: SetValueAction,
-    option: Option
+    option?: Option
   ) => void;
   theme: Theme;
 }


### PR DESCRIPTION
Tiny fix with regards to [this discussion](https://github.com/JedWatson/react-select/discussions/4877#discussioncomment-1620058).