### PR TITLE
add box-sizing to border-box for RequiredInput

### DIFF
--- a/packages/react-select/src/internal/RequiredInput.tsx
+++ b/packages/react-select/src/internal/RequiredInput.tsx
@@ -21,6 +21,7 @@ const RequiredInput: FunctionComponent<{
       left: 0,
       right: 0,
       width: '100%',
+      boxSizing: 'border-box',
     }}
     // Prevent `Switching from uncontrolled to controlled` error
     value=""


### PR DESCRIPTION
adding `required` would otherwise cause an extra (unstylable) component to be added which has some implicit padding from the user agent style sheet (inputs have padding) which could cause horizontal scrolling when the whole scroll field is 100% wide.

The RequiredInput is added if the select is required and empty, to make the native browser validation messages show at a valid location. If it was completely hidden/removed using `display: none` it wouldn't show any validation errors anymore (at least in chromium based browsers)