### PR TITLE
Include import statement in Custom Select Props example

### DIFF
--- a/docs/pages/typescript/index.tsx
+++ b/docs/pages/typescript/index.tsx
@@ -91,6 +91,8 @@ The \`actionMeta\` parameter is optional. \`ActionMeta\` is a union that is disc
 You can use module augmentation to add custom props to the \`Select\` prop types:
 
 ~~~jsx
+import { GroupBase } from 'react-select';
+
 declare module 'react-select/dist/declarations/src/Select' {
   export interface Props<
     Option,


### PR DESCRIPTION
Updates the example code in the docs for Custom Select Props to include the `GroupBase` import as discussed in #4804.  