### PR TITLE
Fix type inference for Async's loadOptions prop

### DIFF
--- a/.changeset/serious-cheetahs-give.md
+++ b/.changeset/serious-cheetahs-give.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix type inference for Async's loadOptions prop

--- a/packages/react-select/src/useAsync.ts
+++ b/packages/react-select/src/useAsync.ts
@@ -24,12 +24,10 @@ export interface AsyncAdditionalProps<Option, Group extends GroupBase<Option>> {
    * Function that returns a promise, which is the set of options to be used
    * once the promise resolves.
    */
-  loadOptions?:
-    | ((
-        inputValue: string,
-        callback: (options: OptionsOrGroups<Option, Group>) => void
-      ) => void)
-    | ((inputValue: string) => Promise<OptionsOrGroups<Option, Group>>);
+  loadOptions?: (
+    inputValue: string,
+    callback: (options: OptionsOrGroups<Option, Group>) => void
+  ) => Promise<OptionsOrGroups<Option, Group>> | void;
   /**
    * Will cause the select to be displayed in the loading state, even if the
    * Async select is not currently waiting for loadOptions to resolve


### PR DESCRIPTION
Fixes https://github.com/JedWatson/react-select/issues/5055.