### PR TITLE
Fixes #4966 Async select: inputChange bug

### DIFF
--- a/packages/react-select/src/__tests__/Async.test.tsx
+++ b/packages/react-select/src/__tests__/Async.test.tsx
@@ -212,6 +212,58 @@ test('in case of callbacks display the most recently-requested loaded options (i
   );
 });
 
+test('in case of callbacks display the most recently-requested loaded options (when most recently-requested loaded options come from cache)', () => {
+  let callbacks: ((options: readonly Option[]) => void)[] = [];
+  const loadOptions = (
+    inputValue: string,
+    callback: (options: readonly Option[]) => void
+  ) => {
+    callbacks.push(callback);
+  };
+  let { container } = render(
+    <Async
+      className="react-select"
+      classNamePrefix="react-select"
+      loadOptions={loadOptions}
+      cacheOptions
+    />
+  );
+  let input = container.querySelector('input.react-select__input');
+  // preloading data to cache
+  fireEvent.input(input!, {
+    target: {
+      value: 'bar',
+    },
+    bubbles: true,
+    cancelable: true,
+  });
+  expect(container.querySelector('.react-select__option')).toBeFalsy();
+  act(() => {
+    callbacks[0]([{ value: 'bar', label: 'bar' }]);
+  });
+  fireEvent.input(input!, {
+    target: {
+      value: 'foo',
+    },
+    bubbles: true,
+    cancelable: true,
+  });
+  // this one loads from cache
+  fireEvent.input(input!, {
+    target: {
+      value: 'bar',
+    },
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => {
+    callbacks[1]([{ value: 'foo', label: 'foo' }]);
+  });
+  expect(container.querySelector('.react-select__option')!.textContent).toBe(
+    'bar'
+  );
+});
+
 // QUESTION: we currently do not do this, do we want to?
 test.skip('in case of callbacks should handle an error by setting options to an empty array', () => {
   const loadOptions = (

--- a/packages/react-select/src/useAsync.ts
+++ b/packages/react-select/src/useAsync.ts
@@ -153,6 +153,7 @@ export default function useAsync<
         return;
       }
       if (cacheOptions && optionsCache[inputValue]) {
+        lastRequest.current = undefined;
         setStateInputValue(inputValue);
         setLoadedInputValue(inputValue);
         setLoadedOptions(optionsCache[inputValue]);


### PR DESCRIPTION
This change fixes #4966

The bug presented when the options were loaded asynchronously with a callback using `loadOptions` and had `cacheOptions: true`.

I included both a fix and unit tests for this.