### PR TITLE
Added aria-autocomplete prop to select input

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -79,6 +79,8 @@ export interface Props<
   'aria-invalid'?: boolean;
   /** Aria label (for assistive tech) */
   'aria-label'?: string;
+  /** Aria autocomplete */
+  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both';
   /** HTML ID of an element that should be used as the label (for assistive tech) */
   'aria-labelledby'?: string;
   /** Used to set the priority with which screen reader should treat updates to live regions. The possible settings are: off, polite (default) or assertive */
@@ -1557,7 +1559,7 @@ export default class Select<
 
     // aria attributes makes the JSX "noisy", separated for clarity
     const ariaAttributes = {
-      'aria-autocomplete': 'list' as const,
+      'aria-autocomplete': this.props['aria-autocomplete'] || 'list',
       'aria-expanded': menuIsOpen,
       'aria-haspopup': true,
       'aria-controls': this.getElementId('listbox'),


### PR DESCRIPTION
### How it was:
There is no prop available for react select to change aria-autocomplete attribute like we can change aria-label.
The value for aria-autocomplete is set to "list" and is unable to change through props.
Refer the following url to the line of code.
https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/Select.tsx#L1560
Because of aria-autocomplete="list", the screen reader reads out things that the user shouldn't really need to hear. something like "edit text autocompletion lists" is read out.
to prevent that we need to set aria-autocomplete to none. But since it has constant value "list", we are not able to do so.


### What I did:
I have added aria-autocomplete prop to the select input with default value as 'list'