### PR TITLE
feat: Add aria-describedby prop

### DIFF
--- a/.changeset/friendly-pans-buy.md
+++ b/.changeset/friendly-pans-buy.md
@@ -1,0 +1,5 @@
+---
+'react-select': patch
+---
+
+Add aria-describedby prop to Select

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1235,6 +1235,25 @@ export default class Select<
     this.setState({ ariaSelection: { value, ...actionMeta } });
   };
 
+  getAriaDescribedByValue = () => {
+    const { ariaSelection } = this.state;
+    const ariaDescribedByIds = [];
+
+    if (this.hasValue() && ariaSelection?.action === 'initial-input-focus') {
+      ariaDescribedByIds.push(this.getElementId('live-region'));
+    }
+
+    if (!this.hasValue()) {
+      ariaDescribedByIds.push(this.getElementId('placeholder'));
+    }
+
+    if (this.props['aria-describedby'] != null) {
+      ariaDescribedByIds.push(this.props['aria-describedby']);
+    }
+
+    return ariaDescribedByIds.join(' ');
+  };
+
   hasValue() {
     const { selectValue } = this.state;
     return selectValue.length > 0;
@@ -1710,7 +1729,7 @@ export default class Select<
       required,
     } = this.props;
     const { Input } = this.getComponents();
-    const { inputIsHidden, ariaSelection } = this.state;
+    const { inputIsHidden } = this.state;
     const { commonProps } = this;
 
     const id = inputId || this.getElementId('input');
@@ -1736,21 +1755,8 @@ export default class Select<
       ...(!isSearchable && {
         'aria-readonly': true,
       }),
-      ...(this.hasValue()
-        ? ariaSelection?.action === 'initial-input-focus' && {
-            'aria-describedby': this.getElementId('live-region'),
-          }
-        : {
-            'aria-describedby': this.getElementId('placeholder'),
-          }),
+      'aria-describedby': this.getAriaDescribedByValue(),
     };
-
-    // aria-describedby allows for multiple IDs to be specified, separated by a space
-    if (this.props['aria-describedby'] != null) {
-      ariaAttributes[
-        'aria-describedby'
-      ] += ` ${this.props['aria-describedby']}`;
-    }
 
     if (!isSearchable) {
       // use a dummy input to maintain focus/blur functionality

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -78,7 +78,9 @@ export interface Props<
   IsMulti extends boolean,
   Group extends GroupBase<Option>
 > {
-  /** HTML ID of an element containing an error message related to the input**/
+  /** HTML ID(s) of the element(s) that describe the input. */
+  'aria-describedby'?: AriaAttributes['aria-describedby'];
+  /** HTML ID of an element containing an error message related to the input */
   'aria-errormessage'?: AriaAttributes['aria-errormessage'];
   /** Indicate if the value entered in the field is invalid **/
   'aria-invalid'?: AriaAttributes['aria-invalid'];
@@ -1742,6 +1744,11 @@ export default class Select<
             'aria-describedby': this.getElementId('placeholder'),
           }),
     };
+
+    // aria-describedby allows for multiple IDs to be specified, separated by a space
+    if (this.props['aria-describedby'] != null) {
+      ariaAttributes['aria-describedby'] += ` ${this.props['aria-describedby']}`;
+    }
 
     if (!isSearchable) {
       // use a dummy input to maintain focus/blur functionality

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1747,7 +1747,9 @@ export default class Select<
 
     // aria-describedby allows for multiple IDs to be specified, separated by a space
     if (this.props['aria-describedby'] != null) {
-      ariaAttributes['aria-describedby'] += ` ${this.props['aria-describedby']}`;
+      ariaAttributes[
+        'aria-describedby'
+      ] += ` ${this.props['aria-describedby']}`;
     }
 
     if (!isSearchable) {

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2253,6 +2253,28 @@ cases(
 );
 
 cases(
+  'accessibility > passes through aria-describedby prop',
+  ({ props = { ...BASIC_PROPS, 'aria-describedby': 'testing' } }) => {
+    let { container } = render(<Select {...props} />);
+    expect(
+      container
+        .querySelector('input.react-select__input')!
+        .getAttribute('aria-describedby')
+    ).toContain('testing');
+  },
+  {
+    'single select > should pass aria-describedby prop down to input': {},
+    'multi select > should pass aria-describedby prop down to input': {
+      props: {
+        ...BASIC_PROPS,
+        'aria-describedby': 'testing',
+        isMulti: true,
+      },
+    },
+  }
+);
+
+cases(
   'accessibility > passes through aria-errormessage prop',
   ({ props = { ...BASIC_PROPS, 'aria-errormessage': 'error-message' } }) => {
     let { container } = render(<Select {...props} />);


### PR DESCRIPTION
Adds an aria-describedby prop that adds additional ids to the property. This allows consumers to define additional elements that describe their select input.

Fixes #5562 