### PR TITLE
fix: Add declarations export to package.json

### DIFF
--- a/.changeset/wild-carrots-joke.md
+++ b/.changeset/wild-carrots-joke.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix declaration exports to re-enable module augmentation for projects using TS moduleResolution="bundler"

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -58,7 +58,14 @@
       "async/index.ts",
       "creatable/index.ts",
       "async-creatable/index.ts"
-    ]
+    ],
+    "exports": {
+      "extra": {
+        "./dist/declarations/src/*": {
+          "types": "./dist/declarations/src/*.d.ts"
+        }
+      }
+    }
   },
   "exports": {
     ".": {
@@ -91,6 +98,9 @@
       "import": "./async-creatable/dist/react-select-async-creatable.cjs.mjs",
       "default": "./async-creatable/dist/react-select-async-creatable.cjs.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./dist/declarations/src/*": {
+      "types": "./dist/declarations/src/*.d.ts"
+    }
   }
 }


### PR DESCRIPTION
This is an attempt to fix #5743, in which the module augmentation described in the docs no longer works in projects using [`"moduleResolution": "bundler" | "node16" | "nodenext"`](https://www.typescriptlang.org/tsconfig#moduleResolution). As far as I can tell, it's because projects using those settings look for the `exports` field in the package.json, which is more strict about which file paths can be accessed in the dependency package. I'm honestly not the most familiar with the interactions between TypeScript, ES Modules, and module augmentation (the entire node package ecosystem is hard to keep track of haha), but this fix did the trick for me when I tested it in my own project [`chakra-react-select`](https://github.com/csandman/chakra-react-select) by modifying the `react-select` package.json manually.

I know that @FabianFrank already had a similar PR up for this fix (#5744) but it wouldn't actually build because `preconstruct` saw the `exports` config as invalid. I was able to fix this by adding the following to the `preconstruct` config:

```json
    "exports": {
      "extra": {
        "./dist/declarations/src/*": {
          "types": "./dist/declarations/src/*.d.ts"
        }
      }
    }
```

I extended the export statement to use a wildcard as well, because in my project I'm also extending the types for the `MultiValue` props, as well as the `indicators` props, so hopefully we can stick with that. I'm not exactly sure how the path structure is supposed to work, but doing it like this also allowed for augmenting the nested declarations like `"react-select/dist/declarations/src/components/MultiValue"`.

Anyway, I'm really not sure if this is the best approach to fixing this issue, but [users of my package have been having issues with this for a while now](https://github.com/csandman/chakra-react-select/issues/273) before I finally discovered that this must be the issue, so it would be great if a fix for this could get merged in.

---

On a side note, this could be an opportunity to simplify the import path people have to use with something like this:

```json
    "./declarations/*": {
      "types": "./dist/declarations/src/*.d.ts"
    }
```

Which would allow people to simplify their module augmentation to this:

```ts
declare module "react-select/declarations/Select" {
  export interface Props<Option, IsMulti extends boolean, Group extends GroupBase<Option>> {
    // ...
  }
}
```

However, this would only work for those whose projects are actually using the `exports` field, which would create a divergence in the guide for how to accomplish adding custom props with module augmentation, so I figured it was probably best to keep them consistent for now.

---

**EDIT:**

I actually went ahead and made two example CodeSandboxes for the original issue, one highlighting how the module augmentation is broken with the current version of this package `v5.7.5`, and another with the version generated by this PR showing it fixed:

- Current broken example: https://codesandbox.io/s/f3zpfm?file=/src/App.tsx
- New fixed example: https://codesandbox.io/s/66j6gy?file=/src/App.tsx

Both of these will appear fixed in the generated CodeSandboxes below.