### PR TITLE
Fix type inference for Async's loadOptions prop

### DIFF
--- a/.changeset/few-owls-repeat.md
+++ b/.changeset/few-owls-repeat.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix type inference for Async's loadOptions prop

--- a/packages/react-select/src/useAsync.ts
+++ b/packages/react-select/src/useAsync.ts
@@ -118,7 +118,9 @@ export default function useAsync<
       callback: (options?: OptionsOrGroups<Option, Group>) => void
     ) => {
       if (!propsLoadOptions) return callback();
-      const loader = propsLoadOptions(inputValue, callback);
+      const loader = propsLoadOptions(inputValue, callback) as Promise<
+        OptionsOrGroups<Option, Group>
+      > | void;
       if (loader && typeof loader.then === 'function') {
         loader.then(callback, () => callback());
       }

--- a/packages/react-select/src/useAsync.ts
+++ b/packages/react-select/src/useAsync.ts
@@ -24,12 +24,13 @@ export interface AsyncAdditionalProps<Option, Group extends GroupBase<Option>> {
    * Function that returns a promise, which is the set of options to be used
    * once the promise resolves.
    */
-  loadOptions?:
-    | ((
-        inputValue: string,
-        callback: (options: OptionsOrGroups<Option, Group>) => void
-      ) => void)
-    | ((inputValue: string) => Promise<OptionsOrGroups<Option, Group>>);
+  loadOptions?: {
+    (
+      inputValue: string,
+      callback: (options: OptionsOrGroups<Option, Group>) => void
+    ): void;
+    (inputValue: string): Promise<OptionsOrGroups<Option, Group>>;
+  };
   /**
    * Will cause the select to be displayed in the loading state, even if the
    * Async select is not currently waiting for loadOptions to resolve


### PR DESCRIPTION
Fixes https://github.com/JedWatson/react-select/issues/5055.

Basically, TypeScript handles function overloading better than taking the union of functions.