### PR TITLE
Resolve `defaultProps` deprecation warning for React v18+

### DIFF
--- a/.changeset/metal-pens-boil.md
+++ b/.changeset/metal-pens-boil.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Replace `defaultProps` usage on functional components with JavaScript parameter defaults to support future React versions.

--- a/.changeset/metal-pens-boil.md
+++ b/.changeset/metal-pens-boil.md
@@ -2,4 +2,4 @@
 'react-select': patch
 ---
 
-Replace `defaultProps` usage on functional components with JavaScript parameter defaults to support future React versions.
+Resolve `defaultProps` deprecation warning for React v18+.

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -498,15 +498,21 @@ export const NoOptionsMessage = <
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
->(
-  { children = 'No options', innerProps, ...restProps }: NoticeProps<Option, IsMulti, Group>
-) => {
+>({
+  children = 'No options',
+  innerProps,
+  ...restProps
+}: NoticeProps<Option, IsMulti, Group>) => {
   return (
     <div
-      {...getStyleProps({ ...restProps, children, innerProps }, 'noOptionsMessage', {
-        'menu-notice': true,
-        'menu-notice--no-options': true,
-      })}
+      {...getStyleProps(
+        { ...restProps, children, innerProps },
+        'noOptionsMessage',
+        {
+          'menu-notice': true,
+          'menu-notice--no-options': true,
+        }
+      )}
       {...innerProps}
     >
       {children}
@@ -518,15 +524,21 @@ export const LoadingMessage = <
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
->(
-  { children = 'Loading...', innerProps, ...restProps }: NoticeProps<Option, IsMulti, Group>
-) => {
+>({
+  children = 'Loading...',
+  innerProps,
+  ...restProps
+}: NoticeProps<Option, IsMulti, Group>) => {
   return (
     <div
-      {...getStyleProps({ ...restProps, children, innerProps }, 'loadingMessage', {
-        'menu-notice': true,
-        'menu-notice--loading': true,
-      })}
+      {...getStyleProps(
+        { ...restProps, children, innerProps },
+        'loadingMessage',
+        {
+          'menu-notice': true,
+          'menu-notice--loading': true,
+        }
+      )}
       {...innerProps}
     >
       {children}

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -499,12 +499,11 @@ export const NoOptionsMessage = <
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
-  props: NoticeProps<Option, IsMulti, Group>
+  { children = 'No options', innerProps, ...restProps }: NoticeProps<Option, IsMulti, Group>
 ) => {
-  const { children, innerProps } = props;
   return (
     <div
-      {...getStyleProps(props, 'noOptionsMessage', {
+      {...getStyleProps({ ...restProps, children, innerProps }, 'noOptionsMessage', {
         'menu-notice': true,
         'menu-notice--no-options': true,
       })}
@@ -514,21 +513,17 @@ export const NoOptionsMessage = <
     </div>
   );
 };
-NoOptionsMessage.defaultProps = {
-  children: 'No options',
-};
 
 export const LoadingMessage = <
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
-  props: NoticeProps<Option, IsMulti, Group>
+  { children = 'Loading...', innerProps, ...restProps }: NoticeProps<Option, IsMulti, Group>
 ) => {
-  const { children, innerProps } = props;
   return (
     <div
-      {...getStyleProps(props, 'loadingMessage', {
+      {...getStyleProps({ ...restProps, children, innerProps }, 'loadingMessage', {
         'menu-notice': true,
         'menu-notice--loading': true,
       })}
@@ -537,9 +532,6 @@ export const LoadingMessage = <
       {children}
     </div>
   );
-};
-LoadingMessage.defaultProps = {
-  children: 'Loading...',
 };
 
 // ==============================

--- a/packages/react-select/src/components/indicators.tsx
+++ b/packages/react-select/src/components/indicators.tsx
@@ -288,13 +288,12 @@ export const LoadingIndicator = <
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 >(
-  props: LoadingIndicatorProps<Option, IsMulti, Group>
+  { innerProps, isRtl, size = 4, ...restProps }: LoadingIndicatorProps<Option, IsMulti, Group>
 ) => {
-  const { innerProps, isRtl } = props;
 
   return (
     <div
-      {...getStyleProps(props, 'loadingIndicator', {
+      {...getStyleProps({ ...restProps, innerProps, isRtl, size }, 'loadingIndicator', {
         indicator: true,
         'loading-indicator': true,
       })}
@@ -306,4 +305,3 @@ export const LoadingIndicator = <
     </div>
   );
 };
-LoadingIndicator.defaultProps = { size: 4 };

--- a/packages/react-select/src/components/indicators.tsx
+++ b/packages/react-select/src/components/indicators.tsx
@@ -287,16 +287,22 @@ export const LoadingIndicator = <
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
->(
-  { innerProps, isRtl, size = 4, ...restProps }: LoadingIndicatorProps<Option, IsMulti, Group>
-) => {
-
+>({
+  innerProps,
+  isRtl,
+  size = 4,
+  ...restProps
+}: LoadingIndicatorProps<Option, IsMulti, Group>) => {
   return (
     <div
-      {...getStyleProps({ ...restProps, innerProps, isRtl, size }, 'loadingIndicator', {
-        indicator: true,
-        'loading-indicator': true,
-      })}
+      {...getStyleProps(
+        { ...restProps, innerProps, isRtl, size },
+        'loadingIndicator',
+        {
+          indicator: true,
+          'loading-indicator': true,
+        }
+      )}
       {...innerProps}
     >
       <LoadingDot delay={0} offset={isRtl} />


### PR DESCRIPTION
The next minor release of React (v18.3.0) will throw a deprecation warning if functional components use `defaultProps` (see https://github.com/facebook/react/pull/25699 for reason why).

PR removes `defaultProps` references on functional components (only in package, not docs) and replaces them with JavaScript default parameters.

Resolves #5596.