### PR TITLE
Use ResizeObserver to auto-update menu position if available

### DIFF
--- a/.changeset/tricky-books-design.md
+++ b/.changeset/tricky-books-design.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Use ResizeObserver to auto-update menu position if available

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -648,7 +648,7 @@ export const MenuPortal = <
         controlElement,
         menuPortalRef.current,
         updateComputedPosition,
-        { elementResize: false }
+        { elementResize: 'ResizeObserver' in window }
       );
     }
   }, [controlElement, updateComputedPosition]);


### PR DESCRIPTION
Fixes https://github.com/JedWatson/react-select/issues/5403.

I mistakenly thought in https://github.com/JedWatson/react-select/pull/5381 that the resize event was placed on the control element, but's it really just on the scroll parents of the control element.

This PR enables `ResizeObserver` if it's available. The referenced issue demonstrates a good use-case for it.