### PR TITLE
Improve contrast of example buttons in docs

### DIFF
--- a/docs/ExampleWrapper.tsx
+++ b/docs/ExampleWrapper.tsx
@@ -183,7 +183,7 @@ const Actions = (props: JSX.IntrinsicElements['div']) => (
       alignItems: 'center',
       display: 'flex',
       justifyContent: 'flex-end',
-      opacity: 0.2,
+      opacity: 0.8,
       transition: 'opacity 140ms',
       transitionDelay: '140ms',
 


### PR DESCRIPTION
Closes https://github.com/JedWatson/react-select/issues/5434