### PR TITLE
test: add NonceProvider coverage for cache creation and memoization

### DIFF
--- a/.changeset/add-nonceprovider-tests.md
+++ b/.changeset/add-nonceprovider-tests.md
@@ -1,0 +1,5 @@
+---
+"react-select": patch
+---
+
+Add unit coverage for `NonceProvider` to verify Emotion cache creation and memoisation under nonce/cacheKey changes.

--- a/.changeset/add-nonceprovider-tests.md
+++ b/.changeset/add-nonceprovider-tests.md
@@ -1,5 +1,6 @@
 ---
-"react-select": patch
+'react-select': patch
 ---
 
-Add unit coverage for `NonceProvider` to verify Emotion cache creation and memoisation under nonce/cacheKey changes.
+Add unit coverage for `NonceProvider` to verify Emotion cache creation and
+memoisation under nonce/cacheKey changes.

--- a/packages/react-select/src/__tests__/NonceProvider.test.tsx
+++ b/packages/react-select/src/__tests__/NonceProvider.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NonceProvider from '../NonceProvider';
+import createCache from '@emotion/cache';
+import type { EmotionCache } from '@emotion/cache';
+
+jest.mock('@emotion/cache', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@emotion/react', () => {
+  const actualReact = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    CacheProvider: ({
+      children,
+      value,
+    }: {
+      children: import('react').ReactNode;
+      value: any;
+    }) =>
+      actualReact.createElement(
+        'div',
+        {
+          'data-testid': 'cache-provider',
+          'data-cache-key': value?.key,
+          'data-cache-nonce': value?.nonce,
+          'data-cache-id': value?.id,
+        },
+        children
+      ),
+  };
+});
+
+describe('NonceProvider', () => {
+  let createCacheMock: jest.MockedFunction<typeof createCache>;
+  let cacheId: number;
+
+  const createFakeCache = (
+    key: string,
+    nonce?: string
+  ): EmotionCache & { id: number } =>
+    ({
+      key,
+      nonce,
+      inserted: {},
+      registered: {},
+      sheet: {
+        key,
+        nonce,
+        container: document.head,
+        tags: [],
+        insert: () => {},
+        flush: () => {},
+      },
+      insert: () => '',
+      id: ++cacheId,
+    } as unknown as EmotionCache & { id: number });
+
+  beforeEach(() => {
+    createCacheMock = createCache as jest.MockedFunction<typeof createCache>;
+    cacheId = 0;
+    createCacheMock.mockImplementation(({ key, nonce }) =>
+      createFakeCache(key, nonce)
+    );
+    jest.clearAllMocks();
+  });
+
+  it('creates an Emotion cache with the provided nonce and cacheKey and renders children', () => {
+    render(
+      <NonceProvider nonce="abc123" cacheKey="css">
+        <div data-testid="child">Child content</div>
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledWith({
+      key: 'css',
+      nonce: 'abc123',
+    });
+    expect(screen.getByTestId('cache-provider')).toHaveAttribute(
+      'data-cache-key',
+      'css'
+    );
+    expect(screen.getByTestId('cache-provider')).toHaveAttribute(
+      'data-cache-nonce',
+      'abc123'
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('memoizes the cache when nonce and cacheKey remain stable', () => {
+    const { rerender } = render(
+      <NonceProvider nonce="abc123" cacheKey="css">
+        <div />
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledTimes(1);
+    const initialId = screen
+      .getByTestId('cache-provider')
+      .getAttribute('data-cache-id');
+
+    rerender(
+      <NonceProvider nonce="abc123" cacheKey="css">
+        <div />
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledTimes(1);
+    const rerenderId = screen
+      .getByTestId('cache-provider')
+      .getAttribute('data-cache-id');
+    expect(rerenderId).toBe(initialId);
+  });
+
+  it('recreates the cache when cacheKey or nonce changes', () => {
+    const { rerender } = render(
+      <NonceProvider nonce="abc123" cacheKey="css">
+        <div />
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledTimes(1);
+    const initialId = screen
+      .getByTestId('cache-provider')
+      .getAttribute('data-cache-id');
+
+    rerender(
+      <NonceProvider nonce="abc123" cacheKey="css-2">
+        <div />
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledTimes(2);
+    const cacheKeyChangeId = screen
+      .getByTestId('cache-provider')
+      .getAttribute('data-cache-id');
+    expect(cacheKeyChangeId).not.toBe(initialId);
+
+    rerender(
+      <NonceProvider nonce="def456" cacheKey="css-2">
+        <div />
+      </NonceProvider>
+    );
+
+    expect(createCacheMock).toHaveBeenCalledTimes(3);
+    const nonceChangeId = screen
+      .getByTestId('cache-provider')
+      .getAttribute('data-cache-id');
+    expect(nonceChangeId).not.toBe(cacheKeyChangeId);
+  });
+});


### PR DESCRIPTION
**Summary**
This PR adds a new test suite for NonceProvider.tsx to increase confidence in Emotion cache creation and state memoization within the provider. NonceProvider is a small but important utility in the styling pipeline, and previously it had no direct test coverage. The new tests ensure its behaviour is correct, stable, and resilient to future refactors.

**Motivation**
Because this logic was untested, regressions could slip in unnoticed — especially around memoization behaviour or CSP-related attributes. This PR introduces targeted unit tests to close that gap.

**What This PR Does**
This PR introduces a new test file:
`packages/react-select/src/__tests__/NonceProvider.test.tsx`

**The test suite covers:**
1. ✔ Correct cache creation
Ensures createCache is called with the expected { key, nonce } values.

2. ✔  Correct rendering of children
Verifies that the provider passes through its children as expected.

3. ✔  Cache memoization across stable props
When nonce and cacheKey remain the same across rerenders:
- The Emotion cache is not recreated
- The same cache instance (identified via injected test id) persists

4. ✔ Cache recreation when props change
If nonce or cacheKey changes:
- A new Emotion cache instance is created
- The previous instance is not reused

5. ✔ Proper integration with Emotion’s `CacheProvider`
Using a lightweight mock of CacheProvider, tests validate that:
- The generated cache is passed through
- key, nonce, and a test id propagate correctly

**Testing Approach**
- @emotion/cache is mocked to prevent side effects and control cache instances deterministically.
- CacheProvider is mocked to expose internal props via data-* attributes, allowing the tests to assert behaviour without inspecting DOM style tags.
- No changes were made to core library logic — this is a test-only addition.

**Impact**
- Increases coverage for an untested but important component.
- Reduces risk of regressions when future Emotion or CSP-related updates occur.
- No runtime or bundle changes.
- No breaking changes.