### PR TITLE
Disable use of ResizeObserver for menu auto-updating

### DIFF
--- a/.changeset/new-sloths-wink.md
+++ b/.changeset/new-sloths-wink.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Disable use of ResizeObserver for menu position auto-updating to avoid potential breaking changes.

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -647,7 +647,8 @@ export const MenuPortal = <
       cleanupRef.current = autoUpdate(
         controlElement,
         menuPortalRef.current,
-        updateComputedPosition
+        updateComputedPosition,
+        { elementResize: false }
       );
     }
   }, [controlElement, updateComputedPosition]);


### PR DESCRIPTION
Resolves https://github.com/JedWatson/react-select/pull/5256#issuecomment-1278916683.

We do not have an official browser support policy, but it would be nice to delay relying on `ResizeObserver` for a major bump and make our official browser support policy clear in the next major.

I do not believe we anticipate the `ResizeObserver` getting triggered in many situations anyway since the menu itself shouldn't be resizing. The scroll events are much more critical to auto-updating working properly.