### PR TITLE
Remove duplicate handler for indicator

### DIFF
--- a/.changeset/allow-event-bubbling-for-all-controls.md
+++ b/.changeset/allow-event-bubbling-for-all-controls.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Replace stopPropagation with target check.

--- a/.changeset/share-click-handler-for-dropdown-and-select.md
+++ b/.changeset/share-click-handler-for-dropdown-and-select.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Use single click handler for opening select options. 

--- a/.changeset/share-click-handler-for-dropdown-and-select.md
+++ b/.changeset/share-click-handler-for-dropdown-and-select.md
@@ -1,5 +1,0 @@
----
-'react-select': patch
----
-
-Use single click handler for opening select options. 

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1156,6 +1156,11 @@ export default class Select<
   onControlMouseDown = (
     event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
   ) => {
+    // Event captured by dropdown indicator
+    // @ts-ignore
+    if (event.target.closest('.DropdownIndicatorContainer')) {
+      return;
+    }
     const { openMenuOnClick } = this.props;
     if (!this.state.isFocused) {
       if (openMenuOnClick) {
@@ -1202,7 +1207,6 @@ export default class Select<
       this.openMenu('first');
     }
     event.preventDefault();
-    event.stopPropagation();
   };
   onClearIndicatorMouseDown = (
     event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
@@ -1776,6 +1780,7 @@ export default class Select<
 
     return (
       <DropdownIndicator
+        className="DropdownIndicatorContainer"
         {...commonProps}
         innerProps={innerProps}
         isDisabled={isDisabled}


### PR DESCRIPTION
I have no idea why two different handlers should be applied for single action. The approach with two handlers was forcing to call `stopPropagation` which was causing this issue to occur
https://github.com/JedWatson/react-select/issues/5050