### PR TITLE
Export MenuPortalProps

### DIFF
--- a/packages/react-select/src/index.ts
+++ b/packages/react-select/src/index.ts
@@ -32,7 +32,12 @@ export type {
   LoadingIndicatorProps,
 } from './components/indicators';
 export type { InputProps } from './components/Input';
-export type { MenuListProps, MenuProps, NoticeProps } from './components/Menu';
+export type {
+  MenuListProps,
+  MenuProps,
+  MenuPortalProps,
+  NoticeProps,
+} from './components/Menu';
 export type {
   MultiValueGenericProps,
   MultiValueProps,


### PR DESCRIPTION
It seems like this type is not re-exported from index like the other Props types are, but it would be useful when providing a replacement component for MenuPortal.
