### PR TITLE
Bugfix: menuShouldBlockScroll now applies the correct right-padding

### DIFF
--- a/packages/react-select/src/internal/useScrollLock.ts
+++ b/packages/react-select/src/internal/useScrollLock.ts
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-const STYLE_KEYS = [
-  'boxSizing',
-  'height',
-  'overflow',
-  'position',
-] as const;
+const STYLE_KEYS = ['boxSizing', 'height', 'overflow', 'position'] as const;
 
 const LOCK_STYLES = {
   boxSizing: 'border-box', // account for possible declaration `width: 100%;` on body
@@ -82,7 +77,9 @@ export default function useScrollLock({
 
       // apply the lock styles and padding if this is the first scroll lock
       if (accountForScrollbars && activeScrollLocks < 1) {
-        const currentPadding = parseInt(window.getComputedStyle(document.body).paddingRight.slice(0,-2));
+        const currentPadding = parseInt(
+          window.getComputedStyle(document.body).paddingRight.slice(0, -2)
+        );
         const clientWidth = document.body ? document.body.clientWidth : 0;
         const adjustedPadding =
           window.innerWidth - clientWidth + currentPadding || 0;

--- a/packages/react-select/src/internal/useScrollLock.ts
+++ b/packages/react-select/src/internal/useScrollLock.ts
@@ -4,15 +4,14 @@ const STYLE_KEYS = [
   'boxSizing',
   'height',
   'overflow',
-  'paddingRight',
   'position',
 ] as const;
 
 const LOCK_STYLES = {
   boxSizing: 'border-box', // account for possible declaration `width: 100%;` on body
+  height: '100%',
   overflow: 'hidden',
   position: 'relative',
-  height: '100%',
 };
 
 function preventTouchMove(e: TouchEvent) {
@@ -83,8 +82,7 @@ export default function useScrollLock({
 
       // apply the lock styles and padding if this is the first scroll lock
       if (accountForScrollbars && activeScrollLocks < 1) {
-        const currentPadding =
-          parseInt(originalStyles.current.paddingRight, 10) || 0;
+        const currentPadding = parseInt(window.getComputedStyle(document.body).paddingRight.slice(0,-2));
         const clientWidth = document.body ? document.body.clientWidth : 0;
         const adjustedPadding =
           window.innerWidth - clientWidth + currentPadding || 0;


### PR DESCRIPTION
# Bug Description
When `menuShouldBlockScroll=true`, the right padding for the `body` tag is computed. This is to account for the right scrollbar disappearing when this prop is set. However, it computes this new right padding by accounting for any right padding applied through the `styles` prop; this doesn't take into account for right padding added from classes.

# Bug Example
An example of the bug can be seen here where a class based right padding is applied using tailwind:
https://codesandbox.io/p/devbox/react-select-v5-sandbox-forked-fckm5s
Opening and closing the select will cause a shift in padding due to incomplete padding extraction.  

# Solution
https://codesandbox.io/p/devbox/react-select-v5-sandbox-forked-qnd3sz?workspaceId=ws_CRHnC6VmWcMy6krqXNjCPZ
- `window.getComputedStyle` is used to get the final computed right padding which accounts for padding from a class or style. 
- Removed the floating `paddingRight` property from `STYLE_KEYS` as we are no longer using this style anywhere in the code.

# Closes
#5342


