### PR TITLE
Update Defining components docs to reflex example

### DIFF
--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -154,8 +154,8 @@ export default function Components() {
         )
 
         // Good: Custom component declared outside of the Select scope
-        const Control = props => ({ children, ...rest }) => (
-          <components.Control {...rest}>
+        const Control = ({ children, ...props }) => (
+          <components.Control {...props}>
             👍 {children}
           </components.Control>
         );


### PR DESCRIPTION
I believe there is an issue in the current "Defining components" docs. When following the current component docs. I got the following error:

"Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it."

I was able to resolve the issue by having my function directly return a component instead of a curried function that returns a component. This matches the docs example below the snippet that I updated.