### PR TITLE
replace text 'npm' with 'yarn'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Features include:
 
 # Installation and usage
 
-The easiest way to use react-select is to install it from npm and build it into your app with Webpack.
+The easiest way to use react-select is to install it from yarn and build it into your app with Webpack.
 
 ```
 yarn add react-select


### PR DESCRIPTION
The build command is for 'yarn', but the label for that command has 'npm', which can be confusing for newcomers (me too).