### PR TITLE
Fix pop-value being sent for undefined values.

### DIFF
--- a/.changeset/calm-snakes-collect.md
+++ b/.changeset/calm-snakes-collect.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+No longer send pop-value action when multi-select is empty. This correctly resolves typings with that event, where removedValue cannot be undefined.

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1096,10 +1096,12 @@ export default class Select<
       newValueArray[0] || null
     );
 
-    this.onChange(newValue, {
-      action: 'pop-value',
-      removedValue: lastSelectedValue,
-    });
+    if (lastSelectedValue) {
+      this.onChange(newValue, {
+        action: 'pop-value',
+        removedValue: lastSelectedValue,
+      });
+    }
   };
 
   // ==============================

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -1906,6 +1906,7 @@ test('should call onChange with an array on hitting backspace when backspaceRemo
       isClearable
       isMulti
       onChange={onChangeSpy}
+      value={[OPTIONS[0]]}
     />
   );
   fireEvent.keyDown(container.querySelector('.react-select__control')!, {
@@ -1915,9 +1916,28 @@ test('should call onChange with an array on hitting backspace when backspaceRemo
   expect(onChangeSpy).toHaveBeenCalledWith([], {
     action: 'pop-value',
     name: 'test-input-name',
-    removedValue: undefined,
+    removedValue: OPTIONS[0],
   });
 });
+
+test('should call not call onChange on hitting backspace when backspaceRemovesValue is true and isMulti is true and there are no values', () => {
+  let onChangeSpy = jest.fn();
+  let { container } = render(
+    <Select
+      {...BASIC_PROPS}
+      backspaceRemovesValue
+      isClearable
+      isMulti
+      onChange={onChangeSpy}
+    />
+  );
+  fireEvent.keyDown(container.querySelector('.react-select__control')!, {
+    keyCode: 8,
+    key: 'Backspace',
+  });
+  expect(onChangeSpy).not.toHaveBeenCalled();
+});
+
 
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {
   let onChangeSpy = jest.fn();

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -1938,7 +1938,6 @@ test('should call not call onChange on hitting backspace when backspaceRemovesVa
   expect(onChangeSpy).not.toHaveBeenCalled();
 });
 
-
 test('multi select > clicking on X next to option will call onChange with all options other that the clicked option', () => {
   let onChangeSpy = jest.fn();
   let { container } = render(


### PR DESCRIPTION
Because of this array access:

https://github.com/JedWatson/react-select/blob/884f1c42549faad7cb210169223b427ad6f0c9fd/packages/react-select/src/Select.tsx#L1091

`removedValue` could technically be undefined. This happens when the select box is empty and a user hits backspace. It can cause runtime errors in the consuming libraries if the options are objects rather than primitives. This stops those actions being sent.

(The other option would be to update the typing in the below part of the code to mark removedValue as optional, forcing consumers to protect against potential undefined values, but I believe this makes more sense, as we are not removing anything if the set of values is already empty, so sending a `pop-value` action doesn't really make sense):

https://github.com/JedWatson/react-select/blob/edf5265ee0158c026c9e8527a6d0490a5ac2ef23/packages/react-select/src/types.ts#L138-L142