### PR TITLE
Fixed deprecated link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Check the docs for more information on:
 
 ## Typescript
 
-The v5 release represents a rewrite from JavaScript to Typescript. The types for v4 and earlier releases are available at [@types](https://www.npmjs.com/package/@types/react-select). See the [TypeScript guide](https://www.react-select.com/typescript) for how to use the types starting with v5.
+The v5 release represents a rewrite from JavaScript to Typescript. See the [TypeScript guide](https://www.react-select.com/typescript) for how to use the types starting with v5.
 
 # Thanks
 


### PR DESCRIPTION
[@types](https://www.npmjs.com/package/@types/react-select) is a stub types definition for @types/react-select (undefined).
react-select provides its own type definitions, so we don't need @types/react-select installed by ourselves.
The link is deprecated.
So we can remove it from README.md in order to have consistent links in our Markdown file.
