### PR TITLE
Fix animated multi-value select width bug

### DIFF
--- a/.changeset/plenty-clocks-trade.md
+++ b/.changeset/plenty-clocks-trade.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix bug with animated multi-value select width being too wide

--- a/packages/react-select/src/animated/ValueContainer.tsx
+++ b/packages/react-select/src/animated/ValueContainer.tsx
@@ -87,7 +87,7 @@ const useIsMultiValueContainer = ({
     ...innerProps,
     style: {
       ...innerProps?.style,
-      display: cssDisplayFlex ? 'flex' : 'grid',
+      display: (isMulti && hasValue) || cssDisplayFlex ? 'flex' : 'grid',
     },
   };
 


### PR DESCRIPTION
# Description

This PR fixes https://github.com/JedWatson/react-select/issues/5251 (where the width of selected item in a multi-value select could sometimes be far too wide if it was animated).

As an added bonus this refactors a class component into a function component.

Since useEffect fires _after_ the first paint, the width that we get from `getBoundingClientRect` _should_ always be correct.

**Before:**

https://user-images.githubusercontent.com/3422401/195511304-894b8a8b-aa07-4376-a338-8d12c59a09f7.mp4

**After:**

https://user-images.githubusercontent.com/3422401/195523341-72fc6792-9eec-44f7-a2fe-e539bdd8dc35.mp4


In my testing I couldn't reliably reproduce the bug — before I made the changes, most of the time I could get bug to happen, but not _always_ (you can see in the video about that it doesn't happen on my first attempt). After making the changes I haven't been able to reproduce it. I'm reasonably confident that this is fixed, but some extra eyes on this would be appreciated.