### PR TITLE
Fix scrollbar issue not triggering onMenuScrollToBottom

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -242,9 +242,9 @@ export interface Props<
   /** Handle the menu closing */
   onMenuClose: () => void;
   /** Fired when the user scrolls to the top of the menu */
-  onMenuScrollToTop?: (event: WheelEvent | TouchEvent) => void;
+  onMenuScrollToTop?: (event: Event) => void;
   /** Fired when the user scrolls to the bottom of the menu */
-  onMenuScrollToBottom?: (event: WheelEvent | TouchEvent) => void;
+  onMenuScrollToBottom?: (event: Event) => void;
   /** Allows control of whether the menu is opened when the Select is focused */
   openMenuOnFocus: boolean;
   /** Allows control of whether the menu is opened when the Select is clicked */

--- a/packages/react-select/src/internal/ScrollManager.tsx
+++ b/packages/react-select/src/internal/ScrollManager.tsx
@@ -8,10 +8,10 @@ interface Props {
   readonly children: (ref: RefCallback<HTMLElement>) => ReactElement;
   readonly lockEnabled: boolean;
   readonly captureEnabled: boolean;
-  readonly onBottomArrive?: (event: WheelEvent | TouchEvent) => void;
-  readonly onBottomLeave?: (event: WheelEvent | TouchEvent) => void;
-  readonly onTopArrive?: (event: WheelEvent | TouchEvent) => void;
-  readonly onTopLeave?: (event: WheelEvent | TouchEvent) => void;
+  readonly onBottomArrive?: (event: Event) => void;
+  readonly onBottomLeave?: (event: Event) => void;
+  readonly onTopArrive?: (event: Event) => void;
+  readonly onTopLeave?: (event: Event) => void;
 }
 
 const blurSelectInput = (event: MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
First of all, thank you for creating react-select!

Fixes https://github.com/JedWatson/react-select/issues/3232 & https://github.com/JedWatson/react-select/issues/5957
Superseed https://github.com/JedWatson/react-select/pull/4970

I fixed the #4970 PR from @Duarte10 to allow `onMenuScrollToBottom` function to be triggered using scrollbar with mouse dragged.

To fix the issue, we use a `scroll` listener, which requires changing the callback type from a `WheelEvent` to `Event` ([which contains all WheelEvent, TouchEvent and UIEvent](https://developer.mozilla.org/en-US/docs/Web/API/Event#interfaces_based_on_event)).