### PR TITLE
Fix `exports` field

### DIFF
--- a/.changeset/nervous-islands-shake.md
+++ b/.changeset/nervous-islands-shake.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix importing `react-select` in Node ESM

--- a/docs/generate-magical-types/generate/package.json
+++ b/docs/generate-magical-types/generate/package.json
@@ -1,3 +1,4 @@
 {
-  "main": "dist/react-select-generate-magical-types-generate.cjs.js"
+  "main": "dist/react-select-generate-magical-types-generate.cjs.js",
+  "module": "dist/react-select-generate-magical-types-generate.esm.js"
 }

--- a/docs/generate-magical-types/package.json
+++ b/docs/generate-magical-types/package.json
@@ -1,6 +1,19 @@
 {
   "name": "@react-select/generate-magical-types",
   "main": "dist/generate-magical-types.cjs.js",
+  "exports": {
+    "./generate": {
+      "module": "./generate/dist/react-select-generate-magical-types-generate.esm.js",
+      "import": "./generate/dist/react-select-generate-magical-types-generate.cjs.mjs",
+      "default": "./generate/dist/react-select-generate-magical-types-generate.cjs.js"
+    },
+    "./serialize": {
+      "module": "./serialize/dist/react-select-generate-magical-types-serialize.esm.js",
+      "import": "./serialize/dist/react-select-generate-magical-types-serialize.cjs.mjs",
+      "default": "./serialize/dist/react-select-generate-magical-types-serialize.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "//": "these deps aren't real, they're just to appease preconstruct",
   "dependencies": {
     "@babel/runtime": "*",

--- a/docs/generate-magical-types/serialize/package.json
+++ b/docs/generate-magical-types/serialize/package.json
@@ -1,3 +1,4 @@
 {
-  "main": "dist/react-select-generate-magical-types-serialize.cjs.js"
+  "main": "dist/react-select-generate-magical-types-serialize.cjs.js",
+  "module": "dist/react-select-generate-magical-types-serialize.esm.js"
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@emotion/babel-plugin": "^11.10.2",
     "@emotion/jest": "^11.1.0",
     "@manypkg/cli": "^0.19.2",
-    "@preconstruct/cli": "^2.6.0",
+    "@preconstruct/cli": "^2.6.2",
     "@testing-library/dom": "8.19.0",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "12.1.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@emotion/babel-plugin": "^11.10.2",
     "@emotion/jest": "^11.1.0",
     "@manypkg/cli": "^0.19.2",
-    "@preconstruct/cli": "^2.2.2",
+    "@preconstruct/cli": "^2.6.0",
     "@testing-library/dom": "8.19.0",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "12.1.4",
@@ -120,11 +120,10 @@
     "packages": [
       "packages/*",
       "docs/generate-magical-types"
-    ]
-  },
-  "browser": {
-    "./dist/react-select.cjs.js": "./dist/react-select.browser.cjs.js",
-    "./dist/react-select.esm.js": "./dist/react-select.browser.esm.js"
+    ],
+    "exports": {
+      "importConditionDefaultExport": "default"
+    }
   },
   "resolutions": {
     "csstype": "^3.0.2"

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -62,34 +62,35 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/react-select.cjs.js",
-      "import": "./dist/react-select.esm.js",
-      "types": "./dist/react-select.cjs.d.ts"
+      "module": "./dist/react-select.esm.js",
+      "import": "./dist/react-select.cjs.mjs",
+      "default": "./dist/react-select.cjs.js"
     },
     "./base": {
-      "require": "./base/dist/react-select-base.cjs.js",
-      "import": "./base/dist/react-select-base.esm.js",
-      "types": "./base/dist/react-select-base.cjs.d.ts"
-    },
-    "./animated": {
-      "require": "./animated/dist/react-select-animated.cjs.js",
-      "import": "./animated/dist/react-select-animated.esm.js",
-      "types": "./animated/dist/react-select-animated.cjs.d.ts"
+      "module": "./base/dist/react-select-base.esm.js",
+      "import": "./base/dist/react-select-base.cjs.mjs",
+      "default": "./base/dist/react-select-base.cjs.js"
     },
     "./async": {
-      "require": "./async/dist/react-select-async.cjs.js",
-      "import": "./async/dist/react-select-async.esm.js",
-      "types": "./async/dist/react-select-async.cjs.d.ts"
+      "module": "./async/dist/react-select-async.esm.js",
+      "import": "./async/dist/react-select-async.cjs.mjs",
+      "default": "./async/dist/react-select-async.cjs.js"
+    },
+    "./animated": {
+      "module": "./animated/dist/react-select-animated.esm.js",
+      "import": "./animated/dist/react-select-animated.cjs.mjs",
+      "default": "./animated/dist/react-select-animated.cjs.js"
     },
     "./creatable": {
-      "require": "./creatable/dist/react-select-creatable.cjs.js",
-      "import": "./creatable/dist/react-select-creatable.esm.js",
-      "types": "./creatable/dist/react-select-creatable.cjs.d.ts"
+      "module": "./creatable/dist/react-select-creatable.esm.js",
+      "import": "./creatable/dist/react-select-creatable.cjs.mjs",
+      "default": "./creatable/dist/react-select-creatable.cjs.js"
     },
     "./async-creatable": {
-      "require": "./async-creatable/dist/react-select-async-creatable.cjs.js",
-      "import": "./async-creatable/dist/react-select-async-creatable.esm.js",
-      "types": "./async-creatable/dist/react-select-async-creatable.cjs.d.ts"
-    }
+      "module": "./async-creatable/dist/react-select-async-creatable.esm.js",
+      "import": "./async-creatable/dist/react-select-async-creatable.cjs.mjs",
+      "default": "./async-creatable/dist/react-select-async-creatable.cjs.js"
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,10 +2313,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@preconstruct/cli@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.6.0.tgz#4ac23d36c5b7852adc565760c08ce5a56f2270af"
-  integrity sha512-pZ6zn8uGx21iy1b6XOHiWQ+dkUpfpR/JPGjVeD+nIqub7YKZWONeskPm8GnAC5xN+M1UALgD375ig/20KxVbew==
+"@preconstruct/cli@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.6.2.tgz#ee0dd6456129cd72b918a52440088e54f46bdc5d"
+  integrity sha512-KhWeiw3hutnue5CTRlfWAZrB8qjW/uJNuSKC0OkwaerH9v8LdnbnnpMEdave8LAbruTuDJKhZ9KQd67ooY2n4g==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     "@babel/core" "^7.7.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,6 +2102,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.13":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
@@ -2308,10 +2313,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@preconstruct/cli@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.2.2.tgz#2327aa2486f7c3650cfa726e667a9d80007e50d8"
-  integrity sha512-7Zk8g/G+SPusoL1Ir3oslj19QDoFuAKeQO8B6fnNkRRgvIntxnylGZyC4wdKVX/eeDHwca1LNLT/GyjXx1f1nA==
+"@preconstruct/cli@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.6.0.tgz#4ac23d36c5b7852adc565760c08ce5a56f2270af"
+  integrity sha512-pZ6zn8uGx21iy1b6XOHiWQ+dkUpfpR/JPGjVeD+nIqub7YKZWONeskPm8GnAC5xN+M1UALgD375ig/20KxVbew==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     "@babel/core" "^7.7.7"
@@ -2335,7 +2340,7 @@
     is-ci "^2.0.0"
     is-reference "^1.2.1"
     jest-worker "^26.3.0"
-    magic-string "^0.25.7"
+    magic-string "^0.30.0"
     meow "^7.1.0"
     ms "^2.1.2"
     normalize-path "^3.0.0"
@@ -2346,9 +2351,9 @@
     quick-lru "^5.1.1"
     resolve "^1.17.0"
     resolve-from "^5.0.0"
-    rollup "^2.32.0"
+    rollup "^2.79.1"
     semver "^7.3.4"
-    terser "^5.2.1"
+    terser "^5.16.8"
     v8-compile-cache "^2.1.1"
 
 "@preconstruct/hook@^0.4.0":
@@ -9081,7 +9086,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.1.2, fsevents@~2.3.1, fsevents@~2.3.2:
+fsevents@^2.1.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -12143,6 +12148,13 @@ magic-string@^0.25.7:
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"
+
+magic-string@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
+  integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -15542,12 +15554,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup@^2.32.0:
-  version "2.50.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.50.6.tgz#24e2211caf9031081656e98a5e5e94d3b5e786e2"
-  integrity sha512-6c5CJPLVgo0iNaZWWliNu1Kl43tjP9LZcp6D/tkf2eLH2a9/WeHxg9vfTFl8QV/2SOyaJX37CEm9XuGM0rviUg==
+rollup@^2.79.1:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
-    fsevents "~2.3.1"
+    fsevents "~2.3.2"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -16880,10 +16892,20 @@ terser@^4.1.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.14.1, terser@^5.2.1, terser@^5.3.4:
+terser@^5.14.1, terser@^5.3.4:
   version "5.15.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.1.tgz#8561af6e0fd6d839669c73b92bdd5777d870ed6c"
   integrity sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.16.8:
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.1.tgz#948f10830454761e2eeedc6debe45c532c83fd69"
+  integrity sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
closes #5595
closes #4859

The `exports` field added in #5559 was wrong in a few ways, [arethetypeswrong](https://arethetypeswrong.github.io/?p=react-select%405.7.2) explains this well:

> 🐛 Imports of all entrypoints under resolution modes that use the import condition in package.json "exports" resolved through a conditional package.json export, but only after failing to resolve through an earlier condition. This behavior is a [TypeScript bug](https://github.com/microsoft/TypeScript/issues/50762) and should not be relied upon.
> 
> 🚭 The implementation resolved at all entrypoints uses ESM syntax, but the detected module kind is CJS. This will be an error in Node (and potentially other runtimes and bundlers). The module kind was decided based on the nearest package.json’s lack of a "type": "module" field.

This PR makes react-select use Preconstruct's exports field feature which does things correctly, I've also checked the build output on this branch with [arethetypeswrong](https://arethetypeswrong.github.io) and it reports no errors. Of note is that there is still no bundle for Node ESM, the `.mjs` file used when the `import` condition matches just re-exports from the CJS bundle but fixes the default export (this is new to Preconstruct and is what `"importConditionDefaultExport": "default"` is doing), the lack of a Node ESM bundle is intentional so the [dual package hazard](https://nodejs.org/api/packages.html#packages_dual_package_hazard) can't happen. Bundlers will use the `module` condition to still have ESM there. There is also intentionally no `types` condition, that's unnecessary because Typescript will resolve to the `import` or `default` conditions and use the `.d.mts` and `.d.ts` files next to the implementations.
