### PR TITLE
Fix types compatibility with React 19

### DIFF
--- a/.changeset/tough-hats-help.md
+++ b/.changeset/tough-hats-help.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Fix types compatibility with React 19

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/jest-in-case": "^1.0.6",
     "@types/node": "^16.11.68",
     "@types/pretty-proptypes": "^1.1.0",
-    "@types/react": "^16.14.2",
+    "@types/react": "^16.14.60",
     "@types/react-dom": "^16.9.10",
     "@types/react-transition-group": "^4.4.0",
     "@typescript-eslint/eslint-plugin": "^4.14.0",

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -4,6 +4,7 @@ import {
   Component,
   FocusEventHandler,
   FormEventHandler,
+  JSX,
   KeyboardEventHandler,
   MouseEventHandler,
   ReactNode,

--- a/packages/react-select/src/components/Control.tsx
+++ b/packages/react-select/src/components/Control.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode, Ref } from 'react';
+import { JSX, ReactNode, Ref } from 'react';
 import { jsx } from '@emotion/react';
 
 import {

--- a/packages/react-select/src/components/Group.tsx
+++ b/packages/react-select/src/components/Group.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, JSX, ReactNode } from 'react';
 import { jsx } from '@emotion/react';
 import { cleanCommonProps, getStyleProps } from '../utils';
 

--- a/packages/react-select/src/components/Menu.tsx
+++ b/packages/react-select/src/components/Menu.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import {
   createContext,
+  JSX,
   ReactElement,
   ReactNode,
   Ref,

--- a/packages/react-select/src/components/MultiValue.tsx
+++ b/packages/react-select/src/components/MultiValue.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, JSX, ReactNode } from 'react';
 import { jsx } from '@emotion/react';
 import { CrossIcon } from './indicators';
 import {

--- a/packages/react-select/src/components/Option.tsx
+++ b/packages/react-select/src/components/Option.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode, RefCallback } from 'react';
+import { JSX, ReactNode, RefCallback } from 'react';
 import { jsx } from '@emotion/react';
 
 import {

--- a/packages/react-select/src/components/Placeholder.tsx
+++ b/packages/react-select/src/components/Placeholder.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode } from 'react';
+import { JSX, ReactNode } from 'react';
 import { jsx } from '@emotion/react';
 import {
   CommonPropsAndClassName,

--- a/packages/react-select/src/components/SingleValue.tsx
+++ b/packages/react-select/src/components/SingleValue.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode } from 'react';
+import { JSX, ReactNode } from 'react';
 import { jsx } from '@emotion/react';
 import {
   CommonPropsAndClassName,

--- a/packages/react-select/src/components/containers.tsx
+++ b/packages/react-select/src/components/containers.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode } from 'react';
+import { JSX, ReactNode } from 'react';
 import { jsx } from '@emotion/react';
 import {
   CommonPropsAndClassName,

--- a/packages/react-select/src/components/indicators.tsx
+++ b/packages/react-select/src/components/indicators.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { ReactNode } from 'react';
+import { JSX, ReactNode } from 'react';
 import { jsx, keyframes } from '@emotion/react';
 
 import {

--- a/packages/react-select/src/internal/A11yText.tsx
+++ b/packages/react-select/src/internal/A11yText.tsx
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+import { JSX } from 'react';
 import { jsx } from '@emotion/react';
 
 // Assistive text to describe visual elements. Hidden for sighted users.

--- a/packages/react-select/src/internal/DummyInput.tsx
+++ b/packages/react-select/src/internal/DummyInput.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Ref } from 'react';
+import { JSX, Ref } from 'react';
 import { jsx } from '@emotion/react';
 import { removeProps } from '../utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,14 +3709,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@*":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
-  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^16.9.10":
+"@types/react-dom@*", "@types/react-dom@^16.9.10":
   version "16.9.13"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.13.tgz#5898f0ee68fe200685e6b61d3d7d8828692814d0"
   integrity sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==
@@ -3776,13 +3769,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16", "@types/react@^16.14.2":
-  version "16.14.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.8.tgz#4aee3ab004cb98451917c9b7ada3c7d7e52db3fe"
-  integrity sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==
+"@types/react@*", "@types/react@^16", "@types/react@^16.14.60":
+  version "16.14.60"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.60.tgz#f7ab62a329b82826f12d02bc8031d4ef4b5e0d81"
+  integrity sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/relateurl@*":
@@ -3797,10 +3790,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/scheduler@*":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
-  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^6.0.0", "@types/semver@^6.0.1":
   version "6.2.3"


### PR DESCRIPTION
Fixes #5911.

React 19 [removes the `JSX` type from the global scope](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451), so it now needs to be imported from `React`.

This causes some immediate issues for the users of react-select who are trying to use it with `@types/react@19`, since the `Select` types relies on the `JSX.LibraryManagedAttributes` type.

Note that this is technically a breaking change because it requires TypeScript users to have a version of `@types/react` after [DefinitelyTyped/DefinitelyTyped#64464](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464) shipped.

(recreates #5912)