### PR TITLE
Fix for calling non-cancellable scroll events

### DIFF
--- a/.changeset/tender-tools-applaud.md
+++ b/.changeset/tender-tools-applaud.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix for calling non-cancellable scroll events

--- a/packages/react-select/src/internal/useScrollLock.ts
+++ b/packages/react-select/src/internal/useScrollLock.ts
@@ -16,7 +16,7 @@ const LOCK_STYLES = {
 };
 
 function preventTouchMove(e: TouchEvent) {
-  e.preventDefault();
+  if (e.cancelable) e.preventDefault();
 }
 
 function allowTouchMove(e: TouchEvent) {


### PR DESCRIPTION
Noticed that we're still getting errors from another `preventDefault`.

Related to #5549 and #5672.