### PR TITLE
Fix re-focus of component in Firefox if being disabled while focused

### DIFF
--- a/.changeset/neat-hounds-repeat.md
+++ b/.changeset/neat-hounds-repeat.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Fix re-focus of component in Firefox if being disabled while focused

--- a/.changeset/neat-hounds-repeat.md
+++ b/.changeset/neat-hounds-repeat.md
@@ -1,5 +1,5 @@
 ---
-"react-select": patch
+'react-select': patch
 ---
 
 Fix re-focus of component in Firefox if being disabled while focused

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -730,6 +730,10 @@ export default class Select<
       // ensure select state gets blurred in case Select is programmatically disabled while focused
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isFocused: false }, this.onMenuClose);
+    } else if (!isFocused && !isDisabled && prevProps.isDisabled && this.inputRef === document.activeElement) {
+      // ensure select state gets focused in case Select is programatically re-enabled while focused (Firefox)
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ isFocused: true });
     }
 
     // scroll the focused option into view if necessary

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -730,7 +730,12 @@ export default class Select<
       // ensure select state gets blurred in case Select is programmatically disabled while focused
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isFocused: false }, this.onMenuClose);
-    } else if (!isFocused && !isDisabled && prevProps.isDisabled && this.inputRef === document.activeElement) {
+    } else if (
+      !isFocused &&
+      !isDisabled &&
+      prevProps.isDisabled &&
+      this.inputRef === document.activeElement
+    ) {
       // ensure select state gets focused in case Select is programatically re-enabled while focused (Firefox)
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isFocused: true });


### PR DESCRIPTION
Fixes #4906.

As explained in https://github.com/JedWatson/react-select/issues/4906#issuecomment-1068329821, Firefox does not fire blur if component becomes disabled while focused.

When re-enabling, Firefox by default re-focuses the component without firing the focus event, causing in the focused state not being properly set.

This PR fixes this behavior by setting `isFocused` state if component was previously disabled and if `inputRef` is currently active element.