### PR TITLE
design(docs): vertical center text in checkboxes in base example

### DIFF
--- a/docs/examples/BasicSingle.tsx
+++ b/docs/examples/BasicSingle.tsx
@@ -4,7 +4,7 @@ import Select from 'react-select';
 import { colourOptions } from '../data';
 
 const Checkbox = ({ children, ...props }: JSX.IntrinsicElements['input']) => (
-  <label style={{ marginRight: '1em' }}>
+  <label style={{ marginRight: '1em', display: 'inline-flex', 'align-items': 'center' }}>
     <input type="checkbox" {...props} />
     {children}
   </label>


### PR DESCRIPTION
before:
<img width="612" alt="Снимок экрана 2022-10-27 в 17 48 41" src="https://user-images.githubusercontent.com/3195714/198337765-008059e4-c386-4f0f-97a4-7d18a48d9846.png">

after:
<img width="610" alt="Снимок экрана 2022-10-27 в 17 48 45" src="https://user-images.githubusercontent.com/3195714/198337769-b4fc5e3f-bc44-4323-83b0-658617ae6b67.png">
