### PR TITLE
Fix minor defaultAriaLiveMessages wordings

### DIFF
--- a/packages/react-select/src/accessibility/index.ts
+++ b/packages/react-select/src/accessibility/index.ts
@@ -113,12 +113,12 @@ export const defaultAriaLiveMessages = {
         }.`;
       case 'input':
         return `${props['aria-label'] || 'Select'} is focused ${
-          isSearchable ? ',type to refine list' : ''
+          isSearchable ? ', type to refine list' : ''
         }, press Down to open the menu, ${
           isMulti ? ' press left to focus selected values' : ''
         }`;
       case 'value':
-        return 'Use left and right to toggle between focused values, press Backspace to remove the currently focused value';
+        return 'Use left and right to toggle between selected values, press Backspace to remove the currently focused value';
       default:
         return '';
     }


### PR DESCRIPTION
Pressing left and right moves the focus between the selected values. Not the focused values.