### PR TITLE
Change examples from `class` to `functional` components

### DIFF
--- a/docs/examples/AsyncCallbacks.tsx
+++ b/docs/examples/AsyncCallbacks.tsx
@@ -1,11 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import AsyncSelect from 'react-select/async';
 import { ColourOption, colourOptions } from '../data';
-
-interface State {
-  readonly inputValue: string;
-}
 
 const filterColors = (inputValue: string) => {
   return colourOptions.filter((i) =>
@@ -22,24 +18,6 @@ const loadOptions = (
   }, 1000);
 };
 
-export default class WithCallbacks extends Component<{}, State> {
-  state: State = { inputValue: '' };
-  handleInputChange = (newValue: string) => {
-    const inputValue = newValue.replace(/\W/g, '');
-    this.setState({ inputValue });
-    return inputValue;
-  };
-  render() {
-    return (
-      <div>
-        <pre>inputValue: "{this.state.inputValue}"</pre>
-        <AsyncSelect
-          cacheOptions
-          loadOptions={loadOptions}
-          defaultOptions
-          onInputChange={this.handleInputChange}
-        />
-      </div>
-    );
-  }
-}
+export default () => (
+  <AsyncSelect cacheOptions loadOptions={loadOptions} defaultOptions />
+);

--- a/docs/examples/AsyncCreatable.tsx
+++ b/docs/examples/AsyncCreatable.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import AsyncCreatableSelect from 'react-select/async-creatable';
 import { ColourOption, colourOptions } from '../data';
@@ -16,14 +16,10 @@ const promiseOptions = (inputValue: string) =>
     }, 1000);
   });
 
-export default class WithPromises extends Component {
-  render() {
-    return (
-      <AsyncCreatableSelect
-        cacheOptions
-        defaultOptions
-        loadOptions={promiseOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <AsyncCreatableSelect
+    cacheOptions
+    defaultOptions
+    loadOptions={promiseOptions}
+  />
+);

--- a/docs/examples/AsyncMulti.tsx
+++ b/docs/examples/AsyncMulti.tsx
@@ -1,11 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import AsyncSelect from 'react-select/async';
 import { ColourOption, colourOptions } from '../data';
-
-interface State {
-  readonly inputValue: string;
-}
 
 const filterColors = (inputValue: string) => {
   return colourOptions.filter((i) =>
@@ -20,21 +16,11 @@ const promiseOptions = (inputValue: string) =>
     }, 1000);
   });
 
-export default class AsyncMulti extends Component<{}, State> {
-  state: State = { inputValue: '' };
-  handleInputChange = (newValue: string) => {
-    const inputValue = newValue.replace(/\W/g, '');
-    this.setState({ inputValue });
-    return inputValue;
-  };
-  render() {
-    return (
-      <AsyncSelect
-        isMulti
-        cacheOptions
-        defaultOptions
-        loadOptions={promiseOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <AsyncSelect
+    isMulti
+    cacheOptions
+    defaultOptions
+    loadOptions={promiseOptions}
+  />
+);

--- a/docs/examples/AsyncPromises.tsx
+++ b/docs/examples/AsyncPromises.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import AsyncSelect from 'react-select/async';
 import { ColourOption, colourOptions } from '../data';
@@ -16,10 +16,6 @@ const promiseOptions = (inputValue: string) =>
     }, 1000);
   });
 
-export default class WithPromises extends Component {
-  render() {
-    return (
-      <AsyncSelect cacheOptions defaultOptions loadOptions={promiseOptions} />
-    );
-  }
-}
+export default () => (
+  <AsyncSelect cacheOptions defaultOptions loadOptions={promiseOptions} />
+);

--- a/docs/examples/BasicSingle.tsx
+++ b/docs/examples/BasicSingle.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState } from 'react';
 
 import Select from 'react-select';
 import { colourOptions } from '../data';
@@ -10,86 +10,65 @@ const Checkbox = ({ children, ...props }: JSX.IntrinsicElements['input']) => (
   </label>
 );
 
-interface State {
-  readonly isClearable: boolean;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRtl: boolean;
-  readonly isSearchable: boolean;
-}
+export default () => {
+  const [isClearable, setIsClearable] = useState(false);
+  const [isSearchable, setIsSearchable] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRtl, setIsRtl] = useState(false);
 
-export default class SingleSelect extends Component<{}, State> {
-  state: State = {
-    isClearable: true,
-    isDisabled: false,
-    isLoading: false,
-    isRtl: false,
-    isSearchable: true,
-  };
+  return (
+    <>
+      <Select
+        className="basic-single"
+        classNamePrefix="select"
+        defaultValue={colourOptions[0]}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        isClearable={isClearable}
+        isRtl={isRtl}
+        isSearchable={isSearchable}
+        name="color"
+        options={colourOptions}
+      />
 
-  toggleClearable = () =>
-    this.setState((state) => ({ isClearable: !state.isClearable }));
-  toggleDisabled = () =>
-    this.setState((state) => ({ isDisabled: !state.isDisabled }));
-  toggleLoading = () =>
-    this.setState((state) => ({ isLoading: !state.isLoading }));
-  toggleRtl = () => this.setState((state) => ({ isRtl: !state.isRtl }));
-  toggleSearchable = () =>
-    this.setState((state) => ({ isSearchable: !state.isSearchable }));
-
-  render() {
-    const {
-      toggleClearable,
-      toggleDisabled,
-      toggleLoading,
-      toggleRtl,
-      toggleSearchable,
-    } = this;
-
-    const { isClearable, isSearchable, isDisabled, isLoading, isRtl } =
-      this.state;
-
-    return (
-      <Fragment>
-        <Select
-          className="basic-single"
-          classNamePrefix="select"
-          defaultValue={colourOptions[0]}
-          isDisabled={isDisabled}
-          isLoading={isLoading}
-          isClearable={isClearable}
-          isRtl={isRtl}
-          isSearchable={isSearchable}
-          name="color"
-          options={colourOptions}
-        />
-
-        <div
-          style={{
-            color: 'hsl(0, 0%, 40%)',
-            display: 'inline-block',
-            fontSize: 12,
-            fontStyle: 'italic',
-            marginTop: '1em',
-          }}
+      <div
+        style={{
+          color: 'hsl(0, 0%, 40%)',
+          display: 'inline-block',
+          fontSize: 12,
+          fontStyle: 'italic',
+          marginTop: '1em',
+        }}
+      >
+        <Checkbox
+          checked={isClearable}
+          onChange={() => setIsClearable((state) => !state)}
         >
-          <Checkbox checked={isClearable} onChange={toggleClearable}>
-            Clearable
-          </Checkbox>
-          <Checkbox checked={isSearchable} onChange={toggleSearchable}>
-            Searchable
-          </Checkbox>
-          <Checkbox checked={isDisabled} onChange={toggleDisabled}>
-            Disabled
-          </Checkbox>
-          <Checkbox checked={isLoading} onChange={toggleLoading}>
-            Loading
-          </Checkbox>
-          <Checkbox checked={isRtl} onChange={toggleRtl}>
-            RTL
-          </Checkbox>
-        </div>
-      </Fragment>
-    );
-  }
-}
+          Clearable
+        </Checkbox>
+        <Checkbox
+          checked={isSearchable}
+          onChange={() => setIsSearchable((state) => !state)}
+        >
+          Searchable
+        </Checkbox>
+        <Checkbox
+          checked={isDisabled}
+          onChange={() => setIsDisabled((state) => !state)}
+        >
+          Disabled
+        </Checkbox>
+        <Checkbox
+          checked={isLoading}
+          onChange={() => setIsLoading((state) => !state)}
+        >
+          Loading
+        </Checkbox>
+        <Checkbox checked={isRtl} onChange={() => setIsRtl((state) => !state)}>
+          RTL
+        </Checkbox>
+      </div>
+    </>
+  );
+};

--- a/docs/examples/BasicSingle.tsx
+++ b/docs/examples/BasicSingle.tsx
@@ -11,8 +11,8 @@ const Checkbox = ({ children, ...props }: JSX.IntrinsicElements['input']) => (
 );
 
 export default () => {
-  const [isClearable, setIsClearable] = useState(false);
-  const [isSearchable, setIsSearchable] = useState(false);
+  const [isClearable, setIsClearable] = useState(true);
+  const [isSearchable, setIsSearchable] = useState(true);
   const [isDisabled, setIsDisabled] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isRtl, setIsRtl] = useState(false);

--- a/docs/examples/ControlledMenu.tsx
+++ b/docs/examples/ControlledMenu.tsx
@@ -1,52 +1,44 @@
-import React, { Component, Fragment } from 'react';
+import React, { useRef, useState } from 'react';
 
 import Select, { SelectInstance } from 'react-select';
-import { ColourOption, colourOptions } from '../data';
+import { colourOptions } from '../data';
 import { Note } from '../styled-components';
 
 const Checkbox = (props: JSX.IntrinsicElements['input']) => (
   <input type="checkbox" {...props} />
 );
 
-interface State {
-  readonly menuIsOpen: boolean;
-}
+export default () => {
+  const ref = useRef<SelectInstance>(null);
+  const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
 
-export default class controlledMenu extends Component<{}, State> {
-  state: State = {
-    menuIsOpen: false,
+  const toggleMenuIsOpen = () => {
+    setMenuIsOpen((value) => !value);
+    const { current } = ref;
+    if (!current) return;
+    if (menuIsOpen) current.blur();
+    else current.focus();
   };
-  select?: SelectInstance<ColourOption> | null;
-  toggleMenuIsOpen = () => {
-    this.setState((state) => ({ menuIsOpen: !state.menuIsOpen }));
-    if (this.select) {
-      return !this.state.menuIsOpen ? this.select.focus() : this.select.blur();
-    }
-  };
-  render() {
-    const { menuIsOpen } = this.state;
-    return (
-      <Fragment>
-        <Select
-          ref={(ref) => {
-            this.select = ref;
-          }}
-          defaultValue={colourOptions[0]}
-          isClearable
-          menuIsOpen={menuIsOpen}
-          styles={{ menu: (base) => ({ ...base, position: 'relative' }) }}
-          name="color"
-          options={colourOptions}
+
+  return (
+    <>
+      <Select
+        ref={ref}
+        defaultValue={colourOptions[0]}
+        isClearable
+        menuIsOpen={menuIsOpen}
+        styles={{ menu: (base) => ({ ...base, position: 'relative' }) }}
+        name="color"
+        options={colourOptions}
+      />
+      <Note Tag="label">
+        <Checkbox
+          checked={menuIsOpen}
+          onChange={toggleMenuIsOpen}
+          id="cypress-single__clearable-checkbox"
         />
-        <Note Tag="label">
-          <Checkbox
-            checked={menuIsOpen}
-            onChange={this.toggleMenuIsOpen}
-            id="cypress-single__clearable-checkbox"
-          />
-          menuIsOpen
-        </Note>
-      </Fragment>
-    );
-  }
-}
+        menuIsOpen
+      </Note>
+    </>
+  );
+};

--- a/docs/examples/CreatableAdvanced.tsx
+++ b/docs/examples/CreatableAdvanced.tsx
@@ -1,17 +1,10 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import CreatableSelect from 'react-select/creatable';
-import { ActionMeta, OnChangeValue } from 'react-select';
 
 interface Option {
   readonly label: string;
   readonly value: string;
-}
-
-interface State {
-  readonly isLoading: boolean;
-  readonly options: readonly Option[];
-  readonly value: Option | null | undefined;
 }
 
 const createOption = (label: string) => ({
@@ -25,50 +18,30 @@ const defaultOptions = [
   createOption('Three'),
 ];
 
-export default class CreatableAdvanced extends Component<{}, State> {
-  state: State = {
-    isLoading: false,
-    options: defaultOptions,
-    value: undefined,
-  };
-  handleChange = (
-    newValue: OnChangeValue<Option, false>,
-    actionMeta: ActionMeta<Option>
-  ) => {
-    console.group('Value Changed');
-    console.log(newValue);
-    console.log(`action: ${actionMeta.action}`);
-    console.groupEnd();
-    this.setState({ value: newValue });
-  };
-  handleCreate = (inputValue: string) => {
-    this.setState({ isLoading: true });
-    console.group('Option created');
-    console.log('Wait a moment...');
+export default () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [options, setOptions] = useState(defaultOptions);
+  const [value, setValue] = useState<Option | null>();
+
+  const handleCreate = (inputValue: string) => {
+    setIsLoading(true);
     setTimeout(() => {
-      const { options } = this.state;
       const newOption = createOption(inputValue);
-      console.log(newOption);
-      console.groupEnd();
-      this.setState({
-        isLoading: false,
-        options: [...options, newOption],
-        value: newOption,
-      });
+      setIsLoading(false);
+      setOptions((prev) => [...prev, newOption]);
+      setValue(newOption);
     }, 1000);
   };
-  render() {
-    const { isLoading, options, value } = this.state;
-    return (
-      <CreatableSelect
-        isClearable
-        isDisabled={isLoading}
-        isLoading={isLoading}
-        onChange={this.handleChange}
-        onCreateOption={this.handleCreate}
-        options={options}
-        value={value}
-      />
-    );
-  }
-}
+
+  return (
+    <CreatableSelect
+      isClearable
+      isDisabled={isLoading}
+      isLoading={isLoading}
+      onChange={(newValue) => setValue(newValue)}
+      onCreateOption={handleCreate}
+      options={options}
+      value={value}
+    />
+  );
+};

--- a/docs/examples/CreatableInputOnly.tsx
+++ b/docs/examples/CreatableInputOnly.tsx
@@ -1,7 +1,6 @@
-import React, { Component, KeyboardEventHandler } from 'react';
+import React, { KeyboardEventHandler } from 'react';
 
 import CreatableSelect from 'react-select/creatable';
-import { ActionMeta, OnChangeValue } from 'react-select';
 
 const components = {
   DropdownIndicator: null,
@@ -17,60 +16,33 @@ const createOption = (label: string) => ({
   value: label,
 });
 
-interface State {
-  readonly inputValue: string;
-  readonly value: readonly Option[];
-}
+export default () => {
+  const [inputValue, setInputValue] = React.useState('');
+  const [value, setValue] = React.useState<readonly Option[]>([]);
 
-export default class CreatableInputOnly extends Component<{}, State> {
-  state: State = {
-    inputValue: '',
-    value: [],
-  };
-  handleChange = (
-    value: OnChangeValue<Option, true>,
-    actionMeta: ActionMeta<Option>
-  ) => {
-    console.group('Value Changed');
-    console.log(value);
-    console.log(`action: ${actionMeta.action}`);
-    console.groupEnd();
-    this.setState({ value });
-  };
-  handleInputChange = (inputValue: string) => {
-    this.setState({ inputValue });
-  };
-  handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
-    const { inputValue, value } = this.state;
+  const handleKeyDown: KeyboardEventHandler = (event) => {
     if (!inputValue) return;
     switch (event.key) {
       case 'Enter':
       case 'Tab':
-        console.group('Value Added');
-        console.log(value);
-        console.groupEnd();
-        this.setState({
-          inputValue: '',
-          value: [...value, createOption(inputValue)],
-        });
+        setValue((prev) => [...prev, createOption(inputValue)]);
+        setInputValue('');
         event.preventDefault();
     }
   };
-  render() {
-    const { inputValue, value } = this.state;
-    return (
-      <CreatableSelect
-        components={components}
-        inputValue={inputValue}
-        isClearable
-        isMulti
-        menuIsOpen={false}
-        onChange={this.handleChange}
-        onInputChange={this.handleInputChange}
-        onKeyDown={this.handleKeyDown}
-        placeholder="Type something and press enter..."
-        value={value}
-      />
-    );
-  }
-}
+
+  return (
+    <CreatableSelect
+      components={components}
+      inputValue={inputValue}
+      isClearable
+      isMulti
+      menuIsOpen={false}
+      onChange={(newValue) => setValue(newValue)}
+      onInputChange={(newValue) => setInputValue(newValue)}
+      onKeyDown={handleKeyDown}
+      placeholder="Type something and press enter..."
+      value={value}
+    />
+  );
+};

--- a/docs/examples/CreatableMulti.tsx
+++ b/docs/examples/CreatableMulti.tsx
@@ -1,26 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import CreatableSelect from 'react-select/creatable';
-import { ColourOption, colourOptions } from '../data';
-import { ActionMeta, OnChangeValue } from 'react-select';
+import { colourOptions } from '../data';
 
-export default class CreatableMulti extends Component<{}> {
-  handleChange = (
-    newValue: OnChangeValue<ColourOption, true>,
-    actionMeta: ActionMeta<ColourOption>
-  ) => {
-    console.group('Value Changed');
-    console.log(newValue);
-    console.log(`action: ${actionMeta.action}`);
-    console.groupEnd();
-  };
-  render() {
-    return (
-      <CreatableSelect
-        isMulti
-        onChange={this.handleChange}
-        options={colourOptions}
-      />
-    );
-  }
-}
+export default () => <CreatableSelect isMulti options={colourOptions} />;

--- a/docs/examples/CreatableSingle.tsx
+++ b/docs/examples/CreatableSingle.tsx
@@ -1,33 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import CreatableSelect from 'react-select/creatable';
-import { ColourOption, colourOptions } from '../data';
-import { ActionMeta, OnChangeValue } from 'react-select';
+import { colourOptions } from '../data';
 
-export default class CreatableSingle extends Component {
-  handleChange = (
-    newValue: OnChangeValue<ColourOption, false>,
-    actionMeta: ActionMeta<ColourOption>
-  ) => {
-    console.group('Value Changed');
-    console.log(newValue);
-    console.log(`action: ${actionMeta.action}`);
-    console.groupEnd();
-  };
-  handleInputChange = (inputValue: any, actionMeta: any) => {
-    console.group('Input Changed');
-    console.log(inputValue);
-    console.log(`action: ${actionMeta.action}`);
-    console.groupEnd();
-  };
-  render() {
-    return (
-      <CreatableSelect
-        isClearable
-        onChange={this.handleChange}
-        onInputChange={this.handleInputChange}
-        options={colourOptions}
-      />
-    );
-  }
-}
+export default () => <CreatableSelect isClearable options={colourOptions} />;

--- a/docs/examples/CreateFilter.tsx
+++ b/docs/examples/CreateFilter.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState } from 'react';
 import Select, { createFilter } from 'react-select';
 import { colourOptions } from '../data';
 import { Note } from '../styled-components';
@@ -7,78 +7,61 @@ const Checkbox = (props: JSX.IntrinsicElements['input']) => (
   <input type="checkbox" {...props} />
 );
 
-interface State {
-  readonly ignoreCase: boolean;
-  readonly ignoreAccents: boolean;
-  readonly trim: boolean;
-  readonly matchFromStart: boolean;
-}
+export default () => {
+  const [ignoreCase, setIgnoreCase] = useState(false);
+  const [ignoreAccents, setIgnoreAccents] = useState(false);
+  const [trim, setTrim] = useState(false);
+  const [matchFromStart, setMatchFromStart] = useState(false);
 
-export default class SelectCreateFilter extends Component<{}, State> {
-  state: State = {
-    ignoreCase: false,
-    ignoreAccents: false,
-    trim: false,
-    matchFromStart: false,
+  const filterConfig = {
+    ignoreCase,
+    ignoreAccents,
+    trim,
+    matchFrom: matchFromStart ? ('start' as const) : ('any' as const),
   };
-  toggleOption = (key: keyof State) => () => {
-    this.setState((state) => ({ ...state, [key]: !state[key] }));
-  };
-  render() {
-    const { ignoreCase, ignoreAccents, trim, matchFromStart } = this.state;
 
-    const filterConfig = {
-      ignoreCase,
-      ignoreAccents,
-      trim,
-      matchFrom: this.state.matchFromStart
-        ? ('start' as const)
-        : ('any' as const),
-    };
-
-    return (
-      <Fragment>
-        <Select
-          defaultValue={colourOptions[0]}
-          isClearable
-          isSearchable
-          name="color"
-          options={colourOptions}
-          filterOption={createFilter(filterConfig)}
+  return (
+    <>
+      <Select
+        defaultValue={colourOptions[0]}
+        isClearable
+        isSearchable
+        name="color"
+        options={colourOptions}
+        filterOption={createFilter(filterConfig)}
+      />
+      <Note Tag="label">
+        <Checkbox
+          checked={ignoreCase}
+          onChange={() => setIgnoreCase((prev) => !prev)}
+          id="cypress-single__clearable-checkbox"
         />
-        <Note Tag="label">
-          <Checkbox
-            checked={ignoreCase}
-            onChange={this.toggleOption('ignoreCase')}
-            id="cypress-single__clearable-checkbox"
-          />
-          Ignore Case
-        </Note>
-        <Note Tag="label">
-          <Checkbox
-            checked={ignoreAccents}
-            onChange={this.toggleOption('ignoreAccents')}
-            id="cypress-single__clearable-checkbox"
-          />
-          Ignore Accents
-        </Note>
-        <Note Tag="label">
-          <Checkbox
-            checked={trim}
-            onChange={this.toggleOption('trim')}
-            id="cypress-single__clearable-checkbox"
-          />
-          Trim
-        </Note>
-        <Note Tag="label">
-          <Checkbox
-            checked={matchFromStart}
-            onChange={this.toggleOption('matchFromStart')}
-            id="cypress-single__clearable-checkbox"
-          />
-          Match from the start
-        </Note>
-      </Fragment>
-    );
-  }
-}
+        Ignore Case
+      </Note>
+      <Note Tag="label">
+        <Checkbox
+          checked={ignoreAccents}
+          onChange={() => setIgnoreAccents((prev) => !prev)}
+          id="cypress-single__clearable-checkbox"
+        />
+        Ignore Accents
+      </Note>
+      <Note Tag="label">
+        <Checkbox
+          checked={trim}
+          onChange={() => setTrim((prev) => !prev)}
+          id="cypress-single__clearable-checkbox"
+        />
+        Trim
+      </Note>
+      <Note Tag="label">
+        <Checkbox
+          checked={matchFromStart}
+          onChange={() => setMatchFromStart((prev) => !prev)}
+          id="cypress-single__clearable-checkbox"
+        />
+        Match from the start
+      </Note>
+    </>
+  );
+};

--- a/docs/examples/CustomControl.tsx
+++ b/docs/examples/CustomControl.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import Select, { components, ControlProps } from 'react-select';
 import { ColourOption, colourOptions } from '../data';
@@ -16,17 +16,13 @@ const ControlComponent = (props: ControlProps<ColourOption, false>) => (
   </div>
 );
 
-export default class CustomControl extends Component {
-  render() {
-    return (
-      <Select
-        defaultValue={colourOptions[0]}
-        isClearable
-        components={{ Control: ControlComponent }}
-        isSearchable
-        name="color"
-        options={colourOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <Select
+    defaultValue={colourOptions[0]}
+    isClearable
+    components={{ Control: ControlComponent }}
+    isSearchable
+    name="color"
+    options={colourOptions}
+  />
+);

--- a/docs/examples/CustomFilterOptions.tsx
+++ b/docs/examples/CustomFilterOptions.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Select from 'react-select';
 import { colourOptions } from '../data';
 
@@ -20,17 +20,13 @@ const customOptions = [
   ...colourOptions,
 ];
 
-export default class SelectCreateFilter extends Component {
-  render() {
-    return (
-      <Select
-        defaultValue={customOptions[0]}
-        isClearable
-        isSearchable
-        name="color"
-        options={customOptions}
-        filterOption={filterOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <Select
+    defaultValue={customOptions[0]}
+    isClearable
+    isSearchable
+    name="color"
+    options={customOptions}
+    filterOption={filterOptions}
+  />
+);

--- a/docs/examples/CustomGetOptionLabel.tsx
+++ b/docs/examples/CustomGetOptionLabel.tsx
@@ -1,24 +1,20 @@
-import React, { Component, Fragment } from 'react';
+import React from 'react';
 import Select from 'react-select';
 import { flavourOptions } from '../data';
 
-export default class CustomGetOptionLabel extends Component {
-  render() {
-    return (
-      <Fragment>
-        <p>
-          Composing a display label from the label property and rating property
-          in the options object
-        </p>
-        <Select
-          defaultValue={flavourOptions[0]}
-          isClearable
-          isSearchable
-          name="color"
-          options={flavourOptions}
-          getOptionLabel={(option) => `${option.label}: ${option.rating}`}
-        />
-      </Fragment>
-    );
-  }
-}
+export default () => (
+  <>
+    <p>
+      Composing a display label from the label property and rating property in
+      the options object
+    </p>
+    <Select
+      defaultValue={flavourOptions[0]}
+      isClearable
+      isSearchable
+      name="color"
+      options={flavourOptions}
+      getOptionLabel={(option) => `${option.label}: ${option.rating}`}
+    />
+  </>
+);

--- a/docs/examples/CustomIsOptionDisabled.tsx
+++ b/docs/examples/CustomIsOptionDisabled.tsx
@@ -1,24 +1,20 @@
-import React, { Component, Fragment } from 'react';
+import React from 'react';
 import Select from 'react-select';
 import { flavourOptions } from '../data';
 
-export default class CustomIsOptionDisabled extends Component {
-  render() {
-    return (
-      <Fragment>
-        <p>
-          Disable all options that do not have a 'safe' rating, via the
-          isOptionsDisabled fn prop
-        </p>
-        <Select
-          defaultValue={flavourOptions[0]}
-          isClearable
-          isSearchable
-          name="color"
-          options={flavourOptions}
-          isOptionDisabled={(option) => option.rating !== 'safe'}
-        />
-      </Fragment>
-    );
-  }
-}
+export default () => (
+  <>
+    <p>
+      Disable all options that do not have a 'safe' rating, via the
+      isOptionsDisabled fn prop
+    </p>
+    <Select
+      defaultValue={flavourOptions[0]}
+      isClearable
+      isSearchable
+      name="color"
+      options={flavourOptions}
+      isOptionDisabled={(option) => option.rating !== 'safe'}
+    />
+  </>
+);

--- a/docs/examples/CustomSingleValue.tsx
+++ b/docs/examples/CustomSingleValue.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Select, { components, SingleValueProps } from 'react-select';
 import { ColourOption, colourOptions } from '../data';
 
@@ -9,27 +9,23 @@ const SingleValue = ({
   <components.SingleValue {...props}>{children}</components.SingleValue>
 );
 
-export default class CustomControl extends Component {
-  render() {
-    return (
-      <Select
-        defaultValue={colourOptions[0]}
-        isClearable
-        styles={{
-          singleValue: (base) => ({
-            ...base,
-            padding: 5,
-            borderRadius: 5,
-            background: colourOptions[2].color,
-            color: 'white',
-            display: 'flex',
-          }),
-        }}
-        components={{ SingleValue }}
-        isSearchable
-        name="color"
-        options={colourOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <Select
+    defaultValue={colourOptions[0]}
+    isClearable
+    styles={{
+      singleValue: (base) => ({
+        ...base,
+        padding: 5,
+        borderRadius: 5,
+        background: colourOptions[2].color,
+        color: 'white',
+        display: 'flex',
+      }),
+    }}
+    components={{ SingleValue }}
+    isSearchable
+    name="color"
+    options={colourOptions}
+  />
+);

--- a/docs/examples/CustomValueContainer.tsx
+++ b/docs/examples/CustomValueContainer.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Select, { components, ValueContainerProps } from 'react-select';
 import { ColourOption, colourOptions } from '../data';
 
@@ -9,26 +9,22 @@ const ValueContainer = ({
   <components.ValueContainer {...props}>{children}</components.ValueContainer>
 );
 
-export default class CustomControl extends Component {
-  render() {
-    return (
-      <Select
-        defaultValue={colourOptions[0]}
-        isClearable
-        styles={{
-          singleValue: (base) => ({ ...base, color: 'white' }),
-          valueContainer: (base) => ({
-            ...base,
-            background: colourOptions[2].color,
-            color: 'white',
-            width: '100%',
-          }),
-        }}
-        components={{ ValueContainer }}
-        isSearchable
-        name="color"
-        options={colourOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <Select
+    defaultValue={colourOptions[0]}
+    isClearable
+    styles={{
+      singleValue: (base) => ({ ...base, color: 'white' }),
+      valueContainer: (base) => ({
+        ...base,
+        background: colourOptions[2].color,
+        color: 'white',
+        width: '100%',
+      }),
+    }}
+    components={{ ValueContainer }}
+    isSearchable
+    name="color"
+    options={colourOptions}
+  />
+);

--- a/docs/examples/DefaultOptions.tsx
+++ b/docs/examples/DefaultOptions.tsx
@@ -1,11 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import AsyncSelect from 'react-select/async';
 import { ColourOption, colourOptions } from '../data';
-
-interface State {
-  readonly inputValue: string;
-}
 
 const filterColors = (inputValue: string) => {
   return colourOptions.filter((i) =>
@@ -20,20 +16,10 @@ const promiseOptions = (inputValue: string) =>
     }, 1000);
   });
 
-export default class WithPromises extends Component<{}, State> {
-  state: State = { inputValue: '' };
-  handleInputChange = (newValue: string) => {
-    const inputValue = newValue.replace(/\W/g, '');
-    this.setState({ inputValue });
-    return inputValue;
-  };
-  render() {
-    return (
-      <AsyncSelect
-        cacheOptions
-        defaultOptions={colourOptions}
-        loadOptions={promiseOptions}
-      />
-    );
-  }
-}
+export default () => (
+  <AsyncSelect
+    cacheOptions
+    defaultOptions={colourOptions}
+    loadOptions={promiseOptions}
+  />
+);

--- a/docs/examples/Experimental.tsx
+++ b/docs/examples/Experimental.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Component } from 'react';
+import { useState } from 'react';
 import { jsx } from '@emotion/react';
 import { CSSObject } from '@emotion/serialize';
 import moment, { Moment } from 'moment';
@@ -183,73 +183,47 @@ const Option = (props: OptionProps<DateOption, false>) => {
 
 interface DatePickerProps {
   readonly value: DateOption | null;
-  readonly onChange: (value: DateOption | null) => void;
+  readonly onChange: (newValue: DateOption | null) => void;
 }
 
-interface DatePickerState {
-  readonly options: readonly (DateOption | CalendarGroup)[];
-}
+const DatePicker = (props: DatePickerProps) => {
+  const [options, setOptions] = useState(defaultOptions);
 
-class DatePicker extends Component<DatePickerProps, DatePickerState> {
-  state: DatePickerState = {
-    options: defaultOptions,
-  };
-  handleInputChange = (value: string) => {
+  const handleInputChange = (value: string) => {
     if (!value) {
-      this.setState({ options: defaultOptions });
+      setOptions(defaultOptions);
       return;
     }
     const date = chrono.parseDate(suggest(value.toLowerCase()));
-    if (date) {
-      this.setState({
-        options: [createOptionForDate(date), createCalendarOptions(date)],
-      });
-    } else {
-      this.setState({
-        options: [],
-      });
+    if (!date) {
+      setOptions([]);
+      return;
     }
+    setOptions([createOptionForDate(date), createCalendarOptions(date)]);
   };
-  render() {
-    const { value } = this.props;
-    const { options } = this.state;
-    return (
-      <Select<DateOption, false>
-        {...this.props}
-        components={{ Group, Option }}
-        filterOption={null}
-        isMulti={false}
-        isOptionSelected={(o, v) => v.some((i) => i.date.isSame(o.date, 'day'))}
-        maxMenuHeight={380}
-        onChange={this.props.onChange}
-        onInputChange={this.handleInputChange}
-        options={options}
-        value={value}
-      />
-    );
-  }
-}
 
-interface State {
-  readonly value: DateOption | null;
-}
+  return (
+    <Select<DateOption, false>
+      {...props}
+      components={{ Group, Option }}
+      filterOption={null}
+      isMulti={false}
+      isOptionSelected={(o, v) => v.some((i) => i.date.isSame(o.date, 'day'))}
+      maxMenuHeight={380}
+      onChange={props.onChange}
+      onInputChange={handleInputChange}
+      options={options}
+      value={props.value}
+    />
+  );
+};
 
-export default class Experimental extends Component<{}, State> {
-  state: State = {
-    value: defaultOptions[0] as DateOption,
-  };
-  handleChange = (value: DateOption | null) => {
-    this.setState({ value });
-  };
-  render() {
-    const { value } = this.state;
-    const displayValue =
-      value && 'value' in value ? value.value.toString() : 'null';
-    return (
-      <div>
-        <pre>Value: {displayValue}</pre>
-        <DatePicker value={value} onChange={this.handleChange} />
-      </div>
-    );
-  }
-}
+export default () => {
+  const [value, setValue] = useState<DateOption | null>(
+    defaultOptions[0] as DateOption
+  );
+
+  return (
+    <DatePicker value={value} onChange={(newValue) => setValue(newValue)} />
+  );
+};

--- a/docs/examples/FixedOptions.tsx
+++ b/docs/examples/FixedOptions.tsx
@@ -1,11 +1,7 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import Select, { ActionMeta, OnChangeValue, StylesConfig } from 'react-select';
 import { ColourOption, colourOptions } from '../data';
-
-interface State {
-  readonly value: readonly ColourOption[];
-}
 
 const styles: StylesConfig<ColourOption, true> = {
   multiValue: (base, state) => {
@@ -27,21 +23,15 @@ const orderOptions = (values: readonly ColourOption[]) => {
     .concat(values.filter((v) => !v.isFixed));
 };
 
-export default class FixedOptions extends Component<{}, State> {
-  state = {
-    value: orderOptions([colourOptions[0], colourOptions[1], colourOptions[3]]),
-  };
+export default () => {
+  const [value, setValue] = useState<readonly ColourOption[]>(
+    orderOptions([colourOptions[0], colourOptions[1], colourOptions[3]])
+  );
 
-  constructor(props: {}) {
-    super(props);
-
-    this.onChange = this.onChange.bind(this);
-  }
-
-  onChange(
-    value: OnChangeValue<ColourOption, true>,
+  const onChange = (
+    newValue: OnChangeValue<ColourOption, true>,
     actionMeta: ActionMeta<ColourOption>
-  ) {
+  ) => {
     switch (actionMeta.action) {
       case 'remove-value':
       case 'pop-value':
@@ -50,27 +40,24 @@ export default class FixedOptions extends Component<{}, State> {
         }
         break;
       case 'clear':
-        value = colourOptions.filter((v) => v.isFixed);
+        newValue = colourOptions.filter((v) => v.isFixed);
         break;
     }
 
-    value = orderOptions(value);
-    this.setState({ value: value });
-  }
+    setValue(orderOptions(newValue));
+  };
 
-  render() {
-    return (
-      <Select
-        value={this.state.value}
-        isMulti
-        styles={styles}
-        isClearable={this.state.value.some((v) => !v.isFixed)}
-        name="colors"
-        className="basic-multi-select"
-        classNamePrefix="select"
-        onChange={this.onChange}
-        options={colourOptions}
-      />
-    );
-  }
-}
+  return (
+    <Select
+      value={value}
+      isMulti
+      styles={styles}
+      isClearable={value.some((v) => !v.isFixed)}
+      name="colors"
+      className="basic-multi-select"
+      classNamePrefix="select"
+      onChange={onChange}
+      options={colourOptions}
+    />
+  );
+};

--- a/docs/examples/MenuPortal.tsx
+++ b/docs/examples/MenuPortal.tsx
@@ -1,93 +1,69 @@
-import React, { ChangeEventHandler, Component, Fragment } from 'react';
+import React, { useState } from 'react';
 import Modal from '@atlaskit/modal-dialog';
 import Button from '@atlaskit/button';
-import Select from 'react-select';
+import Select, { MenuPlacement } from 'react-select';
 import { H1, Note } from '../styled-components';
 
 import { colourOptions } from '../data';
 
-interface State {
-  readonly isOpen: boolean;
-  readonly isFixed: boolean;
-  readonly portalPlacement: 'auto' | 'bottom' | 'top';
-}
+export default () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isFixed, setIsFixed] = useState(false);
+  const [menuPlacement, setMenuPlacement] = useState<MenuPlacement>('bottom');
 
-export default class MenuPortal extends Component<{}, State> {
-  state: State = {
-    isOpen: false,
-    isFixed: false,
-    portalPlacement: 'bottom',
-  };
-  open = () => {
-    console.log('menuPortal is Open');
-    this.setState({ isOpen: true });
-  };
-  close = () => {
-    this.setState({ isOpen: false });
-  };
-  setPlacement: ChangeEventHandler<HTMLSelectElement> = ({ currentTarget }) => {
-    const portalPlacement =
-      currentTarget && (currentTarget.value as 'auto' | 'bottom' | 'top');
-    this.setState({ portalPlacement });
-  };
-  toggleMode = () => {
-    this.setState((state) => ({ isFixed: !state.isFixed }));
-  };
-  render() {
-    const { close, open } = this;
-    const { isOpen, isFixed, portalPlacement } = this.state;
-    return (
-      <Fragment>
-        <Button onClick={open}>Open Modal</Button>
-        {isOpen ? (
-          <Modal onClose={close}>
-            <H1>Portaled Menu Element</H1>
-            <Select
-              defaultValue={colourOptions[0]}
-              isClearable
-              styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
-              menuPortalTarget={document.body}
-              isSearchable
-              name="color"
-              menuPosition={isFixed ? 'fixed' : 'absolute'}
-              menuPlacement={portalPlacement}
-              options={colourOptions}
-              menuShouldScrollIntoView={false}
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
+      {isOpen ? (
+        <Modal onClose={() => setIsOpen(false)}>
+          <H1>Portaled Menu Element</H1>
+          <Select
+            defaultValue={colourOptions[0]}
+            isClearable
+            styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
+            menuPortalTarget={document.body}
+            isSearchable
+            name="color"
+            menuPosition={isFixed ? 'fixed' : 'absolute'}
+            menuPlacement={menuPlacement}
+            options={colourOptions}
+            menuShouldScrollIntoView={false}
+          />
+          <Note Tag="label">
+            <select
+              onChange={(e) =>
+                setMenuPlacement(e.currentTarget.value as MenuPlacement)
+              }
+              value={menuPlacement}
+              id="cypress-portalled__radio-bottom"
+            >
+              <option value="auto">auto</option>
+              <option value="bottom">bottom</option>
+              <option value="top">top</option>
+            </select>
+          </Note>
+          <Note Tag="label" style={{ marginLeft: '1em' }}>
+            <input
+              type="radio"
+              onChange={() => setIsFixed((prev) => !prev)}
+              value="fixed"
+              checked={isFixed}
+              id="cypress-portalled__fixed"
             />
-            <Note Tag="label">
-              <select
-                onChange={this.setPlacement}
-                value={portalPlacement}
-                id="cypress-portalled__radio-bottom"
-              >
-                <option value="auto">auto</option>
-                <option value="bottom">bottom</option>
-                <option value="top">top</option>
-              </select>
-            </Note>
-            <Note Tag="label" style={{ marginLeft: '1em' }}>
-              <input
-                type="radio"
-                onChange={this.toggleMode}
-                value="fixed"
-                checked={isFixed}
-                id="cypress-portalled__fixed"
-              />
-              Fixed
-            </Note>
-            <Note Tag="label" style={{ marginLeft: '1em' }}>
-              <input
-                type="radio"
-                onChange={this.toggleMode}
-                value="portal"
-                checked={!isFixed}
-                id="cypress-portalled__portal"
-              />
-              Portal
-            </Note>
-          </Modal>
-        ) : null}
-      </Fragment>
-    );
-  }
-}
+            Fixed
+          </Note>
+          <Note Tag="label" style={{ marginLeft: '1em' }}>
+            <input
+              type="radio"
+              onChange={() => setIsFixed((prev) => !prev)}
+              value="portal"
+              checked={!isFixed}
+              id="cypress-portalled__portal"
+            />
+            Portal
+          </Note>
+        </Modal>
+      ) : null}
+    </>
+  );
+};

--- a/docs/examples/OnSelectResetsInput.tsx
+++ b/docs/examples/OnSelectResetsInput.tsx
@@ -1,48 +1,32 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Select, { InputActionMeta } from 'react-select';
 import { colourOptions } from '../data';
 
-interface State {
-  readonly menuIsOpen?: boolean;
-}
+export default () => {
+  const [menuIsOpen, setMenuIsOpen] = React.useState<boolean>();
 
-export default class OnSelectResetsInput extends Component<{}, State> {
-  state: State = {};
-  onInputChange = (
+  const onInputChange = (
     inputValue: string,
     { action, prevInputValue }: InputActionMeta
   ) => {
-    console.log(inputValue, action);
-    switch (action) {
-      case 'input-change':
-        return inputValue;
-      case 'menu-close':
-        console.log(prevInputValue);
-        let menuIsOpen = undefined;
-        if (prevInputValue) {
-          menuIsOpen = true;
-        }
-        this.setState({
-          menuIsOpen,
-        });
-        return prevInputValue;
-      default:
-        return prevInputValue;
+    if (action === 'input-change') return inputValue;
+    if (action === 'menu-close') {
+      if (prevInputValue) setMenuIsOpen(true);
+      else setMenuIsOpen(undefined);
     }
+    return prevInputValue;
   };
-  render() {
-    const { menuIsOpen } = this.state;
-    return (
-      <Select
-        isMulti
-        defaultValue={colourOptions[0]}
-        isClearable
-        isSearchable
-        onInputChange={this.onInputChange}
-        name="color"
-        options={colourOptions}
-        menuIsOpen={menuIsOpen}
-      />
-    );
-  }
-}
+
+  return (
+    <Select
+      isMulti
+      defaultValue={colourOptions[0]}
+      isClearable
+      isSearchable
+      onInputChange={onInputChange}
+      name="color"
+      options={colourOptions}
+      menuIsOpen={menuIsOpen}
+    />
+  );
+};

--- a/docs/examples/Popout.tsx
+++ b/docs/examples/Popout.tsx
@@ -1,9 +1,9 @@
 /** @jsx jsx */
-import { Component, FunctionComponent, ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { jsx } from '@emotion/react';
 import Button from '@atlaskit/button';
 
-import Select, { OnChangeValue, StylesConfig } from 'react-select';
+import Select, { StylesConfig } from 'react-select';
 import { defaultTheme } from 'react-select';
 import { StateOption, stateOptions } from '../data';
 
@@ -18,55 +18,45 @@ const selectStyles: StylesConfig<StateOption, false> = {
   menu: () => ({ boxShadow: 'inset 0 1px 0 rgba(0, 0, 0, 0.1)' }),
 };
 
-interface State {
-  readonly isOpen: boolean;
-  readonly value: StateOption | null | undefined;
-}
+export default () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [value, setValue] = useState<StateOption | null>();
 
-export default class PopoutExample extends Component<{}, State> {
-  state: State = { isOpen: false, value: undefined };
-  toggleOpen = () => {
-    this.setState((state) => ({ isOpen: !state.isOpen }));
-  };
-  onSelectChange = (value: OnChangeValue<StateOption, false>) => {
-    this.toggleOpen();
-    this.setState({ value });
-  };
-  render() {
-    const { isOpen, value } = this.state;
-    return (
-      <Dropdown
-        isOpen={isOpen}
-        onClose={this.toggleOpen}
-        target={
-          <Button
-            iconAfter={<ChevronDown />}
-            onClick={this.toggleOpen}
-            isSelected={isOpen}
-          >
-            {value ? `State: ${value.label}` : 'Select a State'}
-          </Button>
-        }
-      >
-        <Select
-          autoFocus
-          backspaceRemovesValue={false}
-          components={{ DropdownIndicator, IndicatorSeparator: null }}
-          controlShouldRenderValue={false}
-          hideSelectedOptions={false}
-          isClearable={false}
-          menuIsOpen
-          onChange={this.onSelectChange}
-          options={stateOptions}
-          placeholder="Search..."
-          styles={selectStyles}
-          tabSelectsValue={false}
-          value={value}
-        />
-      </Dropdown>
-    );
-  }
-}
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      target={
+        <Button
+          iconAfter={<ChevronDown />}
+          onClick={() => setIsOpen((prev) => !prev)}
+          isSelected={isOpen}
+        >
+          {value ? `State: ${value.label}` : 'Select a State'}
+        </Button>
+      }
+    >
+      <Select
+        autoFocus
+        backspaceRemovesValue={false}
+        components={{ DropdownIndicator, IndicatorSeparator: null }}
+        controlShouldRenderValue={false}
+        hideSelectedOptions={false}
+        isClearable={false}
+        menuIsOpen
+        onChange={(newValue) => {
+          setValue(newValue);
+          setIsOpen(false);
+        }}
+        options={stateOptions}
+        placeholder="Search..."
+        styles={selectStyles}
+        tabSelectsValue={false}
+        value={value}
+      />
+    </Dropdown>
+  );
+};
 
 // styled components
 
@@ -99,16 +89,16 @@ const Blanket = (props: JSX.IntrinsicElements['div']) => (
     {...props}
   />
 );
-interface DropdownProps {
-  readonly isOpen: boolean;
-  readonly target: ReactNode;
-  readonly onClose: () => void;
-}
-const Dropdown: FunctionComponent<DropdownProps> = ({
+const Dropdown = ({
   children,
   isOpen,
   target,
   onClose,
+}: {
+  children?: ReactNode;
+  readonly isOpen: boolean;
+  readonly target: ReactNode;
+  readonly onClose: () => void;
 }) => (
   <div css={{ position: 'relative' }}>
     {target}


### PR DESCRIPTION
This PR updates the examples to use `functional` components