### PR TITLE
Fix : color issue with Dropdown indicator on Menu open

### DIFF
--- a/docs/examples/CustomIndicatorsContainer.tsx
+++ b/docs/examples/CustomIndicatorsContainer.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import Select, { components, IndicatorsContainerProps } from 'react-select';
+import Select, {
+  components,
+  IndicatorsContainerProps,
+  defaultTheme,
+} from 'react-select';
 import { ColourOption, colourOptions } from '../data';
+
+const { colors } = defaultTheme;
 
 const IndicatorsContainer = (
   props: IndicatorsContainerProps<ColourOption, true>
@@ -12,6 +18,17 @@ const IndicatorsContainer = (
   );
 };
 
+const customStyles = {
+  dropdownIndicator: (provided: any) => ({
+    ...provided,
+    color: colors.neutral20,
+  }),
+  clearIndicator: (provided: any) => ({
+    ...provided,
+    color: colors.neutral20,
+  }),
+};
+
 export default () => (
   <Select
     closeMenuOnSelect={false}
@@ -19,5 +36,6 @@ export default () => (
     defaultValue={[colourOptions[4], colourOptions[5]]}
     isMulti
     options={colourOptions}
+    styles={customStyles}
   />
 );


### PR DESCRIPTION
- There was issue with one of the examples from https://react-select.com/components page where the dropdown indicator was getting grey color and due to which it wasn't seem good. Just fix that issue here with adding the valid color.

![Screenshot (36)](https://user-images.githubusercontent.com/38291892/166145427-9bf6a1ac-492b-4dd6-a675-da3f96fae908.png)
