### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']


### PR DESCRIPTION
This adds a dependabot config that schedules the checks to `weekly` and only updates `major` versions