### PR TITLE
Add `exports` field in package.json

### DIFF
--- a/.changeset/early-pans-obey.md
+++ b/.changeset/early-pans-obey.md
@@ -1,5 +1,5 @@
 ---
-"react-select": patch
+'react-select': patch
 ---
 
 Add `exports` field in package.json

--- a/.changeset/early-pans-obey.md
+++ b/.changeset/early-pans-obey.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Add `exports` field in package.json

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -59,5 +59,37 @@
       "creatable/index.ts",
       "async-creatable/index.ts"
     ]
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/react-select.cjs.js",
+      "import": "./dist/react-select.esm.js",
+      "types": "./dist/react-select.cjs.d.ts"
+    },
+    "./base": {
+      "require": "./base/dist/react-select-base.cjs.js",
+      "import": "./base/dist/react-select-base.esm.js",
+      "types": "./base/dist/react-select-base.cjs.d.ts"
+    },
+    "./animated": {
+      "require": "./animated/dist/react-select-animated.cjs.js",
+      "import": "./animated/dist/react-select-animated.esm.js",
+      "types": "./animated/dist/react-select-animated.cjs.d.ts"
+    },
+    "./async": {
+      "require": "./async/dist/react-select-async.cjs.js",
+      "import": "./async/dist/react-select-async.esm.js",
+      "types": "./async/dist/react-select-async.cjs.d.ts"
+    },
+    "./creatable": {
+      "require": "./creatable/dist/react-select-creatable.cjs.js",
+      "import": "./creatable/dist/react-select-creatable.esm.js",
+      "types": "./creatable/dist/react-select-creatable.cjs.d.ts"
+    },
+    "./async-creatable": {
+      "require": "./async-creatable/dist/react-select-async-creatable.cjs.js",
+      "import": "./async-creatable/dist/react-select-async-creatable.esm.js",
+      "types": "./async-creatable/dist/react-select-async-creatable.cjs.d.ts"
+    }
   }
 }


### PR DESCRIPTION
### TL;DR

Fixes the issue mentioned here: https://github.com/JedWatson/react-select/issues/4859

### Description

#### Issue
Consuming a React Select subpath from a JS module in a project using Webpack 5, throws an error saying the path in the  import statement is not fully specified.

#### Context
Webpack 5 introduced a default behavior that requires all import statements in JS modules to be [fully specified](https://webpack.js.org/configuration/module/#resolvefullyspecified).

Importing a React Select subpath (e.g. `import Creatable from 'react-select/creatable'`) is breaking that rule. Webpack 5 thinks that import statement is trying to import a file with a missing extension.

#### Solution
Inform Webpack that the subpaths are not file imports (and an extension shouldn't be required) by declaring an `exports` field in `package.json`.

The `exports` field is documented in these two places:
- [Node](https://nodejs.org/api/packages.html#exports)
- [Webpack](https://webpack.js.org/guides/package-exports/)

The new `exports` field includes all the subpaths mentioned in React Select's documentation. All other subpath imports will fail from now on.

Each subpath declared in the `exports` field includes 3 different file system paths to satisfy the different environments that might consume them:
- `require`: Will be used by environments using the `require` keyword to import files (e.g CommonJS)
- `import`: Will be used by environments using the `import` keyword to import files (e.g. ES Modules)
- `types`: Will be used by TypeScript to query type definitions