### PR TITLE
Allow type imports

### DIFF
--- a/.changeset/weak-glasses-kneel.md
+++ b/.changeset/weak-glasses-kneel.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Allow type imports

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -91,6 +91,9 @@
       "import": "./async-creatable/dist/react-select-async-creatable.cjs.mjs",
       "default": "./async-creatable/dist/react-select-async-creatable.cjs.js"
     },
+    "./dist/declarations/*": {
+      "types": "./dist/declarations/*.d.ts"
+    },
     "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
I'm working on a typescript react component library that wraps and restyles `react-select` including types, and in an effort to make that work we currently have the following type import;

```ts
import type SelectClass from 'react-select/dist/declarations/src/Select'
```

`exports` field in `package.json` was introduced in https://github.com/JedWatson/react-select/pull/5559 which breaks this since nothing can be imported from `react-select/dist/declarations/...` any longer :/

Adding an export rule for declaration types in the package fixes this issue.