### PR TITLE
Export filter interfaces from index.js: FilterOptionOption & [FilterOptions]Config

### DIFF
--- a/packages/react-select/src/filters.ts
+++ b/packages/react-select/src/filters.ts
@@ -7,7 +7,7 @@ export interface FilterOptionOption<Option> {
   readonly data: Option;
 }
 
-interface Config<Option> {
+export interface Config<Option> {
   readonly ignoreCase?: boolean;
   readonly ignoreAccents?: boolean;
   readonly stringify?: (option: FilterOptionOption<Option>) => string;

--- a/packages/react-select/src/index.ts
+++ b/packages/react-select/src/index.ts
@@ -7,6 +7,7 @@ export { default as NonceProvider } from './NonceProvider';
 export { mergeStyles } from './styles';
 export { defaultTheme } from './theme';
 export { createFilter } from './filters';
+export type { FilterOptionOption, Config as FilterOptionConfig } from './filters';
 export { components } from './components';
 export type SelectInstance<
   Option = unknown,


### PR DESCRIPTION
I was trying to work with custom filter logic with typescript and `createFilter`, which is currently only available in old pre-typescript docs:
https://react-select.com/advanced#custom-filter-logic

Anyhow, while trying to figure out the typescript way, and realized I had to copy these interfaces into my own codebase.

This is the example that could perhaps be updated with this (?)
https://github.com/JedWatson/react-select/blob/master/docs/examples/CreateFilter.tsx

I'm still getting my sea-legs with typescript, so happy to hear if there's another way and this isn't necessary.