### PR TITLE
Add option for custom aria-describedby

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1738,7 +1738,9 @@ export default class Select<
             'aria-describedby': this.getElementId('live-region'),
           }
         : {
-            'aria-describedby': this.props['aria-describedby'] || this.getElementId('placeholder'),
+            'aria-describedby':
+              this.props['aria-describedby'] ||
+              this.getElementId('placeholder'),
           }),
     };
 

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -87,6 +87,8 @@ export interface Props<
   'aria-labelledby'?: AriaAttributes['aria-labelledby'];
   /** Used to set the priority with which screen reader should treat updates to live regions. The possible settings are: off, polite (default) or assertive */
   'aria-live'?: AriaAttributes['aria-live'];
+  /** HTML ID of an element that should be used as a description (for assistive tech) */
+  'aria-describedby'?: AriaAttributes['aria-describedby'];
   /** Customise the messages used by the aria-live component */
   ariaLiveMessages?: AriaLiveMessages<Option, IsMulti, Group>;
   /** Focus the control when it is mounted */
@@ -1736,7 +1738,7 @@ export default class Select<
             'aria-describedby': this.getElementId('live-region'),
           }
         : {
-            'aria-describedby': this.getElementId('placeholder'),
+            'aria-describedby': this.props['aria-describedby'] || this.getElementId('placeholder'),
           }),
     };
 

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2212,6 +2212,28 @@ test('accessibility > aria-activedescendant should not exist if hideSelectedOpti
 });
 
 cases(
+  'accessibility > passes through aria-describedby prop',
+  ({ props = { ...BASIC_PROPS, 'aria-describedby': 'testing' } }) => {
+    let { container } = render(<Select {...props} />);
+    expect(
+      container
+        .querySelector('input.react-select__input')!
+        .getAttribute('aria-describedby')
+    ).toBe('testing');
+  },
+  {
+    'single select > should pass aria-describedby prop down to input': {},
+    'multi select > should pass aria-describedby prop down to input': {
+      props: {
+        ...BASIC_PROPS,
+        'aria-describedby': 'testing',
+        isMulti: true,
+      },
+    },
+  }
+);
+
+cases(
   'accessibility > passes through aria-labelledby prop',
   ({ props = { ...BASIC_PROPS, 'aria-labelledby': 'testing' } }) => {
     let { container } = render(<Select {...props} />);


### PR DESCRIPTION
Provides support for issues: #5562 and #1570 

I've tested my fork on local repository to confirm this does indeed pass the provided `aria-describedby` to the react-select. Also tested and passed the `yarn lint`, `yarn type-check`, and `yarn test` per CONTRIBUTING.MD

<img width="1285" alt="Screenshot 2024-03-06 at 2 24 54 PM" src="https://github.com/JedWatson/react-select/assets/7015638/1d49dddf-c588-49c9-8d66-a58272841605">

Our team needs this implemented to meet a11y support for our use of react-select. We have some custom hint and error messaging that is related to the Select and needs to be accessibly connected through aria-describedby. I'm hoping we can contribute to the library and make this available in a minor update to the package. Please let me know what I can do to assist in getting this PR approved and ready to merge :) Cheers!