### PR TITLE
feat: add aria describedby attribute to props

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -86,6 +86,8 @@ export interface Props<
   'aria-labelledby'?: AriaAttributes['aria-labelledby'];
   /** Used to set the priority with which screen reader should treat updates to live regions. The possible settings are: off, polite (default) or assertive */
   'aria-live'?: AriaAttributes['aria-live'];
+  /** HTML ID of an element that should be used as a description */
+  'aria-describedby'?: AriaAttributes['aria-describedby'];
   /** Customise the messages used by the aria-live component */
   ariaLiveMessages?: AriaLiveMessages<Option, IsMulti, Group>;
   /** Focus the control when it is mounted */
@@ -1638,6 +1640,9 @@ export default class Select<
         : {
             'aria-describedby': this.getElementId('placeholder'),
           }),
+      ...(!!this.props['aria-describedby'] && {
+        'aria-describedby': this.props['aria-describedby']
+      })
     };
 
     if (!isSearchable) {


### PR DESCRIPTION
fixes #5562

react-select doesn't respect aria-describedby as prop. This results in for errors not being pronounced by screen readers when focusing back on the field.

    <AsyncSelect
      onChange={handleSelect}
      loadOptions={loadOptions}
      placeholder={placeholder}
      inputId={id}
      aria-describedby="id-of-another-element"
    />
Example:
https://codesandbox.io/s/react-select-v5-sandbox-forked-i1vu1l

### This PR fixes this issue by accepting `aria-describedby` as prop