### PR TITLE
fix: allow passing arbitrary data-* attributes

### DIFF
--- a/.changeset/strange-grapes-mix.md
+++ b/.changeset/strange-grapes-mix.md
@@ -1,0 +1,5 @@
+---
+'react-select': minor
+---
+
+Add `dataAttributes` prop to allow passing data attributes (e.g., `data-testid`) to the select container

--- a/docs/examples/BasicMulti.tsx
+++ b/docs/examples/BasicMulti.tsx
@@ -12,7 +12,7 @@ export default () => (
     className="basic-multi-select"
     classNamePrefix="select"
     dataAttributes={{
-      'data-testid': 'basic-multi-select'
+      'data-testid': 'basic-multi-select',
     }}
   />
 );

--- a/docs/examples/BasicMulti.tsx
+++ b/docs/examples/BasicMulti.tsx
@@ -11,5 +11,8 @@ export default () => (
     options={colourOptions}
     className="basic-multi-select"
     classNamePrefix="select"
+    dataAttributes={{
+      'data-testid': 'basic-multi-select'
+    }}
   />
 );

--- a/docs/examples/BasicSingle.tsx
+++ b/docs/examples/BasicSingle.tsx
@@ -31,7 +31,7 @@ export default () => {
         name="color"
         options={colourOptions}
         dataAttributes={{
-          'data-testid': 'basic-single-select'
+          'data-testid': 'basic-single-select',
         }}
       />
 

--- a/docs/examples/BasicSingle.tsx
+++ b/docs/examples/BasicSingle.tsx
@@ -30,6 +30,9 @@ export default () => {
         isSearchable={isSearchable}
         name="color"
         options={colourOptions}
+        dataAttributes={{
+          'data-testid': 'basic-single-select'
+        }}
       />
 
       <div

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -2215,7 +2215,7 @@ export default class Select<
         innerProps={{
           id: id,
           onKeyDown: this.onKeyDown,
-          ...dataAttributes,
+          ...(dataAttributes || {}),
         }}
         isDisabled={isDisabled}
         isFocused={isFocused}
@@ -2254,7 +2254,4 @@ export type PublicBaseSelectProps<
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
-> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>> & {
-  /** Data attributes to be applied to the select container */
-  dataAttributes?: Record<string, string>;
-};
+> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>>;

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -407,7 +407,11 @@ function buildCategorizedOptions<
 ): CategorizedGroupOrOption<Option, Group>[] {
   return props.options
     .map((groupOrOption, groupOrOptionIndex) => {
-      if ('options' in groupOrOption) {
+      if (
+        groupOrOption &&
+        typeof groupOrOption === 'object' &&
+        'options' in groupOrOption
+      ) {
         const categorizedOptions = groupOrOption.options
           .map((option, optionIndex) =>
             toCategorizedOption(props, option, selectValue, optionIndex)
@@ -2204,7 +2208,8 @@ export default class Select<
     const { Control, IndicatorsContainer, SelectContainer, ValueContainer } =
       this.getComponents();
 
-    const { className, id, isDisabled, menuIsOpen, dataAttributes } = this.props;
+    const { className, id, isDisabled, menuIsOpen, dataAttributes } =
+      this.props;
     const { isFocused } = this.state;
     const commonProps = (this.commonProps = this.getCommonProps());
 

--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -277,6 +277,8 @@ export interface Props<
   form?: string;
   /** Marks the value-holding input as required for form validation */
   required?: boolean;
+  /** Data attributes to be applied to the select container */
+  dataAttributes?: Record<string, string>;
 }
 
 export const defaultProps = {
@@ -2202,7 +2204,7 @@ export default class Select<
     const { Control, IndicatorsContainer, SelectContainer, ValueContainer } =
       this.getComponents();
 
-    const { className, id, isDisabled, menuIsOpen } = this.props;
+    const { className, id, isDisabled, menuIsOpen, dataAttributes } = this.props;
     const { isFocused } = this.state;
     const commonProps = (this.commonProps = this.getCommonProps());
 
@@ -2213,6 +2215,7 @@ export default class Select<
         innerProps={{
           id: id,
           onKeyDown: this.onKeyDown,
+          ...dataAttributes,
         }}
         isDisabled={isDisabled}
         isFocused={isFocused}
@@ -2251,4 +2254,7 @@ export type PublicBaseSelectProps<
   Option,
   IsMulti extends boolean,
   Group extends GroupBase<Option>
-> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>>;
+> = JSX.LibraryManagedAttributes<typeof Select, Props<Option, IsMulti, Group>> & {
+  /** Data attributes to be applied to the select container */
+  dataAttributes?: Record<string, string>;
+};

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2318,6 +2318,27 @@ cases(
   }
 );
 
+cases(
+  'accessibility > passes through dataAttributes prop',
+  ({ props = { ...BASIC_PROPS, dataAttributes: { 'data-testid': 'test-select' } } }) => {
+    let { container } = render(<Select {...props} />);
+    // The data attributes should be on the outermost div (SelectContainer)
+    const selectContainer = container.querySelector('div[data-testid]');
+    expect(selectContainer).toBeTruthy();
+    expect(selectContainer!.getAttribute('data-testid')).toBe('test-select');
+  },
+  {
+    'single select > should pass dataAttributes prop down to container': {},
+    'multi select > should pass dataAttributes prop down to container': {
+      props: {
+        ...BASIC_PROPS,
+        dataAttributes: { 'data-testid': 'test-select' },
+        isMulti: true,
+      },
+    },
+  }
+);
+
 test('accessibility > to show the number of options available in A11yText when the menu is Open', () => {
   let { container, rerender } = render(
     <Select {...BASIC_PROPS} inputValue={''} autoFocus menuIsOpen />

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2320,7 +2320,12 @@ cases(
 
 cases(
   'accessibility > passes through dataAttributes prop',
-  ({ props = { ...BASIC_PROPS, dataAttributes: { 'data-testid': 'test-select' } } }) => {
+  ({
+    props = {
+      ...BASIC_PROPS,
+      dataAttributes: { 'data-testid': 'test-select' },
+    },
+  }) => {
     let { container } = render(<Select {...props} />);
     // The data attributes should be on the outermost div (SelectContainer)
     const selectContainer = container.querySelector('div[data-testid]');

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -2328,8 +2328,8 @@ cases(
     expect(selectContainer!.getAttribute('data-testid')).toBe('test-select');
   },
   {
-    'single select > should pass dataAttributes prop down to container': {},
-    'multi select > should pass dataAttributes prop down to container': {
+    'single select > should pass dataAttributes prop down to the container': {},
+    'multi select > should pass dataAttributes prop down to the container': {
       props: {
         ...BASIC_PROPS,
         dataAttributes: { 'data-testid': 'test-select' },


### PR DESCRIPTION
Fixes [#6018](https://github.com/jedwatson/react-select/issues/6018).

Allows passing arbitrary `data-*` attributes to the `Select` component 