### PR TITLE
Memoize `buildCategorizedOptions`

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -19,6 +19,7 @@ import { DummyInput, ScrollManager } from './internal/index';
 import { AriaLiveMessages, AriaSelection } from './accessibility';
 
 import {
+  areArraysEqual,
   classNames,
   cleanValue,
   isTouchCapable,
@@ -664,7 +665,11 @@ export default class Select<
       prevWasFocused,
     } = state;
     const { options, value, menuIsOpen, inputValue, isMulti } = props;
-    const selectValue = cleanValue(value);
+
+    // Try to preserve instance equality of `selectValue` if possible to improve memoization of `buildCategorizedOptions`.
+    const cleanedSelectValue = cleanValue(value);
+    const selectValue = areArraysEqual(state.selectValue, cleanedSelectValue) ? state.selectValue : cleanedSelectValue;
+
     let newMenuOptionsState = {};
     if (
       prevProps &&

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -468,7 +468,8 @@ function isFocusable<
   const { data, isSelected, label, value } = categorizedOption;
 
   return (
-    (!shouldHideSelectedOptions(props) || !isSelected) &&
+    (!shouldHideSelectedOptions(props.hideSelectedOptions, props.isMulti) ||
+      !isSelected) &&
     filterOption(props, { label, value, data }, inputValue)
   );
 }
@@ -532,17 +533,13 @@ function filterOption<
   return props.filterOption ? props.filterOption(option, inputValue) : true;
 }
 
-const shouldHideSelectedOptions = <
-  Option,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>
->(
-  props: Props<Option, IsMulti, Group>
-) => {
-  const { hideSelectedOptions, isMulti } = props;
-  if (hideSelectedOptions === undefined) return isMulti;
-  return hideSelectedOptions;
-};
+function shouldHideSelectedOptions<Option, IsMulti extends boolean>(
+  hideSelectedOptionsProp: boolean | undefined,
+  isMultiProp: IsMulti
+) {
+  if (hideSelectedOptionsProp === undefined) return isMultiProp;
+  return hideSelectedOptionsProp;
+}
 
 let instanceId = 1;
 
@@ -1380,9 +1377,6 @@ export default class Select<
       return;
     }
     this.setState({ focusedOption });
-  };
-  shouldHideSelectedOptions = () => {
-    return shouldHideSelectedOptions(this.props);
   };
 
   // ==============================

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -383,10 +383,25 @@ function buildCategorizedOptions<
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
-  props: Props<Option, IsMulti, Group>,
-  selectValue: Options<Option>
+  selectValue: Options<Option>,
+  filterOptionProp:
+    | ((option: FilterOptionOption<Option>, inputValue: string) => boolean)
+    | null,
+  getOptionLabelProp: GetOptionLabel<Option>,
+  getOptionValueProp: GetOptionValue<Option>,
+  hideSelectedOptionsProp: boolean | undefined,
+  inputValueProp: string,
+  isMultiProp: IsMulti,
+  isOptionDisabledProp: (
+    option: Option,
+    selectValue: Options<Option>
+  ) => boolean,
+  isOptionSelectedProp:
+    | ((option: Option, selectValue: Options<Option>) => boolean)
+    | undefined,
+  optionsProp: OptionsOrGroups<Option, Group>
 ): CategorizedGroupOrOption<Option, Group>[] {
-  return props.options
+  return optionsProp
     .map((groupOrOption, groupOrOptionIndex) => {
       if ('options' in groupOrOption) {
         const categorizedOptions = groupOrOption.options
@@ -395,19 +410,19 @@ function buildCategorizedOptions<
               option,
               optionIndex,
               selectValue,
-              props.getOptionLabel,
-              props.getOptionValue,
-              props.isOptionDisabled,
-              props.isOptionSelected
+              getOptionLabelProp,
+              getOptionValueProp,
+              isOptionDisabledProp,
+              isOptionSelectedProp
             )
           )
           .filter((categorizedOption) =>
             isFocusable(
               categorizedOption,
-              props.filterOption,
-              props.hideSelectedOptions,
-              props.inputValue,
-              props.isMulti
+              filterOptionProp,
+              hideSelectedOptionsProp,
+              inputValueProp,
+              isMultiProp
             )
           );
         return categorizedOptions.length > 0
@@ -423,17 +438,17 @@ function buildCategorizedOptions<
         groupOrOption,
         groupOrOptionIndex,
         selectValue,
-        props.getOptionLabel,
-        props.getOptionValue,
-        props.isOptionDisabled,
-        props.isOptionSelected
+        getOptionLabelProp,
+        getOptionValueProp,
+        isOptionDisabledProp,
+        isOptionSelectedProp
       );
       return isFocusable(
         categorizedOption,
-        props.filterOption,
-        props.hideSelectedOptions,
-        props.inputValue,
-        props.isMulti
+        filterOptionProp,
+        hideSelectedOptionsProp,
+        inputValueProp,
+        isMultiProp
       )
         ? categorizedOption
         : undefined;
@@ -466,7 +481,18 @@ function buildFocusableOptions<
   Group extends GroupBase<Option>
 >(props: Props<Option, IsMulti, Group>, selectValue: Options<Option>) {
   return buildFocusableOptionsFromCategorizedOptions(
-    buildCategorizedOptions(props, selectValue)
+    buildCategorizedOptions(
+      selectValue,
+      props.filterOption,
+      props.getOptionLabel,
+      props.getOptionValue,
+      props.hideSelectedOptions,
+      props.inputValue,
+      props.isMulti,
+      props.isOptionDisabled,
+      props.isOptionSelected,
+      props.options
+    )
   );
 }
 
@@ -1079,7 +1105,18 @@ export default class Select<
   };
 
   buildCategorizedOptions = () =>
-    buildCategorizedOptions(this.props, this.state.selectValue);
+    buildCategorizedOptions(
+      this.state.selectValue,
+      this.props.filterOption,
+      this.props.getOptionLabel,
+      this.props.getOptionValue,
+      this.props.hideSelectedOptions,
+      this.props.inputValue,
+      this.props.isMulti,
+      this.props.isOptionDisabled,
+      this.props.isOptionSelected,
+      this.props.options
+    );
   getCategorizedOptions = () =>
     this.props.menuIsOpen ? this.buildCategorizedOptions() : [];
   buildFocusableOptions = () =>

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -353,7 +353,7 @@ function toCategorizedOption<
   selectValue: Options<Option>,
   index: number
 ): CategorizedOption<Option> {
-  const isDisabled = isOptionDisabled(props, option, selectValue);
+  const isDisabled = props.isOptionDisabled(option, selectValue);
   const isSelected = isOptionSelected(props, option, selectValue);
   const label = getOptionLabel(props, option);
   const value = getOptionValue(props, option);
@@ -505,19 +505,6 @@ const getOptionValue = <
   return props.getOptionValue(data);
 };
 
-function isOptionDisabled<
-  Option,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>
->(
-  props: Props<Option, IsMulti, Group>,
-  option: Option,
-  selectValue: Options<Option>
-): boolean {
-  return typeof props.isOptionDisabled === 'function'
-    ? props.isOptionDisabled(option, selectValue)
-    : false;
-}
 function isOptionSelected<
   Option,
   IsMulti extends boolean,
@@ -920,7 +907,7 @@ export default class Select<
     const { blurInputOnSelect, isMulti, name } = this.props;
     const { selectValue } = this.state;
     const deselected = isMulti && this.isOptionSelected(newValue, selectValue);
-    const isDisabled = this.isOptionDisabled(newValue, selectValue);
+    const isDisabled = this.props.isOptionDisabled(newValue, selectValue);
 
     if (deselected) {
       const candidate = this.getOptionValue(newValue);
@@ -1117,9 +1104,6 @@ export default class Select<
     if (isClearable === undefined) return isMulti;
 
     return isClearable;
-  }
-  isOptionDisabled(option: Option, selectValue: Options<Option>): boolean {
-    return isOptionDisabled(this.props, option, selectValue);
   }
   isOptionSelected(option: Option, selectValue: Options<Option>): boolean {
     return isOptionSelected(this.props, option, selectValue);

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -356,7 +356,7 @@ function toCategorizedOption<
   const isDisabled = props.isOptionDisabled(option, selectValue);
   const isSelected = isOptionSelected(props, option, selectValue);
   const label = props.getOptionLabel(option);
-  const value = getOptionValue(props, option);
+  const value = props.getOptionValue(option);
 
   return {
     type: 'option',
@@ -484,16 +484,6 @@ function getNextFocusedOption<
     ? lastFocusedOption
     : options[0];
 }
-const getOptionValue = <
-  Option,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>
->(
-  props: Props<Option, IsMulti, Group>,
-  data: Option
-): string => {
-  return props.getOptionValue(data);
-};
 
 function isOptionSelected<
   Option,
@@ -508,8 +498,8 @@ function isOptionSelected<
   if (typeof props.isOptionSelected === 'function') {
     return props.isOptionSelected(option, selectValue);
   }
-  const candidate = getOptionValue(props, option);
-  return selectValue.some((i) => getOptionValue(props, i) === candidate);
+  const candidate = props.getOptionValue(option);
+  return selectValue.some((i) => props.getOptionValue(i) === candidate);
 }
 function filterOption<
   Option,
@@ -900,10 +890,10 @@ export default class Select<
     const isDisabled = this.props.isOptionDisabled(newValue, selectValue);
 
     if (deselected) {
-      const candidate = this.getOptionValue(newValue);
+      const candidate = this.props.getOptionValue(newValue);
       this.setValue(
         multiValueAsValue(
-          selectValue.filter((i) => this.getOptionValue(i) !== candidate)
+          selectValue.filter((i) => this.props.getOptionValue(i) !== candidate)
         ),
         'deselect-option',
         newValue
@@ -935,9 +925,9 @@ export default class Select<
   removeValue = (removedValue: Option) => {
     const { isMulti } = this.props;
     const { selectValue } = this.state;
-    const candidate = this.getOptionValue(removedValue);
+    const candidate = this.props.getOptionValue(removedValue);
     const newValueArray = selectValue.filter(
-      (i) => this.getOptionValue(i) !== candidate
+      (i) => this.props.getOptionValue(i) !== candidate
     );
     const newValue = valueTernary(
       isMulti,
@@ -1028,9 +1018,6 @@ export default class Select<
     };
   }
 
-  getOptionValue = (data: Option): string => {
-    return getOptionValue(this.props, data);
-  };
   getStyles = <Key extends keyof StylesProps<Option, IsMulti, Group>>(
     key: Key,
     props: StylesProps<Option, IsMulti, Group>[Key]
@@ -1638,7 +1625,9 @@ export default class Select<
     if (isMulti) {
       return selectValue.map((opt, index) => {
         const isOptionFocused = opt === focusedValue;
-        const key = `${this.props.getOptionLabel(opt)}-${this.getOptionValue(opt)}`;
+        const key = `${this.props.getOptionLabel(
+          opt
+        )}-${this.props.getOptionValue(opt)}`;
 
         return (
           <MultiValue
@@ -1948,7 +1937,7 @@ export default class Select<
     if (isMulti) {
       if (delimiter) {
         const value = selectValue
-          .map((opt) => this.getOptionValue(opt))
+          .map((opt) => this.props.getOptionValue(opt))
           .join(delimiter);
         return <input name={name} type="hidden" value={value} />;
       } else {
@@ -1959,7 +1948,7 @@ export default class Select<
                 key={`i-${i}`}
                 name={name}
                 type="hidden"
-                value={this.getOptionValue(opt)}
+                value={this.props.getOptionValue(opt)}
               />
             ))
           ) : (
@@ -1969,7 +1958,9 @@ export default class Select<
         return <div>{input}</div>;
       }
     } else {
-      const value = selectValue[0] ? this.getOptionValue(selectValue[0]) : '';
+      const value = selectValue[0]
+        ? this.props.getOptionValue(selectValue[0])
+        : '';
       return <input name={name} type="hidden" value={value} />;
     }
   }

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -10,12 +10,13 @@ import {
   RefCallback,
   TouchEventHandler,
 } from 'react';
+import memoizeOne from 'memoize-one';
 import { MenuPlacer } from './components/Menu';
 import LiveRegion from './components/LiveRegion';
 
 import { createFilter, FilterOptionOption } from './filters';
 import { DummyInput, ScrollManager } from './internal/index';
-import { AriaLiveMessages, AriaSelection } from './accessibility/index';
+import { AriaLiveMessages, AriaSelection } from './accessibility';
 
 import {
   classNames,
@@ -38,7 +39,7 @@ import {
   isOptionDisabled as isOptionDisabledBuiltin,
 } from './builtins';
 
-import { defaultComponents, SelectComponentsConfig } from './components/index';
+import { defaultComponents, SelectComponentsConfig } from './components';
 
 import { defaultStyles, StylesConfig, StylesProps } from './styles';
 import { defaultTheme, ThemeConfig } from './theme';
@@ -378,7 +379,7 @@ function toCategorizedOption<Option>(
   };
 }
 
-function buildCategorizedOptions<
+function buildCategorizedOptionsRaw<
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
@@ -455,6 +456,10 @@ function buildCategorizedOptions<
     })
     .filter(notNullish);
 }
+
+const buildCategorizedOptions = memoizeOne(
+  buildCategorizedOptionsRaw
+) as typeof buildCategorizedOptionsRaw;
 
 function buildFocusableOptionsFromCategorizedOptions<
   Option,
@@ -1183,7 +1188,7 @@ export default class Select<
     event.preventDefault();
     this.focusInput();
   };
-  onMenuMouseMove: MouseEventHandler<HTMLDivElement> = (event) => {
+  onMenuMouseMove: MouseEventHandler<HTMLDivElement> = () => {
     this.blockOptionHover = false;
   };
   onControlMouseDown = (

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -355,7 +355,7 @@ function toCategorizedOption<
 ): CategorizedOption<Option> {
   const isDisabled = props.isOptionDisabled(option, selectValue);
   const isSelected = isOptionSelected(props, option, selectValue);
-  const label = getOptionLabel(props, option);
+  const label = props.getOptionLabel(option);
   const value = getOptionValue(props, option);
 
   return {
@@ -484,16 +484,6 @@ function getNextFocusedOption<
     ? lastFocusedOption
     : options[0];
 }
-const getOptionLabel = <
-  Option,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>
->(
-  props: Props<Option, IsMulti, Group>,
-  data: Option
-): string => {
-  return props.getOptionLabel(data);
-};
 const getOptionValue = <
   Option,
   IsMulti extends boolean,
@@ -1038,9 +1028,6 @@ export default class Select<
     };
   }
 
-  getOptionLabel = (data: Option): string => {
-    return getOptionLabel(this.props, data);
-  };
   getOptionValue = (data: Option): string => {
     return getOptionValue(this.props, data);
   };
@@ -1124,7 +1111,7 @@ export default class Select<
         selectValue,
       });
     } else {
-      return this.getOptionLabel(data);
+      return this.props.getOptionLabel(data);
     }
   }
   formatGroupLabel(data: Group) {
@@ -1651,7 +1638,7 @@ export default class Select<
     if (isMulti) {
       return selectValue.map((opt, index) => {
         const isOptionFocused = opt === focusedValue;
-        const key = `${this.getOptionLabel(opt)}-${this.getOptionValue(opt)}`;
+        const key = `${this.props.getOptionLabel(opt)}-${this.getOptionValue(opt)}`;
 
         return (
           <MultiValue

--- a/packages/react-select/src/utils.ts
+++ b/packages/react-select/src/utils.ts
@@ -381,3 +381,19 @@ export const removeProps = <Props extends object, K extends string[]>(
     return newProps;
   }, {}) as Omit<Props, K[number]>;
 };
+
+export function areArraysEqual(
+  newInputs: readonly unknown[],
+  lastInputs: readonly unknown[],
+): boolean {
+  if (newInputs.length !== lastInputs.length) {
+    return false;
+  }
+
+  for (let i = 0; i < newInputs.length; i++) {
+    if (newInputs[i] !== lastInputs[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/react-select/src/utils.ts
+++ b/packages/react-select/src/utils.ts
@@ -384,7 +384,7 @@ export const removeProps = <Props extends object, K extends string[]>(
 
 export function areArraysEqual(
   newInputs: readonly unknown[],
-  lastInputs: readonly unknown[],
+  lastInputs: readonly unknown[]
 ): boolean {
   if (newInputs.length !== lastInputs.length) {
     return false;


### PR DESCRIPTION
Recreation of https://github.com/JedWatson/react-select/pull/4514. Reduces the render time when opening the menu with 10,000 options from ~300ms to ~200ms. Still not perfect, but it's a first step at reducing unnecessary work.

Before:
![before](https://user-images.githubusercontent.com/693755/198915186-22366f7f-bf2f-4dcc-83e3-9ba228deffae.png)

After:
![after](https://user-images.githubusercontent.com/693755/198915207-56c10b5e-06ec-4f6c-81ab-934e6863ac64.png)

As for [my concerns](https://github.com/JedWatson/react-select/pull/4514#issuecomment-804314463) in the initial PR, it is correct that memoization will still be helpful for performance within a single Select's render cycle, even if there are multiple Selects on the page.