### PR TITLE
Fix focused option if `defaultMenuIsOpen` is set

### DIFF
--- a/.changeset/loud-falcons-design.md
+++ b/.changeset/loud-falcons-design.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Fix focused option if `defaultMenuIsOpen` is set

--- a/.changeset/loud-falcons-design.md
+++ b/.changeset/loud-falcons-design.md
@@ -1,5 +1,5 @@
 ---
-"react-select": patch
+'react-select': patch
 ---
 
 Fix focused option if `defaultMenuIsOpen` is set

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -623,6 +623,13 @@ export default class Select<
     this.instancePrefix =
       'react-select-' + (this.props.instanceId || ++instanceId);
     this.state.selectValue = cleanValue(props.value);
+
+    // Set focusedOption if menuIsOpen is set on init (e.g. defaultMenuIsOpen)
+    if (props.menuIsOpen && this.state.selectValue.length) {
+      const focusableOptions = this.buildFocusableOptions();
+      const optionIndex = focusableOptions.indexOf(this.state.selectValue[0]);
+      this.state.focusedOption = focusableOptions[optionIndex];
+    }
   }
 
   static getDerivedStateFromProps(
@@ -711,6 +718,16 @@ export default class Select<
 
     if (this.props.autoFocus) {
       this.focusInput();
+    }
+
+    // Scroll focusedOption into view if menuIsOpen is set on mount (e.g. defaultMenuIsOpen)
+    if (
+      this.props.menuIsOpen &&
+      this.state.focusedOption &&
+      this.menuListRef &&
+      this.focusedOptionRef
+    ) {
+      scrollIntoView(this.menuListRef, this.focusedOptionRef);
     }
   }
   componentDidUpdate(prevProps: Props<Option, IsMulti, Group>) {


### PR DESCRIPTION
Fix #4013

This PR fixes the behaviour around `defaultMenuIsOpen` so that the selected option is visible on mount.