### PR TITLE
Add resultLimit to improve performance of react-select for many options

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -253,6 +253,8 @@ export interface Props<
   pageSize: number;
   /** Placeholder for the select value */
   placeholder: ReactNode;
+  /** Limits the number of rendered options in the dropdown */
+  resultLimit?: number,
   /** Status to relay to screen readers */
   screenReaderStatus: (obj: { count: number }) => string;
   /**
@@ -1874,6 +1876,7 @@ export default class Select<
       noOptionsMessage,
       onMenuScrollToTop,
       onMenuScrollToBottom,
+      resultLimit,
     } = this.props;
 
     if (!menuIsOpen) return null;
@@ -1915,7 +1918,9 @@ export default class Select<
     let menuUI: ReactNode;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions().map((item) => {
+      menuUI = this.getCategorizedOptions()
+      .slice(0, resultLimit || undefined)
+      .map((item) => {
         if (item.type === 'group') {
           const { data, options, index: groupIndex } = item;
           const groupId = `${this.getElementId('group')}-${groupIndex}`;

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1921,33 +1921,33 @@ export default class Select<
       menuUI = this.getCategorizedOptions()
         .slice(0, resultLimit && resultLimit > 0 ? resultLimit : undefined)
         .map((item) => {
-        if (item.type === 'group') {
-          const { data, options, index: groupIndex } = item;
-          const groupId = `${this.getElementId('group')}-${groupIndex}`;
-          const headingId = `${groupId}-heading`;
+          if (item.type === 'group') {
+            const { data, options, index: groupIndex } = item;
+            const groupId = `${this.getElementId('group')}-${groupIndex}`;
+            const headingId = `${groupId}-heading`;
 
-          return (
-            <Group
-              {...commonProps}
-              key={groupId}
-              data={data}
-              options={options}
-              Heading={GroupHeading}
-              headingProps={{
-                id: headingId,
-                data: item.data,
-              }}
-              label={this.formatGroupLabel(item.data)}
-            >
-              {item.options.map((option) =>
-                render(option, `${groupIndex}-${option.index}`)
-              )}
-            </Group>
-          );
-        } else if (item.type === 'option') {
-          return render(item, `${item.index}`);
-        }
-      });
+            return (
+              <Group
+                {...commonProps}
+                key={groupId}
+                data={data}
+                options={options}
+                Heading={GroupHeading}
+                headingProps={{
+                  id: headingId,
+                  data: item.data,
+                }}
+                label={this.formatGroupLabel(item.data)}
+              >
+                {item.options.map((option) =>
+                  render(option, `${groupIndex}-${option.index}`)
+                )}
+              </Group>
+            );
+          } else if (item.type === 'option') {
+            return render(item, `${item.index}`);
+          }
+        });
     } else if (isLoading) {
       const message = loadingMessage({ inputValue });
       if (message === null) return null;

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -254,7 +254,7 @@ export interface Props<
   /** Placeholder for the select value */
   placeholder: ReactNode;
   /** Limits the number of rendered options in the dropdown */
-  resultLimit?: number,
+  resultLimit?: number;
   /** Status to relay to screen readers */
   screenReaderStatus: (obj: { count: number }) => string;
   /**
@@ -1918,9 +1918,12 @@ export default class Select<
     let menuUI: ReactNode;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions()
-      .slice(0, resultLimit || undefined)
-      .map((item) => {
+      menuUI = this.getCategorizedOptions();
+
+      if (resultLimit && resultLimit > 0) {
+        menuUI = menuUI.slice(0, resultLimit);
+      }
+      menuUI = menuUI.map((item) => {
         if (item.type === 'group') {
           const { data, options, index: groupIndex } = item;
           const groupId = `${this.getElementId('group')}-${groupIndex}`;

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1918,12 +1918,9 @@ export default class Select<
     let menuUI: ReactNode;
 
     if (this.hasOptions()) {
-      menuUI = this.getCategorizedOptions();
-
-      if (resultLimit && resultLimit > 0) {
-        menuUI = menuUI.slice(0, resultLimit);
-      }
-      menuUI = menuUI.map((item) => {
+      menuUI = this.getCategorizedOptions()
+        .slice(0, resultLimit && resultLimit > 0 ? resultLimit : undefined)
+        .map((item) => {
         if (item.type === 'group') {
           const { data, options, index: groupIndex } = item;
           const groupId = `${this.getElementId('group')}-${groupIndex}`;

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -3120,6 +3120,28 @@ test('renders with custom theme', () => {
   ).toEqual(primary);
 });
 
+test('resultLimit limits number of rendered props', () => {
+  const resultLimit = 5;
+  const { container } = render(
+    <Select {...BASIC_PROPS} resultLimit={resultLimit} menuIsOpen />
+  );
+  expect(container.querySelectorAll('.react-select__option').length).toBe(
+    resultLimit
+  );
+});
+
+test.each([undefined, 0, -10])(
+  'resultLimit negative, undefined or zero should render all options',
+  resultLimit => {
+    const { container } = render(
+      <Select {...BASIC_PROPS} resultLimit={resultLimit} menuIsOpen />
+    );
+    expect(container.querySelectorAll('.react-select__option').length).toBe(
+      OPTIONS.length
+    );
+  }
+);
+
 cases(
   '`required` prop',
   ({ props = BASIC_PROPS }) => {

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -3132,7 +3132,7 @@ test('resultLimit limits number of rendered props', () => {
 
 test.each([undefined, 0, -10])(
   'resultLimit negative, undefined or zero should render all options',
-  resultLimit => {
+  (resultLimit) => {
     const { container } = render(
       <Select {...BASIC_PROPS} resultLimit={resultLimit} menuIsOpen />
     );


### PR DESCRIPTION
- Based on PR #4515
- React-select with over 10.000 options has performance issues
- Improve performance limiting displayed options based on user preference using `resultLimit` prop