### PR TITLE
Bump @emotion/react to ^11.8.1

### DIFF
--- a/.changeset/swift-poems-protect.md
+++ b/.changeset/swift-poems-protect.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Bump @emotion/react to ^11.8.1 to avoid `useInsertionEffect` bug

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.0",
     "@emotion/cache": "^11.4.0",
-    "@emotion/react": "^11.1.1",
+    "@emotion/react": "^11.8.1",
     "@types/react-transition-group": "^4.4.0",
     "memoize-one": "^5.0.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Fixes https://github.com/JedWatson/react-select/issues/5076. This ca be fixable from a user side by regenerating the lock file, this just makes sure that it's using a version that has the `useInsertionEffect` fix.