### PR TITLE
docs: update links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # React-Select
 
-The Select control for [React](https://reactjs.com). Initially built for use in [KeystoneJS](http://www.keystonejs.com).
+The Select control for [React](https://reactjs.org). Initially built for use in [KeystoneJS](https://www.keystonejs.com).
 
 See [react-select.com](https://www.react-select.com) for live demos and comprehensive docs.
 


### PR DESCRIPTION
- Update the link to point directly to the reactjs website, instead of a redirected url.
- Add https to the keystonejs link, so it doesn't need to redirect to https.