### PR TITLE
updating aria-controls for combobox to have the value of itself or it…

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1558,7 +1558,7 @@ export default class Select<
       'aria-autocomplete': 'list' as const,
       'aria-expanded': menuIsOpen,
       'aria-haspopup': true,
-      'aria-controls': this.getElementId('listbox'),
+      'aria-controls': menuIsOpen? this.getElementId('listbox') : this.getElementId('input'),
       'aria-owns': this.getElementId('listbox'),
       'aria-errormessage': this.props['aria-errormessage'],
       'aria-invalid': this.props['aria-invalid'],

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1558,7 +1558,9 @@ export default class Select<
       'aria-autocomplete': 'list' as const,
       'aria-expanded': menuIsOpen,
       'aria-haspopup': true,
-      'aria-controls': menuIsOpen? this.getElementId('listbox') : this.getElementId('input'),
+      'aria-controls': menuIsOpen
+        ? this.getElementId('listbox')
+        : this.getElementId('input'),
       'aria-owns': this.getElementId('listbox'),
       'aria-errormessage': this.props['aria-errormessage'],
       'aria-invalid': this.props['aria-invalid'],

--- a/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Async.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
+            aria-controls="react-select-2-input"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"

--- a/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/AsyncCreatable.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
+            aria-controls="react-select-2-input"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"

--- a/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Creatable.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`defaults - snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
+            aria-controls="react-select-2-input"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"

--- a/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`snapshot - defaults 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
+            aria-controls="react-select-2-input"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"

--- a/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
+++ b/packages/react-select/src/__tests__/__snapshots__/StateManaged.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`defaults > snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
+            aria-controls="react-select-2-input"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"


### PR DESCRIPTION
…'s containing listbox based on whether the dropdown is open, also updating snapshots accordingly

This is an attempt at fixing the issue brought up in https://github.com/JedWatson/react-select/issues/4832, 

This is just an accessibility update and should not impact functionality 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls