### PR TITLE
[fix] removed typo

### DIFF
--- a/docs/pages/typescript/index.tsx
+++ b/docs/pages/typescript/index.tsx
@@ -84,7 +84,7 @@ const onChange = (option: readonly Option[], actionMeta: ActionMeta<Option>) => 
 }
 ~~~
 
-The \`actionMeta\` parameter is optional. \`ActionMeta\` is a union that is discriminated on the \`action\` type. Take a look at at [types.ts](https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/types.ts) in the source code to see its full definition.
+The \`actionMeta\` parameter is optional. \`ActionMeta\` is a union that is discriminated on the \`action\` type. Take a look at [types.ts](https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/types.ts) in the source code to see its full definition.
 
 ## Custom Select props
 


### PR DESCRIPTION
- Removed a typo from docs page
- [Page](https://react-select.com/typescript#onchange) `at at` to `at`

![스크린샷 2023-05-02 오후 3 34 12](https://user-images.githubusercontent.com/89691274/235596182-85e7d524-4eca-4e72-9cf1-bf9b9b9642e1.png)
