### PR TITLE
Inner components list contains link to list of components

### DIFF
--- a/docs/pages/styles/index.tsx
+++ b/docs/pages/styles/index.tsx
@@ -111,6 +111,8 @@ export default function Styles() {
       </ul>
     </details>
 
+    Note that this list overlaps with the list of customisable and switchable components listed [here](/components).
+
     ## The classNamePrefix prop
 
     If you provide the \`classNamePrefix\` prop to React Select, all inner elements will be given a className with the provided prefix.


### PR DESCRIPTION
When I was looking at how to style the inner components, I was confused at the lack of documentation at the list [here](https://react-select.com/styles#inner-components) . I just added a link to the list of components so people know what each inner component means.