### PR TITLE
Fixed issue where onMenuScrollToBottom was not fired when the scrollbar is mouse-dragged to the bottom

### DIFF
--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -75,7 +75,7 @@ export default function useScrollCapture({
   );
 
   const onScroll = useCallback(
-    (event: UIEvent<HTMLElement>) => {
+    (event: React.UIEvent<HTMLElement>) => {
       const deltaY = event.currentTarget.scrollTop - previousScrollTop.current;
       previousScrollTop.current = event.currentTarget.scrollTop;
       handleEventDelta(event, deltaY);

--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -104,7 +104,7 @@ export default function useScrollCapture({
       el.addEventListener('touchstart', onTouchStart, notPassive);
       el.addEventListener('touchmove', onTouchMove, notPassive);
     },
-    [onTouchMove, onTouchStart, onWheel]
+    [onTouchMove, onTouchStart, onScroll]
   );
 
   const stopListening = useCallback(
@@ -116,7 +116,7 @@ export default function useScrollCapture({
       el.removeEventListener('touchstart', onTouchStart, false);
       el.removeEventListener('touchmove', onTouchMove, false);
     },
-    [onTouchMove, onTouchStart, onWheel]
+    [onTouchMove, onTouchStart, onScroll]
   );
 
   useEffect(() => {

--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -28,7 +28,7 @@ export default function useScrollCapture({
   const previousScrollTop = useRef(0);
 
   const handleEventDelta = useCallback(
-    (event: WheelEvent | TouchEvent, delta: number) => {
+    (event: WheelEvent | TouchEvent | React.UIEvent<HTMLElement, UIEvent>, delta: number) => {
       if (scrollTarget.current === null) return;
 
       const { scrollTop, scrollHeight, clientHeight } = scrollTarget.current;

--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -25,6 +25,7 @@ export default function useScrollCapture({
   const isTop = useRef(false);
   const touchStart = useRef(0);
   const scrollTarget = useRef<HTMLElement | null>(null);
+  const previousScrollTop = useRef(0);
 
   const handleEventDelta = useCallback(
     (event: WheelEvent | TouchEvent, delta: number) => {
@@ -73,9 +74,11 @@ export default function useScrollCapture({
     [onBottomArrive, onBottomLeave, onTopArrive, onTopLeave]
   );
 
-  const onWheel = useCallback(
-    (event: WheelEvent) => {
-      handleEventDelta(event, event.deltaY);
+  const onScroll = useCallback(
+    (event: ScrollEvent) => {
+      const deltaY = event.currentTarget.scrollTop - previousScrollTop.current;
+      previousScrollTop.current = event.currentTarget.scrollTop;
+      handleEventDelta(event, deltaY);
     },
     [handleEventDelta]
   );
@@ -97,7 +100,7 @@ export default function useScrollCapture({
       if (!el) return;
 
       const notPassive = supportsPassiveEvents ? { passive: false } : false;
-      el.addEventListener('wheel', onWheel, notPassive);
+      el.addEventListener('scroll', onScroll, notPassive);
       el.addEventListener('touchstart', onTouchStart, notPassive);
       el.addEventListener('touchmove', onTouchMove, notPassive);
     },
@@ -109,7 +112,7 @@ export default function useScrollCapture({
       // bail early if no element is available to detach from
       if (!el) return;
 
-      el.removeEventListener('wheel', onWheel, false);
+      el.removeEventListener('scroll', onScroll, false);
       el.removeEventListener('touchstart', onTouchStart, false);
       el.removeEventListener('touchmove', onTouchMove, false);
     },

--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -75,7 +75,7 @@ export default function useScrollCapture({
   );
 
   const onScroll = useCallback(
-    (event: ScrollEvent) => {
+    (event: WheelEvent) => {
       const deltaY = event.currentTarget.scrollTop - previousScrollTop.current;
       previousScrollTop.current = event.currentTarget.scrollTop;
       handleEventDelta(event, deltaY);

--- a/packages/react-select/src/internal/useScrollCapture.ts
+++ b/packages/react-select/src/internal/useScrollCapture.ts
@@ -75,7 +75,7 @@ export default function useScrollCapture({
   );
 
   const onScroll = useCallback(
-    (event: WheelEvent) => {
+    (event: UIEvent<HTMLElement>) => {
       const deltaY = event.currentTarget.scrollTop - previousScrollTop.current;
       previousScrollTop.current = event.currentTarget.scrollTop;
       handleEventDelta(event, deltaY);


### PR DESCRIPTION
Fixed a bug where `onMenuScrollToBottom` isn't called when the scrolling is performed by dragging the scrollbar to the bottom using a mouse-drag.

Related https://github.com/JedWatson/react-select/issues/3232

This PR is based on the PR https://github.com/JedWatson/react-select/pull/3589 originally created by @cdax