### PR TITLE
`required` prop accessibiltiy and functionality improvements

### DIFF
--- a/.changeset/gorgeous-bottles-bow.md
+++ b/.changeset/gorgeous-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+`required` prop accessibiltiy and functionality improvements

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -2022,11 +2022,11 @@ export default class Select<
     const { delimiter, isDisabled, isMulti, name, required } = this.props;
     const { selectValue } = this.state;
 
-    if (!name || isDisabled) return;
-
-    if (required && !this.hasValue()) {
+    if (required && !this.hasValue() && !isDisabled) {
       return <RequiredInput name={name} onFocus={this.onValueInputFocus} />;
     }
+
+    if (!name || isDisabled) return;
 
     if (isMulti) {
       if (delimiter) {

--- a/packages/react-select/src/internal/RequiredInput.tsx
+++ b/packages/react-select/src/internal/RequiredInput.tsx
@@ -3,7 +3,7 @@ import { FocusEventHandler, FunctionComponent } from 'react';
 import { jsx } from '@emotion/react';
 
 const RequiredInput: FunctionComponent<{
-  readonly name: string;
+  readonly name?: string;
   readonly onFocus: FocusEventHandler<HTMLInputElement>;
 }> = ({ name, onFocus }) => (
   <input

--- a/packages/react-select/src/internal/RequiredInput.tsx
+++ b/packages/react-select/src/internal/RequiredInput.tsx
@@ -10,6 +10,7 @@ const RequiredInput: FunctionComponent<{
     required
     name={name}
     tabIndex={-1}
+    aria-hidden="true"
     onFocus={onFocus}
     css={{
       label: 'requiredInput',


### PR DESCRIPTION
* Make `required` work without `name` prop (Synonymous to default HTML form elements).
* Hide `RequiredInput` component from screen readers (https://github.com/JedWatson/react-select/pull/4882#issuecomment-1345303623).