### PR TITLE
support aria-placeholder

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -82,6 +82,8 @@ export interface Props<
   'aria-invalid'?: AriaAttributes['aria-invalid'];
   /** Aria label (for assistive tech) */
   'aria-label'?: AriaAttributes['aria-label'];
+  /** Aria placeholder (for assistive tech) */
+  'aria-placeholder'?: AriaAttributes['aria-placeholder'];
   /** HTML ID of an element that should be used as the label (for assistive tech) */
   'aria-labelledby'?: AriaAttributes['aria-labelledby'];
   /** Used to set the priority with which screen reader should treat updates to live regions. The possible settings are: off, polite (default) or assertive */
@@ -1619,6 +1621,7 @@ export default class Select<
       'aria-expanded': menuIsOpen,
       'aria-haspopup': true,
       'aria-errormessage': this.props['aria-errormessage'],
+      'aria-placeholder': this.props['aria-placeholder'],
       'aria-invalid': this.props['aria-invalid'],
       'aria-label': this.props['aria-label'],
       'aria-labelledby': this.props['aria-labelledby'],

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2053,6 +2053,28 @@ cases(
 );
 
 cases(
+  'accessibility > passes through aria-placeholder prop',
+  ({ props = { ...BASIC_PROPS, 'aria-placeholder': 'foo' } }) => {
+    let { container } = render(<Select {...props} />);
+    expect(
+      container
+        .querySelector('input.react-select__input')!
+        .getAttribute('aria-placeholder')
+    ).toBe('foo');
+  },
+  {
+    'single select > should pass aria-invalid prop down to input': {},
+    'multi select > should pass aria-invalid prop down to input': {
+      props: {
+        ...BASIC_PROPS,
+        'aria-placeholder': 'foo',
+        isMulti: true,
+      },
+    },
+  }
+);
+
+cases(
   'accessibility > passes through aria-label prop',
   ({ props = { ...BASIC_PROPS, 'aria-label': 'testing' } }) => {
     let { container } = render(<Select {...props} />);


### PR DESCRIPTION
The docs (https://react-select.com/props) define `aria-placeholder` as a supported prop, but as far as I could tell it wasn't actually supported. This changeset adds it.

This will enable `page.getPlaceholder("foo")` in playwright tests.