### PR TITLE
Add appropriate roles to option and listbox elements

### DIFF
--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -448,6 +448,7 @@ export const MenuList = <
         'menu-list--is-multi': isMulti,
       })}
       ref={innerRef}
+      role="listbox"
       {...innerProps}
     >
       {children}

--- a/packages/react-select/src/components/Option.tsx
+++ b/packages/react-select/src/components/Option.tsx
@@ -98,6 +98,8 @@ const Option = <
         'option--is-selected': isSelected,
       })}
       ref={innerRef}
+      role="option"
+      aria-selected={isSelected}
       aria-disabled={isDisabled}
       {...innerProps}
     >


### PR DESCRIPTION
This pull request aims to improve the accessibility of react-select by adding appropriate roles to the option and listbox elements.

Changes:

- Added the `option` role and `aria-selected` to the option-equivalent elements
- Added the `listbox` role to the listbox-equivalent elements

I noticed that while using react-select in my own project, I couldn't use getByRole with react-testing-library to target the option-equivalent elements. This led me to create this PR to address the issue.

By merging this PR, we can make react-select more accessible and provide a better experience for users with assistive technologies. Please let me know if any further changes or tests are needed. I look forward to contributing to this project and making it more inclusive for all users.