### PR TITLE
fix: lack of disabled attribute on select element causing color contrast issue

### DIFF
--- a/.changeset/lemon-deers-taste.md
+++ b/.changeset/lemon-deers-taste.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Add aria-disabled to select's control component.

--- a/cypress/fixtures/selectors.json
+++ b/cypress/fixtures/selectors.json
@@ -10,6 +10,7 @@
   "indicatorClear": ".react-select__clear-indicator",
   "indicatorDropdown": ".react-select__dropdown-indicator",
   "menu": ".react-select__menu",
+  "control": ".react-select__control",
   "menuOption": ".react-select__option",
   "noOptionsValue": ".react-select__menu-notice--no-options",
   "placeholder": ".react-select__placeholder",

--- a/cypress/integration/single-select.spec.ts
+++ b/cypress/integration/single-select.spec.ts
@@ -107,7 +107,10 @@ describe('Single Select', () => {
           .click({ force: true })
           .find('input')
           .should('exist')
-          .should('be.disabled');
+          .should('be.disabled')
+          // control should have aria-disabled
+          .get(selector.control)
+          .should('have.a.property', 'aria-disabled', 'true');
       });
 
       it(`Should filter options when searching in view: ${viewport}`, () => {

--- a/cypress/integration/single-select.spec.ts
+++ b/cypress/integration/single-select.spec.ts
@@ -109,8 +109,9 @@ describe('Single Select', () => {
           .should('exist')
           .should('be.disabled')
           // control should have aria-disabled
-          .get(selector.control)
-          .should('have.a.property', 'aria-disabled', 'true');
+          .get(selector.singleBasicSelect)
+          .find(selector.control)
+          .should('have.attr', 'aria-disabled', 'true');
       });
 
       it(`Should filter options when searching in view: ${viewport}`, () => {

--- a/packages/react-select/src/components/Control.tsx
+++ b/packages/react-select/src/components/Control.tsx
@@ -87,6 +87,7 @@ const Control = <
         'control--menu-is-open': menuIsOpen,
       })}
       {...innerProps}
+      aria-disabled={isDisabled || undefined}
     >
       {children}
     </div>


### PR DESCRIPTION
As stated in this issue: https://github.com/JedWatson/react-select/issues/5550

"disabled" is properly set in the input, since it was used instead of aria-disabled, the lack of "aria-disabled" resulted in the automated a11y tool not determining it disabled element and cause a contrast issue. 

Ref: UIEN-3643