### PR TITLE
Add container prop to NonceProvider

### DIFF
--- a/.changeset/angry-numbers-allow.md
+++ b/.changeset/angry-numbers-allow.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+NonceProvider now has a `container` prop to set a custom insertion point for styles

--- a/packages/react-select/src/NonceProvider.tsx
+++ b/packages/react-select/src/NonceProvider.tsx
@@ -8,12 +8,13 @@ interface NonceProviderProps {
   nonce: string;
   children: ReactNode;
   cacheKey: string;
+  container?: Node;
 }
 
-export default ({ nonce, children, cacheKey }: NonceProviderProps) => {
+export default ({ nonce, children, cacheKey, container }: NonceProviderProps) => {
   const emotionCache = useMemo(
-    () => createCache({ key: cacheKey, nonce }),
-    [cacheKey, nonce]
+    () => createCache({ key: cacheKey, nonce, container }),
+    [cacheKey, nonce, container]
   );
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
 };

--- a/packages/react-select/src/NonceProvider.tsx
+++ b/packages/react-select/src/NonceProvider.tsx
@@ -11,7 +11,12 @@ interface NonceProviderProps {
   container?: Node;
 }
 
-export default ({ nonce, children, cacheKey, container }: NonceProviderProps) => {
+export default ({
+  nonce,
+  children,
+  cacheKey,
+  container,
+}: NonceProviderProps) => {
   const emotionCache = useMemo(
     () => createCache({ key: cacheKey, nonce, container }),
     [cacheKey, nonce, container]


### PR DESCRIPTION
Fixes the issue [#3680](https://github.com/JedWatson/react-select/issues/3680)

The `container` prop will allow to set the custom insertion point for CSS, enabling the use of the component inside shadowDOM.